### PR TITLE
chore: format the workspace and gate cargo fmt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,17 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: rustfmt, clippy
 
       - name: Cache cargo + target
         uses: Swatinem/rust-cache@v2
 
+      # Gate: fail the build on any formatting drift.
+      - name: Format
+        run: cargo fmt --all --check
+
       # Non-gating: surfaces clippy findings without failing on the workspace's
-      # pre-existing warnings. (`cargo fmt --check` is intentionally not a gate
-      # yet — the tree has pre-existing formatting drift to clean up first.)
+      # pre-existing warnings.
       - name: Clippy
         run: cargo clippy --workspace --all-targets
 

--- a/myco-blossom/src/lib.rs
+++ b/myco-blossom/src/lib.rs
@@ -98,7 +98,9 @@ impl BlobStore for FsBlobStore {
             return Ok(hash); // immutable + content-addressed → already stored
         }
         // Atomic write: a unique temp file (pid + hash) then rename into place.
-        let tmp = self.root.join(format!(".tmp-{}-{}", std::process::id(), &hash));
+        let tmp = self
+            .root
+            .join(format!(".tmp-{}-{}", std::process::id(), &hash));
         std::fs::write(&tmp, bytes)?;
         std::fs::rename(&tmp, &dest)?;
         Ok(hash)

--- a/myco-blossom/src/server.rs
+++ b/myco-blossom/src/server.rs
@@ -72,7 +72,14 @@ pub async fn serve_on(
     store: Arc<FsBlobStore>,
     listener: tokio::net::TcpListener,
 ) -> anyhow::Result<()> {
-    serve_state(BlossomState { store, access: None }, listener).await
+    serve_state(
+        BlossomState {
+            store,
+            access: None,
+        },
+        listener,
+    )
+    .await
 }
 
 /// Serve on an already-bound listener, restricting **mesh** sources to those that
@@ -83,13 +90,17 @@ pub async fn serve_on_guarded(
     listener: tokio::net::TcpListener,
     access: AccessFn,
 ) -> anyhow::Result<()> {
-    serve_state(BlossomState { store, access: Some(access) }, listener).await
+    serve_state(
+        BlossomState {
+            store,
+            access: Some(access),
+        },
+        listener,
+    )
+    .await
 }
 
-async fn serve_state(
-    state: BlossomState,
-    listener: tokio::net::TcpListener,
-) -> anyhow::Result<()> {
+async fn serve_state(state: BlossomState, listener: tokio::net::TcpListener) -> anyhow::Result<()> {
     let app = Router::new()
         .route("/{sha256}", get(get_blob).head(head_blob))
         .route("/upload", put(upload))
@@ -170,8 +181,7 @@ mod tests {
 
     #[tokio::test]
     async fn http_blossom_get_head_upload() {
-        let dir =
-            std::env::temp_dir().join(format!("myco-blossom-srv-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("myco-blossom-srv-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let store = Arc::new(FsBlobStore::open(&dir).unwrap());
 

--- a/myco-core/src/action.rs
+++ b/myco-core/src/action.rs
@@ -5,7 +5,11 @@ use serde::Deserialize;
 /// `docs/reference/ffi-surface.md`. P1 adds the node lifecycle and the BLE
 /// master switch; site, peer, and settings actions arrive in later phases.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 pub enum NativeAppAction {
     /// Pure read; does not bump `rev`.
     GetState,
@@ -69,7 +73,11 @@ pub enum NativeAppAction {
     /// Scanned a peer's pairing QR: send them a signed pair request over the mesh
     /// (to their relay). Pairs nobody yet — only a mutual accept adds both sides.
     /// `npub`/`name` are the scanned peer's; `secret` is the QR's one-time value.
-    SendPairRequest { npub: String, name: String, secret: String },
+    SendPairRequest {
+        npub: String,
+        name: String,
+        secret: String,
+    },
     /// Accept an incoming pair request: add the requester to the Circle and signal
     /// them (a pair-accept) so they add us back.
     AcceptPairRequest { npub: String, name: String },

--- a/myco-core/src/ble_bridge_jni.rs
+++ b/myco-core/src/ble_bridge_jni.rs
@@ -38,7 +38,9 @@ pub(crate) fn capture_java_vm(env: &JNIEnv) {
 /// Run `f` with a JNIEnv attached to the current (tokio worker) thread. Returns
 /// `default` if the VM is unavailable or attaching fails.
 fn with_env<R>(default: R, f: impl FnOnce(&mut JNIEnv) -> R) -> R {
-    let Some(vm) = JAVA_VM.get() else { return default };
+    let Some(vm) = JAVA_VM.get() else {
+        return default;
+    };
     match vm.attach_current_thread() {
         Ok(mut guard) => f(&mut guard),
         Err(_) => default,
@@ -184,8 +186,12 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverInbound(
     send_mtu: jint,
     recv_mtu: jint,
 ) -> jlong {
-    let Some(bridge) = (unsafe { bridge_ref(handle) }) else { return 0 };
-    let Some(ble_addr) = jstring_to_addr(&mut env, &addr) else { return 0 };
+    let Some(bridge) = (unsafe { bridge_ref(handle) }) else {
+        return 0;
+    };
+    let Some(ble_addr) = jstring_to_addr(&mut env, &addr) else {
+        return 0;
+    };
     bridge.deliver_inbound(ble_addr, send_mtu.max(0) as u16, recv_mtu.max(0) as u16)
 }
 
@@ -201,7 +207,9 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverConnectResult(
     send_mtu: jint,
     recv_mtu: jint,
 ) -> jlong {
-    let Some(bridge) = (unsafe { bridge_ref(handle) }) else { return 0 };
+    let Some(bridge) = (unsafe { bridge_ref(handle) }) else {
+        return 0;
+    };
     let ble_addr = jstring_to_addr(&mut env, &addr).unwrap_or(BleAddr {
         adapter: "ble0".to_string(),
         device: [0; 6],
@@ -225,7 +233,9 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverScan(
     psm: jint,
     rssi: jint,
 ) {
-    let Some(bridge) = (unsafe { bridge_ref(handle) }) else { return };
+    let Some(bridge) = (unsafe { bridge_ref(handle) }) else {
+        return;
+    };
     if let Some(ble_addr) = jstring_to_addr(&mut env, &addr) {
         bridge.deliver_scan(ble_addr, psm.max(0) as u16, rssi);
     }
@@ -241,7 +251,9 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleChannelDeliverRecv(
     data: JByteArray,
     len: jint,
 ) -> jboolean {
-    let Some(bridge) = (unsafe { bridge_ref(handle) }) else { return 0 };
+    let Some(bridge) = (unsafe { bridge_ref(handle) }) else {
+        return 0;
+    };
     let n = len.max(0) as usize;
     let mut buf = vec![0i8; n];
     if env.get_byte_array_region(&data, 0, &mut buf).is_err() {
@@ -276,7 +288,9 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleChannelNextSend(
     out: JByteArray,
     timeout_ms: jint,
 ) -> jint {
-    let Some(bridge) = (unsafe { bridge_ref(handle) }) else { return -1 };
+    let Some(bridge) = (unsafe { bridge_ref(handle) }) else {
+        return -1;
+    };
     match bridge.next_send(ch_id, Duration::from_millis(timeout_ms.max(0) as u64)) {
         Some(bytes) => {
             let i8buf: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -389,7 +389,10 @@ impl Content {
     /// The backend the gateway reads: serves the active (fully-downloaded) version,
     /// not necessarily the relay's newest.
     fn active_backend(&self) -> ActiveBackend<'_> {
-        ActiveBackend { relay: self.relay.as_ref(), active: &self.active_manifests }
+        ActiveBackend {
+            relay: self.relay.as_ref(),
+            active: &self.active_manifests,
+        }
     }
 
     /// Pin `manifest` as the active version for its slot (atomic swap the gateway
@@ -417,7 +420,14 @@ impl Content {
         path: &str,
         range: Option<&str>,
     ) -> GatewayResponse {
-        gateway::serve(&self.active_backend(), self.blobs.as_ref(), host, path, range).await
+        gateway::serve(
+            &self.active_backend(),
+            self.blobs.as_ref(),
+            host,
+            path,
+            range,
+        )
+        .await
     }
 
     /// Serve and frame the response for the `gatewayGet` JNI: a 4-byte big-endian
@@ -516,7 +526,13 @@ impl Content {
             }
         }
         if sources.is_empty() {
-            self.set_status(&addr, "unreachable", 0, 0, "Can't reach anyone who has this app yet.");
+            self.set_status(
+                &addr,
+                "unreachable",
+                0,
+                0,
+                "Can't reach anyone who has this app yet.",
+            );
             return;
         }
         tracing::info!(
@@ -529,7 +545,13 @@ impl Content {
 
         // Live progress so the UI shows "X/Y files" instead of sitting at 0/0.
         let progress = |present: usize, total: usize| {
-            self.set_status(&addr, "syncing", present as u64, total as u64, "Downloading…");
+            self.set_status(
+                &addr,
+                "syncing",
+                present as u64,
+                total as u64,
+                "Downloading…",
+            );
         };
 
         // Try each in order; the first that goes Ready wins. Keep the best
@@ -540,7 +562,8 @@ impl Content {
             // refetch. Otherwise do a full sync (manifest + blobs).
             let outcome = match &known {
                 Some(manifest) => {
-                    sync::stage_blobs(self.blobs.as_ref(), source.as_ref(), manifest, &progress).await
+                    sync::stage_blobs(self.blobs.as_ref(), source.as_ref(), manifest, &progress)
+                        .await
                 }
                 None => {
                     sync::sync_site(
@@ -563,7 +586,14 @@ impl Content {
                             let _ = self.relay.store_event(m.event.clone()).await;
                             self.set_active(&m.event);
                             let n = m.paths.len() as u64;
-                            self.set_status_titled(&addr, m.title.as_deref(), "ready", n, n, "Ready");
+                            self.set_status_titled(
+                                &addr,
+                                m.title.as_deref(),
+                                "ready",
+                                n,
+                                n,
+                                "Ready",
+                            );
                             self.add_to_library(&addr, m.title.as_deref(), now_secs());
                         }
                         // Full sync stored the just-fetched manifest (the relay's
@@ -626,9 +656,13 @@ impl Content {
                 }
             }
         }
-        let outcome =
-            sync::import_site(self.relay.as_ref(), self.blobs.as_ref(), event.clone(), &blobs)
-                .await?;
+        let outcome = sync::import_site(
+            self.relay.as_ref(),
+            self.blobs.as_ref(),
+            event.clone(),
+            &blobs,
+        )
+        .await?;
         // Surface the imported site as `ready` (and pin it) so the UI can open it
         // with one tap and it persists across restarts.
         if outcome == SyncOutcome::Ready {
@@ -716,7 +750,9 @@ impl Content {
     /// relay + Blossom persist, but the in-memory status map does not.
     pub async fn refresh_library_status(self: Arc<Self>) {
         for item in self.library_snapshot() {
-            let Some(addr) = library_addr(&item) else { continue };
+            let Some(addr) = library_addr(&item) else {
+                continue;
+            };
             match gateway::readiness(&self.active_backend(), self.blobs.as_ref(), &addr).await {
                 Ok(Readiness::Ready(m)) => {
                     // Bootstrap/refresh the active pointer to the served version, so
@@ -877,8 +913,11 @@ impl Content {
     /// clears the override (falls back to the npub-derived name).
     pub fn set_device_name(&self, name: &str) {
         let trimmed = name.trim();
-        *self.device_name_override.lock().unwrap() =
-            if trimmed.is_empty() { None } else { Some(trimmed.to_string()) };
+        *self.device_name_override.lock().unwrap() = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
     }
 
     /// Our own device label, sent to the peer so their pop-up / Circle entry has a
@@ -903,7 +942,9 @@ impl Content {
     /// point-to-point and never gossiped). A **request** surfaces a pop-up; an
     /// **accept** means a peer accepted *our* request → add them to the Circle.
     pub fn handle_pair_event(&self, event: &Event) {
-        let Ok(from) = event.pubkey.to_bech32() else { return };
+        let Ok(from) = event.pubkey.to_bech32() else {
+            return;
+        };
         let name = tag_value(event, "n").unwrap_or_else(|| short_name(&from));
         match event.kind.as_u16() {
             KIND_PAIR_REQUEST => {
@@ -911,18 +952,28 @@ impl Content {
                 let secret = tag_value(event, "secret").unwrap_or_default();
                 let mut pending = self.pending_pairs.lock().unwrap();
                 if !pending.iter().any(|p| p.npub == from) {
-                    pending.push(PairRequestView { npub: from, name, secret });
+                    pending.push(PairRequestView {
+                        npub: from,
+                        name,
+                        secret,
+                    });
                 }
             }
             KIND_PAIR_ACCEPT => {
                 tracing::info!(from = %from, "pair: our request accepted — added to circle");
                 self.add_to_circle(&from, &name);
-                self.pending_pairs.lock().unwrap().retain(|p| p.npub != from);
+                self.pending_pairs
+                    .lock()
+                    .unwrap()
+                    .retain(|p| p.npub != from);
             }
             KIND_PAIR_REMOVE => {
                 tracing::info!(from = %from, "pair: peer unpaired — removing from circle");
                 self.remove_from_circle(&from);
-                self.pending_pairs.lock().unwrap().retain(|p| p.npub != from);
+                self.pending_pairs
+                    .lock()
+                    .unwrap()
+                    .retain(|p| p.npub != from);
             }
             _ => {}
         }
@@ -931,20 +982,27 @@ impl Content {
     /// Scanned a peer's QR: send a signed pair request to their mesh relay. We do
     /// not add them yet — only a mutual accept pairs both sides.
     pub async fn send_pair_request(&self, target_npub: &str, secret: &str) {
-        self.dial_pair_event(target_npub, KIND_PAIR_REQUEST, secret).await;
+        self.dial_pair_event(target_npub, KIND_PAIR_REQUEST, secret)
+            .await;
     }
 
     /// Accept an incoming request: add the requester to our Circle and send them a
     /// signed accept so they add us too.
     pub async fn accept_pair_request(&self, npub: &str, name: &str) {
         self.add_to_circle(npub, name);
-        self.pending_pairs.lock().unwrap().retain(|p| p.npub != npub);
+        self.pending_pairs
+            .lock()
+            .unwrap()
+            .retain(|p| p.npub != npub);
         self.dial_pair_event(npub, KIND_PAIR_ACCEPT, "").await;
     }
 
     /// Decline an incoming request (drop it; no signal back).
     pub fn decline_pair_request(&self, npub: &str) {
-        self.pending_pairs.lock().unwrap().retain(|p| p.npub != npub);
+        self.pending_pairs
+            .lock()
+            .unwrap()
+            .retain(|p| p.npub != npub);
     }
 
     /// Tell a peer we've forgotten them, so they drop us from their Circle too.
@@ -1009,7 +1067,9 @@ impl Content {
     /// REQ. (The efficient negentropy version is future work — needs NIP-77 on the
     /// relay.) `npub` is a connected Circle peer.
     pub async fn pull_recent_chat(&self, npub: &str) {
-        let Ok(peer) = fips::PeerIdentity::from_npub(npub) else { return };
+        let Ok(peer) = fips::PeerIdentity::from_npub(npub) else {
+            return;
+        };
         let url = format!("ws://[{}]:4869", peer.address().to_ipv6());
         // kind 9 is the v1 chat kind (myco-bitchat); generalize when more apps land.
         let filter = serde_json::json!({ "kinds": [9], "limit": 100 });
@@ -1039,7 +1099,9 @@ impl Content {
     /// persistent pooled connection (no per-message connect). `npub` is the target
     /// Circle peer. Non-blocking.
     pub fn gossip_to_peer(&self, npub: &str, frame: String) {
-        let Ok(peer) = fips::PeerIdentity::from_npub(npub) else { return };
+        let Ok(peer) = fips::PeerIdentity::from_npub(npub) else {
+            return;
+        };
         let url = format!("ws://[{}]:4869", peer.address().to_ipv6());
         self.peer_relays.send(npub, &url, frame);
     }
@@ -1071,29 +1133,32 @@ impl Content {
             })
             .collect();
 
-        let queries = self.connected_circle_npubs().into_iter().filter_map(|npub| {
-            let peer = fips::PeerIdentity::from_npub(&npub).ok()?;
-            let ip = std::net::IpAddr::V6(peer.address().to_ipv6());
-            if exclude == Some(ip) {
-                return None;
-            }
-            let url = format!("ws://[{}]:4869", ip);
-            let filters = filters.clone();
-            Some(async move {
-                let mut out = Vec::new();
-                for f in &filters {
-                    if let Ok(Ok(evs)) = tokio::time::timeout(
-                        std::time::Duration::from_secs(8),
-                        crate::ip_source::query_relay(&url, f.clone()),
-                    )
-                    .await
-                    {
-                        out.extend(evs);
-                    }
+        let queries = self
+            .connected_circle_npubs()
+            .into_iter()
+            .filter_map(|npub| {
+                let peer = fips::PeerIdentity::from_npub(&npub).ok()?;
+                let ip = std::net::IpAddr::V6(peer.address().to_ipv6());
+                if exclude == Some(ip) {
+                    return None;
                 }
-                out
-            })
-        });
+                let url = format!("ws://[{}]:4869", ip);
+                let filters = filters.clone();
+                Some(async move {
+                    let mut out = Vec::new();
+                    for f in &filters {
+                        if let Ok(Ok(evs)) = tokio::time::timeout(
+                            std::time::Duration::from_secs(8),
+                            crate::ip_source::query_relay(&url, f.clone()),
+                        )
+                        .await
+                        {
+                            out.extend(evs);
+                        }
+                    }
+                    out
+                })
+            });
 
         join_all(queries)
             .await
@@ -1126,7 +1191,10 @@ impl Content {
                 .into_iter()
                 .filter_map(|ev| nsite_deck::Manifest::from_event(ev).ok())
                 .map(|m| {
-                    let addr = SiteAddr { author: m.author, d_tag: m.d_tag.clone() };
+                    let addr = SiteAddr {
+                        author: m.author,
+                        d_tag: m.d_tag.clone(),
+                    };
                     DiscoveredNsite {
                         host: addr.host_label(),
                         author_npub: m.author.to_bech32().unwrap_or_default(),
@@ -1264,7 +1332,9 @@ impl Content {
         for addr in addrs {
             let kind = nsite_deck::kind_for(addr.d_tag.as_deref());
             let key = manifest_key(kind, &addr.author, addr.d_tag.as_deref());
-            let Some(cand) = newest.get(&key) else { continue };
+            let Some(cand) = newest.get(&key) else {
+                continue;
+            };
             // Compare against the version we actually serve (the active pointer),
             // not merely the relay's newest.
             let active_ts = self
@@ -1397,7 +1467,12 @@ impl Content {
             }
             pend.insert(
                 host.clone(),
-                PendingUpdate { manifest: candidate.clone(), total, pulled: 0, ready: false },
+                PendingUpdate {
+                    manifest: candidate.clone(),
+                    total,
+                    pulled: 0,
+                    ready: false,
+                },
             );
         }
         let progress = |pulled: usize, _total: usize| {
@@ -1409,7 +1484,13 @@ impl Content {
         let mut done = false;
         for source in &sources {
             if matches!(
-                nsite_deck::sync::stage_blobs(self.blobs.as_ref(), source.as_ref(), &manifest, &progress).await,
+                nsite_deck::sync::stage_blobs(
+                    self.blobs.as_ref(),
+                    source.as_ref(),
+                    &manifest,
+                    &progress
+                )
+                .await,
                 Ok(SyncOutcome::Ready)
             ) {
                 done = true;
@@ -1441,7 +1522,10 @@ impl Content {
     /// and activate. Forwarding never waits on the download for sites we don't run.
     pub async fn on_manifest_event(self: Arc<Self>, event: Event, inbound: Inbound) {
         let d = event_d_tag(&event);
-        let addr = SiteAddr { author: event.pubkey, d_tag: d };
+        let addr = SiteAddr {
+            author: event.pubkey,
+            d_tag: d,
+        };
 
         // Forward budget (mirrors chat): originate at the default for a local
         // publish, else the ttl that rode in. Clamp so a peer can't over-extend us.
@@ -1647,15 +1731,19 @@ impl Content {
 /// count. Self-refreshes each second; the favicon (fetched first) appears early.
 fn loading_html(status: Option<&SiteStatusView>) -> String {
     const CIRC: f64 = 427.3; // 2π·68, the ring circumference
-    // Poll the favicon every 300ms (cycling the common paths) so the icon fades in
-    // the instant its blob lands — the sync fetches it first, ahead of the 1s reload.
+                             // Poll the favicon every 300ms (cycling the common paths) so the icon fades in
+                             // the instant its blob lands — the sync fetches it first, ahead of the 1s reload.
     const ICON_JS: &str = "<script>(function(){var i=document.getElementById('ic'),\
 s=['/favicon.ico','/favicon.png','/apple-touch-icon.png'],n=0,d=false;\
 i.onload=function(){if(i.naturalWidth>0){d=true;i.style.opacity=1}};\
 i.onerror=function(){if(d)return;n=(n+1)%s.length;setTimeout(function(){i.src=s[n]},300)};})();</script>";
     let (title, state, present, total) = match status {
         Some(s) => (
-            if s.title.is_empty() { "This app".to_string() } else { s.title.clone() },
+            if s.title.is_empty() {
+                "This app".to_string()
+            } else {
+                s.title.clone()
+            },
             s.state.as_str(),
             s.files_pulled,
             s.files_total,
@@ -1674,8 +1762,14 @@ i.onerror=function(){if(d)return;n=(n+1)%s.length;setTimeout(function(){i.src=s[
             "Can't reach anyone with this app yet — Myco keeps trying.".to_string(),
             "#64748b",
         ),
-        "incomplete" => ("Didn't finish downloading — retrying…".to_string(), "#d97706"),
-        "syncing" if total > 0 => (format!("Downloading · {present} of {total} files"), "#059669"),
+        "incomplete" => (
+            "Didn't finish downloading — retrying…".to_string(),
+            "#d97706",
+        ),
+        "syncing" if total > 0 => (
+            format!("Downloading · {present} of {total} files"),
+            "#059669",
+        ),
         _ => ("Getting this app…".to_string(), "#059669"),
     };
     format!(
@@ -1712,7 +1806,9 @@ font-family:-apple-system,system-ui,'Segoe UI',Roboto,sans-serif;background:#fff
 }
 
 fn html_escape_min(s: &str) -> String {
-    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 /// The framing the `gatewayGet` JNI returns: `[u32 BE header-len][header JSON][body]`.
@@ -1763,7 +1859,10 @@ fn tag_value(event: &Event, name: &str) -> Option<String> {
 fn short_name(npub: &str) -> String {
     format!(
         "Myco-{}",
-        npub.trim_start_matches("npub1").chars().take(6).collect::<String>()
+        npub.trim_start_matches("npub1")
+            .chars()
+            .take(6)
+            .collect::<String>()
     )
 }
 
@@ -1787,7 +1886,10 @@ fn build_pair_event(
     if !secret.is_empty() {
         tags.push(Tag::parse(["secret", secret]).ok()?);
     }
-    EventBuilder::new(Kind::from(kind), "").tags(tags).sign_with_keys(keys).ok()
+    EventBuilder::new(Kind::from(kind), "")
+        .tags(tags)
+        .sign_with_keys(keys)
+        .ok()
 }
 
 fn load_library(path: &Path) -> Vec<LibraryItem> {
@@ -1848,7 +1950,10 @@ mod tests {
         let content = Arc::new(Content::open(&dir).unwrap());
 
         let site = build_test_site(
-            &[("/index.html", b"<h1>hi</h1>"), ("/app.js", b"console.log(1)")],
+            &[
+                ("/index.html", b"<h1>hi</h1>"),
+                ("/app.js", b"console.log(1)"),
+            ],
             None,
             Some("E2E"),
         );
@@ -1900,14 +2005,25 @@ mod tests {
         {
             let content = Content::open(&dir).unwrap();
             content.import_dir(&bundle).await.unwrap();
-            assert_eq!(content.library_snapshot().len(), 1, "import should pin to Library");
+            assert_eq!(
+                content.library_snapshot().len(),
+                1,
+                "import should pin to Library"
+            );
         }
 
         // Restart: a fresh Content over the same dir. The status map starts empty;
         // refresh_library_status re-lists the pinned site as ready.
         let content = Arc::new(Content::open(&dir).unwrap());
-        assert_eq!(content.library_snapshot().len(), 1, "Library persists on disk");
-        assert!(content.sites_snapshot().is_empty(), "status map is empty before refresh");
+        assert_eq!(
+            content.library_snapshot().len(),
+            1,
+            "Library persists on disk"
+        );
+        assert!(
+            content.sites_snapshot().is_empty(),
+            "status map is empty before refresh"
+        );
 
         content.clone().refresh_library_status().await;
         let sites = content.sites_snapshot();
@@ -1938,7 +2054,10 @@ mod tests {
 
             // Only connected members are offered as pull sources.
             content.set_connected_peers(vec!["npub1bob".to_string()]);
-            assert_eq!(content.connected_circle_npubs(), vec!["npub1bob".to_string()]);
+            assert_eq!(
+                content.connected_circle_npubs(),
+                vec!["npub1bob".to_string()]
+            );
 
             content.remove_from_circle("npub1bob");
             assert_eq!(content.circle_snapshot().len(), 1);
@@ -1985,7 +2104,10 @@ mod tests {
         let event = build_pair_event(&peer, KIND_PAIR_REMOVE, &peer_npub, "Peer", "")
             .expect("build pair-remove event");
         content.handle_pair_event(&event);
-        assert!(content.circle_snapshot().is_empty(), "peer removed on unpair");
+        assert!(
+            content.circle_snapshot().is_empty(),
+            "peer removed on unpair"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -70,7 +70,9 @@ impl Gossiper for MeshGossiper {
                         for addr in self.content.retriable_library_addrs() {
                             let content = self.content.clone();
                             let holder = npub.clone();
-                            tokio::spawn(async move { content.open_site(addr, Some(holder)).await });
+                            tokio::spawn(
+                                async move { content.open_site(addr, Some(holder)).await },
+                            );
                         }
                     }
                 }
@@ -136,7 +138,9 @@ impl Gossiper for MeshGossiper {
         req_ttl: u8,
         exclude: Option<IpAddr>,
     ) -> Vec<Event> {
-        self.content.pull_from_peers(filters, req_ttl, exclude).await
+        self.content
+            .pull_from_peers(filters, req_ttl, exclude)
+            .await
     }
 }
 
@@ -145,7 +149,11 @@ mod tests {
     use super::*;
 
     fn local() -> Inbound {
-        Inbound { origin: Origin::Local, event_ttl: None, sender: None }
+        Inbound {
+            origin: Origin::Local,
+            event_ttl: None,
+            sender: None,
+        }
     }
 
     #[test]
@@ -171,7 +179,14 @@ mod tests {
             .unwrap();
         // A mesh-origin event whose TTL is already spent must not be re-forwarded.
         gossiper
-            .on_event(ev.clone(), Inbound { origin: Origin::Mesh, event_ttl: Some(0), sender: None })
+            .on_event(
+                ev.clone(),
+                Inbound {
+                    origin: Origin::Mesh,
+                    event_ttl: Some(0),
+                    sender: None,
+                },
+            )
             .await;
         // A local origin with no peers is also a clean no-op.
         gossiper.on_event(ev, local()).await;

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -249,8 +249,11 @@ impl PeerSource for IpPeerSource {
     ) -> anyhow::Result<Option<Vec<u8>>> {
         // Manifest hints first, then this source's own servers (deduped). A mesh
         // source skips the manifest's public hints entirely (stay on the mesh).
-        let mut candidates: Vec<String> =
-            if self.ignore_manifest_servers { Vec::new() } else { servers.to_vec() };
+        let mut candidates: Vec<String> = if self.ignore_manifest_servers {
+            Vec::new()
+        } else {
+            servers.to_vec()
+        };
         for s in &self.blossom_servers {
             if !candidates.contains(s) {
                 candidates.push(s.clone());
@@ -301,11 +304,17 @@ mod tests {
                 let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
                 // Read the REQ (ignore contents; the test filter always matches).
                 if let Some(Ok(Message::Text(_req))) = ws.next().await {
-                    let event = serde_json::json!(["EVENT", "myco", serde_json::from_str::<serde_json::Value>(&event_json).unwrap()]);
+                    let event = serde_json::json!([
+                        "EVENT",
+                        "myco",
+                        serde_json::from_str::<serde_json::Value>(&event_json).unwrap()
+                    ]);
                     ws.send(Message::Text(event.to_string())).await.unwrap();
-                    ws.send(Message::Text(serde_json::json!(["EOSE", "myco"]).to_string()))
-                        .await
-                        .unwrap();
+                    ws.send(Message::Text(
+                        serde_json::json!(["EOSE", "myco"]).to_string(),
+                    ))
+                    .await
+                    .unwrap();
                 }
             }
         });
@@ -399,7 +408,10 @@ mod tests {
 
         // A wrong hash yields nothing.
         let miss = source
-            .fetch_blob("00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff", &[])
+            .fetch_blob(
+                "00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff",
+                &[],
+            )
             .await
             .unwrap();
         assert_eq!(miss, None);
@@ -428,7 +440,8 @@ mod tests {
     #[tokio::test]
     #[ignore = "hits the public internet"]
     async fn fetch_real_nsite_over_ip() {
-        let link = "https://npub1apgedl4jczacut0dasn0mszyyhhxzlvjcshjkczms47nt2d4eymsku78ws.nsite.lol/";
+        let link =
+            "https://npub1apgedl4jczacut0dasn0mszyyhhxzlvjcshjkczms47nt2d4eymsku78ws.nsite.lol/";
         let addr = nsite_deck::parse_link(link).expect("parse link");
 
         let source = IpPeerSource::with_defaults();
@@ -438,11 +451,7 @@ mod tests {
             .expect("fetch ok")
             .expect("manifest found on public relays");
         let m = nsite_deck::Manifest::from_event(manifest).expect("parse manifest");
-        println!(
-            "manifest: title={:?}, {} paths",
-            m.title,
-            m.paths.len()
-        );
+        println!("manifest: title={:?}, {} paths", m.title, m.paths.len());
         assert!(!m.paths.is_empty(), "manifest should map at least one path");
 
         // Pull + verify the index blob (or the first path).
@@ -478,7 +487,10 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("myco-ip-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let content = Arc::new(Content::open(&dir).unwrap());
-        content.set_source(Arc::new(IpPeerSource::new(vec![relay_url], vec![blossom_url])));
+        content.set_source(Arc::new(IpPeerSource::new(
+            vec![relay_url],
+            vec![blossom_url],
+        )));
 
         let addr = nsite_deck::SiteAddr {
             author: site.author,

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -122,8 +122,11 @@ impl AppRuntime {
             // push content. Loopback (the in-app WebView) always bypasses the gate.
             let gate: Arc<dyn myco_relay::server::PeerGate> =
                 Arc::new(crate::content::CircleGate::new(content.clone()));
-            let hub =
-                myco_relay::server::RelayHub::with_gate(content.relay(), Some(gossiper), Some(gate));
+            let hub = myco_relay::server::RelayHub::with_gate(
+                content.relay(),
+                Some(gossiper),
+                Some(gate),
+            );
 
             // Mesh socket: IPV6_V6ONLY `[::]:4869` so it doesn't collide with the
             // loopback bind and is reachable by peers at `ws://<npub>.fips:4869`.
@@ -137,7 +140,8 @@ impl AppRuntime {
                     });
                 }
                 Err(e) => {
-                    mesh_warning = format!("relay port 4869 unavailable (another app using it?): {e}");
+                    mesh_warning =
+                        format!("relay port 4869 unavailable (another app using it?): {e}");
                 }
             }
             // Loopback socket: the in-app nsite WebView talks to `ws://localhost:4869`
@@ -228,10 +232,11 @@ impl AppRuntime {
         // bridge). Host builds have no BLE backend, so this is Android-only.
         #[cfg(target_os = "android")]
         {
-            config.transports.ble = fips::config::TransportInstances::Single(fips::config::BleConfig {
-                auto_connect: Some(true),
-                ..Default::default()
-            });
+            config.transports.ble =
+                fips::config::TransportInstances::Single(fips::config::BleConfig {
+                    auto_connect: Some(true),
+                    ..Default::default()
+                });
         }
         fips::Node::new(config).map_err(|e| anyhow::anyhow!("fips Node::new failed: {e}"))
     }
@@ -289,24 +294,21 @@ impl AppRuntime {
                 self.rev += 1;
             }
             NativeAppAction::AddToLibrary { link } => {
-                if let (Some(content), Some(addr)) =
-                    (&self.content, nsite_deck::parse_link(&link))
+                if let (Some(content), Some(addr)) = (&self.content, nsite_deck::parse_link(&link))
                 {
                     content.add_to_library(&addr, None, now_secs());
                 }
                 self.rev += 1;
             }
             NativeAppAction::RemoveFromLibrary { link } => {
-                if let (Some(content), Some(addr)) =
-                    (&self.content, nsite_deck::parse_link(&link))
+                if let (Some(content), Some(addr)) = (&self.content, nsite_deck::parse_link(&link))
                 {
                     content.remove_from_library(&addr);
                 }
                 self.rev += 1;
             }
             NativeAppAction::ForgetNsite { link } => {
-                if let (Some(content), Some(addr)) =
-                    (&self.content, nsite_deck::parse_link(&link))
+                if let (Some(content), Some(addr)) = (&self.content, nsite_deck::parse_link(&link))
                 {
                     content.forget_site(&addr);
                 }
@@ -520,7 +522,7 @@ impl AppRuntime {
                         node_addr_hex: p.node_addr_hex,
                         npub: p.npub,
                         connected: p.connected,
-                        psm: 0,    // not surfaced in the snapshot yet
+                        psm: 0, // not surfaced in the snapshot yet
                         rssi: None,
                     })
                     .collect()
@@ -583,7 +585,11 @@ impl AppRuntime {
                 enabled: self.ble_enabled,
                 role: "peripheral+central".to_string(),
                 scanning: self.ble_enabled && self.node_running,
-                adapter_name: if self.node_running { "ble0".to_string() } else { "—".to_string() },
+                adapter_name: if self.node_running {
+                    "ble0".to_string()
+                } else {
+                    "—".to_string()
+                },
             },
             ble_peers,
             ble_adverts: self.ble_adverts(),
@@ -617,7 +623,11 @@ impl AppRuntime {
                 .as_ref()
                 .map(|c| c.discovered_snapshot())
                 .unwrap_or_default(),
-            offline_only: self.content.as_ref().map(|c| c.is_offline_only()).unwrap_or(false),
+            offline_only: self
+                .content
+                .as_ref()
+                .map(|c| c.is_offline_only())
+                .unwrap_or(false),
             update_check: self
                 .content
                 .as_ref()
@@ -634,7 +644,11 @@ impl AppRuntime {
             .map(|b| {
                 b.advert_views()
                     .into_iter()
-                    .map(|a| BleAdvert { addr: a.addr, psm: a.psm, rssi: a.rssi })
+                    .map(|a| BleAdvert {
+                        addr: a.addr,
+                        psm: a.psm,
+                        rssi: a.rssi,
+                    })
                     .collect()
             })
             .unwrap_or_default()
@@ -710,7 +724,11 @@ mod tests {
         let first = AppRuntime::new(dir.to_str().unwrap(), "0.0.1");
         let s1 = first.state();
         assert!(s1.error.is_empty(), "startup error: {}", s1.error);
-        assert!(s1.identity.own_npub.starts_with("npub1"), "npub: {}", s1.identity.own_npub);
+        assert!(
+            s1.identity.own_npub.starts_with("npub1"),
+            "npub: {}",
+            s1.identity.own_npub
+        );
         assert_eq!(s1.identity.own_pubkey_hex.len(), 64);
         assert!(s1.identity.fips_addr.ends_with(".fips"));
         assert!(!s1.ble.enabled, "BLE off until SetBleEnabled");
@@ -749,7 +767,10 @@ mod tests {
 
         assert!(!rt.state().ble.enabled);
         rt.dispatch(NativeAppAction::SetBleEnabled { enabled: true });
-        assert!(rt.state().ble.enabled, "SetBleEnabled true should flip the switch");
+        assert!(
+            rt.state().ble.enabled,
+            "SetBleEnabled true should flip the switch"
+        );
         rt.dispatch(NativeAppAction::SetBleEnabled { enabled: false });
         assert!(!rt.state().ble.enabled);
 
@@ -770,7 +791,10 @@ mod tests {
         assert!(s.node.running, "node should be running after StartNode");
 
         rt.dispatch(NativeAppAction::StopNode);
-        assert!(!rt.state().node.running, "node should be stopped after StopNode");
+        assert!(
+            !rt.state().node.running,
+            "node should be stopped after StopNode"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/myco-relay/src/lib.rs
+++ b/myco-relay/src/lib.rs
@@ -362,7 +362,10 @@ mod tests {
             "an already-expired event is not stored"
         );
 
-        let filter = ManifestFilter { kinds: vec![9], ..Default::default() };
+        let filter = ManifestFilter {
+            kinds: vec![9],
+            ..Default::default()
+        };
         let got = store.query(&filter).await.unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].id, live.id);

--- a/myco-relay/src/server.rs
+++ b/myco-relay/src/server.rs
@@ -127,7 +127,12 @@ impl RelayHub {
         // Buffer enough that a brief subscriber stall doesn't drop chat; an
         // over-capacity lag is surfaced as `Lagged` and skipped, not blocked.
         let (live, _) = broadcast::channel(512);
-        Arc::new(Self { store, live, gossip, gate })
+        Arc::new(Self {
+            store,
+            live,
+            gossip,
+            gate,
+        })
     }
 }
 
@@ -207,7 +212,11 @@ async fn root(
 /// One client connection: serve `REQ` backlog + keep the subscription live, accept
 /// `EVENT`s (store → fan to local subs → drive the gossiper), honour `CLOSE`.
 async fn handle_ws(socket: WebSocket, hub: Arc<RelayHub>, peer_ip: IpAddr) {
-    let origin = if peer_ip.is_loopback() { Origin::Local } else { Origin::Mesh };
+    let origin = if peer_ip.is_loopback() {
+        Origin::Local
+    } else {
+        Origin::Mesh
+    };
     let (mut ws_tx, mut ws_rx) = socket.split();
     let mut live = hub.live.subscribe();
     // Active subscriptions on this connection: sub_id -> its filters.
@@ -267,13 +276,22 @@ async fn handle_client_frame(
     };
     match array.first().and_then(|v| v.as_str()) {
         Some("REQ") => {
-            let sub_id = array.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let sub_id = array
+                .get(1)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
             // Mesh access gate: only paired peers may read from us. Unpaired peers
             // get a CLOSED (no backlog, no live subscription registered).
             if origin == Origin::Mesh {
                 if let Some(gate) = &hub.gate {
                     if !gate.may_read(peer_ip) {
-                        return vec![serde_json::json!(["CLOSED", sub_id, "restricted: pair to access"]).to_string()];
+                        return vec![serde_json::json!([
+                            "CLOSED",
+                            sub_id,
+                            "restricted: pair to access"
+                        ])
+                        .to_string()];
                     }
                 }
             }
@@ -305,7 +323,9 @@ async fn handle_client_frame(
             if req_ttl > 0 {
                 if let Some(gossip) = hub.gossip.clone() {
                     let exclude = (origin == Origin::Mesh).then_some(peer_ip);
-                    let remote = gossip.on_req(raw_filters.clone(), req_ttl - 1, exclude).await;
+                    let remote = gossip
+                        .on_req(raw_filters.clone(), req_ttl - 1, exclude)
+                        .await;
                     events.extend(remote);
                 }
             }
@@ -344,12 +364,20 @@ async fn handle_client_frame(
             if origin == Origin::Mesh {
                 if let Some(gate) = &hub.gate {
                     if !gate.may_publish(peer_ip, event.kind.as_u16()) {
-                        return vec![serde_json::json!(["OK", id, false, "restricted: pair to access"]).to_string()];
+                        return vec![serde_json::json!([
+                            "OK",
+                            id,
+                            false,
+                            "restricted: pair to access"
+                        ])
+                        .to_string()];
                     }
                 }
             }
             if event.verify().is_err() {
-                return vec![serde_json::json!(["OK", id, false, "invalid: bad signature"]).to_string()];
+                return vec![
+                    serde_json::json!(["OK", id, false, "invalid: bad signature"]).to_string(),
+                ];
             }
             match hub.store.store_event(event.clone()).await {
                 Ok(true) => {
@@ -368,7 +396,9 @@ async fn handle_client_frame(
                 }
                 // Duplicate / superseded: still an accepted outcome per NIP-01.
                 Ok(false) => vec![serde_json::json!(["OK", id, true, "duplicate:"]).to_string()],
-                Err(e) => vec![serde_json::json!(["OK", id, false, format!("error: {e}")]).to_string()],
+                Err(e) => {
+                    vec![serde_json::json!(["OK", id, false, format!("error: {e}")]).to_string()]
+                }
             }
         }
         Some("CLOSE") => {
@@ -386,7 +416,10 @@ fn parse_filter(value: &serde_json::Value) -> Option<ManifestFilter> {
     let obj = value.as_object()?;
     let mut filter = ManifestFilter::default();
     if let Some(kinds) = obj.get("kinds").and_then(|v| v.as_array()) {
-        filter.kinds = kinds.iter().filter_map(|k| k.as_u64().map(|k| k as u16)).collect();
+        filter.kinds = kinds
+            .iter()
+            .filter_map(|k| k.as_u64().map(|k| k as u16))
+            .collect();
     }
     if let Some(authors) = obj.get("authors").and_then(|v| v.as_array()) {
         filter.authors = authors
@@ -401,7 +434,10 @@ fn parse_filter(value: &serde_json::Value) -> Option<ManifestFilter> {
             .filter_map(|d| d.as_str().map(str::to_string))
             .collect();
     }
-    filter.limit = obj.get("limit").and_then(|v| v.as_u64()).map(|n| n as usize);
+    filter.limit = obj
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize);
     Some(filter)
 }
 
@@ -443,7 +479,9 @@ mod tests {
             "REQ", "s1",
             { "kinds": [KIND_ROOT], "authors": [hex::encode(keys.public_key().to_bytes())] }
         ]);
-        ws.send(WsMessage::Text(req.to_string().into())).await.unwrap();
+        ws.send(WsMessage::Text(req.to_string().into()))
+            .await
+            .unwrap();
 
         let mut got_event = false;
         let mut got_eose = false;
@@ -451,7 +489,10 @@ mod tests {
             let v: serde_json::Value = serde_json::from_str(&txt).unwrap();
             match v[0].as_str() {
                 Some("EVENT") => {
-                    assert_eq!(v[2]["id"].as_str(), Some(site.manifest.id.to_hex().as_str()));
+                    assert_eq!(
+                        v[2]["id"].as_str(),
+                        Some(site.manifest.id.to_hex().as_str())
+                    );
                     got_event = true;
                 }
                 Some("EOSE") => {
@@ -476,9 +517,13 @@ mod tests {
         let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
             .await
             .unwrap();
-        ws.send(WsMessage::Text(serde_json::json!(["EVENT", site.manifest]).to_string().into()))
-            .await
-            .unwrap();
+        ws.send(WsMessage::Text(
+            serde_json::json!(["EVENT", site.manifest])
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
 
         if let Some(Ok(WsMessage::Text(txt))) = ws.next().await {
             let v: serde_json::Value = serde_json::from_str(&txt).unwrap();
@@ -502,7 +547,9 @@ mod tests {
             .await
             .unwrap();
         let req = serde_json::json!(["REQ", "s1", { "kinds": [9], "#d": ["mesh"] }]);
-        sub.send(WsMessage::Text(req.to_string().into())).await.unwrap();
+        sub.send(WsMessage::Text(req.to_string().into()))
+            .await
+            .unwrap();
         // Drain until EOSE so we know the live subscription is registered.
         loop {
             if let Some(Ok(WsMessage::Text(txt))) = sub.next().await {
@@ -518,9 +565,11 @@ mod tests {
             .await
             .unwrap();
         let msg = chat_event(&keys, "mesh", "live hello");
-        pubr.send(WsMessage::Text(serde_json::json!(["EVENT", msg]).to_string().into()))
-            .await
-            .unwrap();
+        pubr.send(WsMessage::Text(
+            serde_json::json!(["EVENT", msg]).to_string().into(),
+        ))
+        .await
+        .unwrap();
 
         // The subscriber should receive it live as ["EVENT","s1",{…}].
         let received = tokio::time::timeout(std::time::Duration::from_secs(3), async {
@@ -534,7 +583,11 @@ mod tests {
         })
         .await
         .expect("did not receive live event in time");
-        assert_eq!(received, Some(msg.id.to_hex()), "live event delivered to subscriber");
+        assert_eq!(
+            received,
+            Some(msg.id.to_hex()),
+            "live event delivered to subscriber"
+        );
     }
 
     /// The gossiper is invoked for an accepted event, tagged with its origin.
@@ -561,9 +614,11 @@ mod tests {
         let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
             .await
             .unwrap();
-        ws.send(WsMessage::Text(serde_json::json!(["EVENT", msg]).to_string().into()))
-            .await
-            .unwrap();
+        ws.send(WsMessage::Text(
+            serde_json::json!(["EVENT", msg]).to_string().into(),
+        ))
+        .await
+        .unwrap();
         // Await the OK so the store+spawn have run.
         let _ = ws.next().await;
 

--- a/nsite-deck/src/lib.rs
+++ b/nsite-deck/src/lib.rs
@@ -48,7 +48,10 @@ mod tests {
         let blobs = MemBlobs::new();
 
         let site = build_test_site(
-            &[("/index.html", b"<h1>hello</h1>"), ("/style.css", b"body{}")],
+            &[
+                ("/index.html", b"<h1>hello</h1>"),
+                ("/style.css", b"body{}"),
+            ],
             None,
             Some("Test Site"),
         );

--- a/nsite-deck/src/sync.rs
+++ b/nsite-deck/src/sync.rs
@@ -149,8 +149,12 @@ async fn fetch_blobs(
 ) -> anyhow::Result<SyncOutcome> {
     // Fetch the icon (and landing page) blobs first, so the UI can show the real
     // app icon while the rest of the site still downloads (iOS-install style).
-    const PRIORITY_PATHS: &[&str] =
-        &["/favicon.ico", "/favicon.png", "/apple-touch-icon.png", "/index.html"];
+    const PRIORITY_PATHS: &[&str] = &[
+        "/favicon.ico",
+        "/favicon.png",
+        "/apple-touch-icon.png",
+        "/index.html",
+    ];
     let mut needed: Vec<String> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for p in PRIORITY_PATHS {
@@ -186,7 +190,7 @@ async fn fetch_blobs(
                     fetched = Some(bytes);
                     break;
                 }
-                Ok(_) => {} // missing or mismatch — retry
+                Ok(_) => {}  // missing or mismatch — retry
                 Err(_) => {} // transport error — retry
             }
         }

--- a/nsite-deck/src/testing.rs
+++ b/nsite-deck/src/testing.rs
@@ -54,7 +54,11 @@ pub fn build_test_site_with_keys(
         tags.push(Tag::parse(["title", t]).expect("title tag"));
     }
 
-    let kind = if d_tag.is_some() { KIND_NAMED } else { KIND_ROOT };
+    let kind = if d_tag.is_some() {
+        KIND_NAMED
+    } else {
+        KIND_ROOT
+    };
     let manifest = EventBuilder::new(Kind::from(kind), "")
         .tags(tags)
         .sign_with_keys(keys)
@@ -200,7 +204,10 @@ impl BlobStore for MemBlobs {
 
     async fn put(&self, bytes: &[u8]) -> anyhow::Result<String> {
         let hash = sha256_hex(bytes);
-        self.blobs.lock().unwrap().insert(hash.clone(), bytes.to_vec());
+        self.blobs
+            .lock()
+            .unwrap()
+            .insert(hash.clone(), bytes.to_vec());
         Ok(hash)
     }
 


### PR DESCRIPTION
Runs `cargo fmt --all` across the workspace crates (`myco-core`,
`myco-relay`, `myco-blossom`, `nsite-deck`) to clear pre-existing
formatting drift, then turns `cargo fmt --all --check` into a **gating**
CI step so any future drift fails the build.

### Why
The CI workflow added in v0.0.3 intentionally left `fmt` non-gating
because the tree had pre-existing drift. This cleans that up and flips
the gate on.

### Notes
- The Rust changes are purely mechanical (rustfmt only) — no behavior
  change; `cargo test --workspace` is unaffected.
- `rustfmt` is added back to the toolchain components in
  `.github/workflows/ci.yml`, and the `Format` step now gates.
- Sits on top of the v0.0.3 release commit; the `v0.0.3` tag stays at the
  pre-fmt commit, which is correct (post-release tidy-up).