### PR TITLE
Bottom-sheet menus for Circle members + share/add, with NFC sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Share an app by tapping phones. The share sheet now presents its
+  `myco://share` code over NFC, so a bump opens the app and pairs with the
+  sharer — the same result as scanning its QR. Receiving a tapped share also
+  works from the new *Add an app* sheet.
+
 ### Changed
+
+- The "Share this app" surface is now a bottom sheet styled like the pairing
+  QR — a larger code and a prominent "tap phones together" prompt — and it
+  closes itself once the recipient pairs.
+- *Add an app* is now a bottom sheet: a live camera scanner, a paste-a-link
+  button, and a tap-a-friend's-phone option, replacing the full-screen add
+  view.
+- Tapping or long-pressing someone in your Circle opens an action sheet
+  (avatar, short npub, "Remove from circle") instead of a bare "Forget?"
+  dialog; removal stays the last, destructive, confirmed action.
 
 ### Fixed
 

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -14,7 +14,9 @@ import android.graphics.RectF
 import android.graphics.drawable.Icon
 import android.net.VpnService
 import android.nfc.NfcAdapter
+import android.nfc.Tag
 import android.nfc.cardemulation.CardEmulation
+import android.nfc.tech.Ndef
 import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
@@ -31,6 +33,7 @@ import app.myco.BuildConfig
 import app.myco.core.AppCoreClient
 import app.myco.core.MycoCore
 import app.myco.core.NativeActions
+import app.myco.nfc.NfcReader
 import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
 import app.myco.share.NsiteShare
@@ -167,6 +170,10 @@ class MainActivity : ComponentActivity() {
         // the foreground HCE service after a background→foreground while on Circle.
         PairPresent.onChanged = { runOnUiThread { updateNfcPresent() } }
         updateNfcPresent()
+        // Foreground reader mode is owned by the add-app sheet (a modal window where
+        // passive NDEF dispatch can't reach us). Re-apply its current state here.
+        NfcReader.onChanged = { runOnUiThread { updateNfcReader() } }
+        updateNfcReader()
         // (Re)assert our memorable name into the core so pair events carry it. Done
         // here (not just onCreate) in case the device identity wasn't ready yet at
         // first launch; set_device_name is idempotent.
@@ -177,11 +184,13 @@ class MainActivity : ComponentActivity() {
 
     override fun onPause() {
         super.onPause()
-        // Drop the callback so the process-global PairPresent doesn't pin this
-        // Activity while backgrounded (it's re-set on the next onResume).
+        // Drop the callbacks so the process-global NFC state doesn't pin this
+        // Activity while backgrounded (they're re-set on the next onResume).
         PairPresent.onChanged = null
+        NfcReader.onChanged = null
         nfcAdapter?.let { adapter ->
             runCatching { CardEmulation.getInstance(adapter).unsetPreferredService(this) }
+            runCatching { adapter.disableReaderMode(this) }
         }
     }
 
@@ -198,6 +207,39 @@ class MainActivity : ComponentActivity() {
             else cardEmu.unsetPreferredService(this)
         }.onFailure { android.util.Log.w("MycoNfc", "nfc present setup failed", it) }
         android.util.Log.i("MycoNfc", "present=${PairPresent.presenting}")
+    }
+
+    /** Claim (or release) foreground NFC reader mode while the add-app sheet is up.
+     *  Reader mode reads a tapped peer's emulated tag in-foreground, which a modal
+     *  sheet's separate window otherwise misses (passive dispatch skips it). */
+    private fun updateNfcReader() {
+        val adapter = nfcAdapter ?: return
+        runCatching {
+            if (NfcReader.active) {
+                val flags = NfcAdapter.FLAG_READER_NFC_A or
+                    NfcAdapter.FLAG_READER_NFC_B or
+                    NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS
+                adapter.enableReaderMode(this, { tag -> handleNfcTag(tag) }, flags, null)
+            } else {
+                adapter.disableReaderMode(this)
+            }
+        }.onFailure { android.util.Log.w("MycoNfc", "nfc reader setup failed", it) }
+        android.util.Log.i("MycoNfc", "reading=${NfcReader.active}")
+    }
+
+    /** Read the NDEF URI record off a tapped tag (the peer's emulated share/pair
+     *  tag) and route it through the same handler as a scan. Runs on a binder
+     *  thread — hop to the main thread to touch the core / show toasts. */
+    private fun handleNfcTag(tag: Tag) {
+        val ndef = Ndef.get(tag) ?: return
+        val uri = runCatching {
+            val msg = ndef.cachedNdefMessage ?: run {
+                ndef.connect()
+                try { ndef.ndefMessage } finally { runCatching { ndef.close() } }
+            }
+            msg?.records?.firstNotNullOfOrNull { it.toUri()?.toString() }
+        }.getOrNull() ?: return
+        runOnUiThread { handleScannedText(uri) }
     }
 
     // --- BLE toggle (remembered) ---

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -237,9 +237,13 @@ class MainActivity : ComponentActivity() {
                 ndef.connect()
                 try { ndef.ndefMessage } finally { runCatching { ndef.close() } }
             }
-            msg?.records?.firstNotNullOfOrNull { it.toUri()?.toString() }
+            msg?.records?.firstNotNullOfOrNull { it.toUri() }
         }.getOrNull() ?: return
-        runOnUiThread { handleScannedText(uri) }
+        // Only act on our own scheme. Reader mode reads *any* tapped NDEF tag, so
+        // without this an unrelated URL tag would fall through to openNsite(). Raw
+        // nsite links are entered via QR/paste, never NFC.
+        if (uri.scheme != NsiteShare.SCHEME) return
+        runOnUiThread { handleScannedText(uri.toString()) }
     }
 
     // --- BLE toggle (remembered) ---

--- a/android/app/src/main/java/app/myco/nfc/NfcReader.kt
+++ b/android/app/src/main/java/app/myco/nfc/NfcReader.kt
@@ -1,0 +1,37 @@
+package app.myco.nfc
+
+import androidx.compose.runtime.mutableStateOf
+
+/**
+ * Process-global flag for foreground NFC **reading**. While [active], the Activity
+ * claims NFC reader mode and reads a tapped peer's emulated tag directly.
+ *
+ * Needed because the share/add surfaces are [androidx.compose.material3.ModalBottomSheet]s
+ * shown in their own focused window: there the OS's passive `NDEF_DISCOVERED` intent
+ * dispatch (what the Circle full-screen relies on) no longer reaches the Activity,
+ * so a tap goes unnoticed. Reader mode is foreground-scoped and works regardless of
+ * which window has focus.
+ *
+ * Scoped to the add-app sheet (the only place we read while a sheet covers us);
+ * [onChanged] lets the Activity enable/disable reader mode as it flips.
+ */
+object NfcReader {
+    private val activeState = mutableStateOf(false)
+
+    /** True while we want foreground reader mode. */
+    val active: Boolean get() = activeState.value
+
+    /** Set by the Activity to react when reading starts/stops. */
+    @Volatile
+    var onChanged: (() -> Unit)? = null
+
+    fun begin() {
+        activeState.value = true
+        onChanged?.invoke()
+    }
+
+    fun stop() {
+        activeState.value = false
+        onChanged?.invoke()
+    }
+}

--- a/android/app/src/main/java/app/myco/nfc/PairPresent.kt
+++ b/android/app/src/main/java/app/myco/nfc/PairPresent.kt
@@ -42,6 +42,15 @@ object PairPresent {
         onChanged?.invoke()
     }
 
+    /** Begin presenting a prebuilt payload verbatim (e.g. a `myco://share/…` URI
+     *  carrying an nsite). Unlike [begin], the caller owns the secret — used by the
+     *  share-an-app surface, which mints its own one-time secret in the share URI. */
+    fun beginRaw(uri: String) {
+        payload.value = uri
+        presentingState.value = true
+        onChanged?.invoke()
+    }
+
     /** Mint a new single-use secret and rebuild the presented payload (called after
      *  a tap is consumed, so the same code can't pair twice). */
     fun rotate(context: Context, ownNpub: String, deviceName: String) {

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -57,7 +57,6 @@ import app.myco.core.NativeActions
 import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
 import app.myco.share.PairSecrets
-import app.myco.ui.screens.AddScreen
 import app.myco.ui.screens.PairConnectedDialog
 import app.myco.ui.screens.AppsScreen
 import app.myco.ui.screens.CircleScreen
@@ -149,13 +148,12 @@ fun MycoApp(
     }
 
     val nav = rememberNavController()
-    val onAddApp = { nav.navigate("add") }
     Scaffold(
         bottomBar = {
             val current by nav.currentBackStackEntryAsState()
             // The full-screen pairing / Add surfaces hide the bottom bar.
             val route = current?.destination?.route
-            if (route !in setOf("add", "qr", "requests")) {
+            if (route !in setOf("qr", "requests")) {
                 NavigationBar(containerColor = MaterialTheme.colorScheme.surface) {
                     val tabs = if (developerMode) TABS else TABS.filterNot { it.route == "dev" }
                     tabs.forEach { tab ->
@@ -197,7 +195,7 @@ fun MycoApp(
         Surface(modifier = Modifier.padding(padding), color = MaterialTheme.colorScheme.background) {
             NavHost(navController = nav, startDestination = "apps") {
                 composable("apps") {
-                    AppsScreen(state, client, onLaunchNsite = onLaunchNsite, onPinToHome = onPinToHome, onAddApp = onAddApp)
+                    AppsScreen(state, client, onLaunchNsite = onLaunchNsite, onPinToHome = onPinToHome, onScanned = onScanned)
                 }
                 composable("circle") {
                     CircleScreen(state, client, onOpenQr = { nav.navigate("qr") }, onOpenRequests = { nav.navigate("requests") })
@@ -226,13 +224,6 @@ fun MycoApp(
                 }
                 composable("requests") {
                     RequestsScreen(state = state, client = client, onBack = { nav.popBackStack() })
-                }
-                composable("add") {
-                    AddScreen(
-                        state = state,
-                        onScanned = { text -> nav.popBackStack(); onScanned(text) },
-                        onBack = { nav.popBackStack() },
-                    )
                 }
             }
         }

--- a/android/app/src/main/java/app/myco/ui/screens/AppsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/AppsScreen.kt
@@ -43,7 +43,9 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -65,8 +67,11 @@ import app.myco.core.AppCoreClient
 import app.myco.core.AppState
 import app.myco.core.NativeActions
 import app.myco.core.SiteStatus
+import app.myco.nfc.PairPresent
 import app.myco.share.NsiteShare
 import app.myco.ui.ScreenHeader
+import app.myco.ui.theme.EmeraldInk
+import app.myco.ui.theme.EmeraldSoft
 import app.myco.ui.theme.Slate
 import app.myco.ui.theme.tileColorFor
 import kotlinx.coroutines.Dispatchers
@@ -88,7 +93,7 @@ fun AppsScreen(
 ) {
     var query by remember { mutableStateOf("") }
     var sheetFor by remember { mutableStateOf<SiteStatus?>(null) }
-    var shareUri by remember { mutableStateOf<String?>(null) }
+    var shareFor by remember { mutableStateOf<ShareTarget?>(null) }
     var confirmRemove by remember { mutableStateOf<SiteStatus?>(null) }
 
     // One-shot toast with the result of a "Check for updates" run (fires when the
@@ -156,12 +161,13 @@ fun AppsScreen(
                 site = site,
                 onOpen = { sheetFor = null; onLaunchNsite(site.host, site.title) },
                 onShare = {
-                    shareUri = NsiteShare.buildShareUri(
+                    val uri = NsiteShare.buildShareUri(
                         nsiteHost = site.host,
                         deviceNpub = state.ownNpub,
                         deviceName = NsiteShare.deviceName(state.ownNpub),
                         pairSecret = NsiteShare.newPairSecret(),
                     )
+                    shareFor = ShareTarget(uri = uri, title = site.title.ifEmpty { site.host.take(12) })
                     sheetFor = null
                 },
                 onPinToHome = { sheetFor = null; onPinToHome(site.host, site.title) },
@@ -170,7 +176,7 @@ fun AppsScreen(
         }
     }
 
-    shareUri?.let { uri -> ShareQrDialog(uri) { shareUri = null } }
+    shareFor?.let { target -> ShareQrSheet(target = target, onDismiss = { shareFor = null }) }
 
     confirmRemove?.let { site ->
         AlertDialog(
@@ -329,10 +335,6 @@ private fun AddTile(onClick: () -> Unit) {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
-private fun Modifier.combinedClickableSafe(onClick: () -> Unit): Modifier =
-    this.combinedClickable(onClick = onClick)
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AppSheet(
@@ -382,45 +384,80 @@ private fun AppSheet(
     }
 }
 
-@Composable
-private fun SheetAction(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    label: String,
-    tint: Color = MaterialTheme.colorScheme.primary,
-    onClick: () -> Unit,
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .combinedClickableSafe(onClick)
-            .padding(vertical = 12.dp),
-    ) {
-        Icon(icon, contentDescription = null, tint = tint)
-        Spacer(Modifier.size(14.dp))
-        Text(label, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
-    }
-}
+/** What a [ShareQrSheet] presents: the prebuilt `myco://share/…` URI (stable, so
+ *  its QR and the NFC payload carry the same one-time secret) plus a label. */
+private class ShareTarget(val uri: String, val title: String)
 
+/**
+ * The **Share an app** surface — a bottom sheet styled like the pair "My code"
+ * panel: the share QR plus a prominent tap-phones-together prompt. While it's
+ * visible the device presents the share URI over NFC ([PairPresent.beginRaw]),
+ * so a phone tap shares the app exactly like a scan would.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ShareQrDialog(uri: String, onDismiss: () -> Unit) {
-    val qr = remember(uri) { NsiteShare.qrBitmap(uri) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } },
-        title = { Text("Share this app") },
-        text = {
-            Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Image(qr.asImageBitmap(), contentDescription = "share QR", modifier = Modifier.size(260.dp))
-                Text(
-                    "Scan with another Myco to open this app — and pair with this device.",
-                    color = Slate,
-                    style = MaterialTheme.typography.bodySmall,
-                    textAlign = TextAlign.Center,
-                )
+private fun ShareQrSheet(target: ShareTarget, onDismiss: () -> Unit) {
+    // Emulate an NDEF tag carrying the share URI for as long as the sheet is up.
+    // The reader phone's OS reads it → MainActivity.openSharedNsite (pair + pull).
+    DisposableEffect(target.uri) {
+        PairPresent.beginRaw(target.uri)
+        onDispose { PairPresent.stop() }
+    }
+    val qr = remember(target.uri) { NsiteShare.qrBitmap(target.uri) }
+    // Open fully expanded (not the half-height detent) so the whole thing — QR plus
+    // the tap-to-share prompt — is on screen without a drag.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text("Share this app", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(12.dp))
+            Surface(shape = RoundedCornerShape(20.dp), color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    QrCodeCard(qr, contentDescription = "Share code for ${target.title}", size = 210.dp)
+                    Spacer(Modifier.height(10.dp))
+                    Text(target.title, fontWeight = FontWeight.ExtraBold, style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        "Scan to open this app — and pair with this device",
+                        color = Slate,
+                        style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center,
+                    )
+                }
             }
-        },
-    )
+            Spacer(Modifier.height(12.dp))
+            // The headline action: just bump phones (no scanning needed). The
+            // breathing NFC bubble mirrors the Circle tab's tap-to-connect hint.
+            Surface(shape = RoundedCornerShape(16.dp), color = EmeraldSoft, modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    NfcPulseBubble(size = 44.dp)
+                    Column {
+                        Text(
+                            "Tap phones together to share",
+                            fontWeight = FontWeight.ExtraBold,
+                            color = EmeraldInk,
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        Text(
+                            "Hold the backs together — no scan needed",
+                            color = Color(0xFF047857),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
+            }
+        }
+    }
 }
 
 private fun initialOf(site: SiteStatus): String =

--- a/android/app/src/main/java/app/myco/ui/screens/AppsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/AppsScreen.kt
@@ -176,7 +176,13 @@ fun AppsScreen(
         }
     }
 
-    shareFor?.let { target -> ShareQrSheet(target = target, onDismiss = { shareFor = null }) }
+    shareFor?.let { target ->
+        ShareQrSheet(
+            target = target,
+            pendingRequestCount = state.pendingPairRequests.size,
+            onDismiss = { shareFor = null },
+        )
+    }
 
     confirmRemove?.let { site ->
         AlertDialog(
@@ -396,12 +402,19 @@ private class ShareTarget(val uri: String, val title: String)
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ShareQrSheet(target: ShareTarget, onDismiss: () -> Unit) {
+private fun ShareQrSheet(target: ShareTarget, pendingRequestCount: Int, onDismiss: () -> Unit) {
     // Emulate an NDEF tag carrying the share URI for as long as the sheet is up.
     // The reader phone's OS reads it → MainActivity.openSharedNsite (pair + pull).
     DisposableEffect(target.uri) {
         PairPresent.beginRaw(target.uri)
         onDispose { PairPresent.stop() }
+    }
+    // The recipient tapping/scanning sends a pair request back to us. Once one
+    // lands, the share has gone through — drop the sheet and let the normal
+    // accept prompt take over (it's suppressed while we're presenting).
+    val baselineRequests = remember { pendingRequestCount }
+    LaunchedEffect(pendingRequestCount) {
+        if (pendingRequestCount > baselineRequests) onDismiss()
     }
     val qr = remember(target.uri) { NsiteShare.qrBitmap(target.uri) }
     // Open fully expanded (not the half-height detent) so the whole thing — QR plus

--- a/android/app/src/main/java/app/myco/ui/screens/AppsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/AppsScreen.kt
@@ -67,6 +67,7 @@ import app.myco.core.AppCoreClient
 import app.myco.core.AppState
 import app.myco.core.NativeActions
 import app.myco.core.SiteStatus
+import app.myco.nfc.NfcReader
 import app.myco.nfc.PairPresent
 import app.myco.share.NsiteShare
 import app.myco.ui.ScreenHeader
@@ -89,12 +90,13 @@ fun AppsScreen(
     client: AppCoreClient,
     onLaunchNsite: (host: String, title: String) -> Unit,
     onPinToHome: (host: String, title: String) -> Unit,
-    onAddApp: () -> Unit,
+    onScanned: (String) -> Unit,
 ) {
     var query by remember { mutableStateOf("") }
     var sheetFor by remember { mutableStateOf<SiteStatus?>(null) }
     var shareFor by remember { mutableStateOf<ShareTarget?>(null) }
     var confirmRemove by remember { mutableStateOf<SiteStatus?>(null) }
+    var showAdd by remember { mutableStateOf(false) }
 
     // One-shot toast with the result of a "Check for updates" run (fires when the
     // core bumps the check generation), so the user gets explicit feedback.
@@ -139,7 +141,7 @@ fun AppsScreen(
             )
         }
         item {
-            AddTile { onAddApp() }
+            AddTile { showAdd = true }
         }
         if (apps.isEmpty() && query.isBlank()) {
             item(span = { GridItemSpan(maxLineSpan) }) {
@@ -181,6 +183,14 @@ fun AppsScreen(
             target = target,
             pendingRequestCount = state.pendingPairRequests.size,
             onDismiss = { shareFor = null },
+        )
+    }
+
+    if (showAdd) {
+        AddAppSheet(
+            siteCount = state.sites.size,
+            onScanned = { showAdd = false; onScanned(it) },
+            onDismiss = { showAdd = false },
         )
     }
 
@@ -469,6 +479,69 @@ private fun ShareQrSheet(target: ShareTarget, pendingRequestCount: Int, onDismis
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * **Add an app** — a bottom sheet mirroring the share sheet, but with a live
+ * camera scanner in place of the QR (you're the one reading a friend's code).
+ * A scan, a pasted link, or an NFC tap (handled passively by the OS) all route
+ * through [onScanned] → MainActivity.handleScannedText.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddAppSheet(siteCount: Int, onScanned: (String) -> Unit, onDismiss: () -> Unit) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    // Claim foreground NFC reader mode while we're up — a modal sheet's own window
+    // misses the OS's passive tap dispatch, so the Activity reads the tag directly.
+    DisposableEffect(Unit) {
+        NfcReader.begin()
+        onDispose { NfcReader.stop() }
+    }
+    // A camera scan routes through onScanned (which dismisses us); an NFC tap is read
+    // into MainActivity — either way close the sheet when a new app shows up, to
+    // reveal it downloading in the grid behind us.
+    val baselineSites = remember { siteCount }
+    LaunchedEffect(siteCount) {
+        if (siteCount > baselineSites) onDismiss()
+    }
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text("Add an app", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(12.dp))
+            Box(modifier = Modifier.fillMaxWidth().height(300.dp)) {
+                ScanPanel(onScanned = onScanned)
+            }
+            Spacer(Modifier.height(12.dp))
+            // Same breathing NFC bubble as the share sheet — here you're the reader.
+            Surface(shape = RoundedCornerShape(16.dp), color = EmeraldSoft, modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    NfcPulseBubble(size = 44.dp)
+                    Column {
+                        Text(
+                            "Or tap a friend's phone",
+                            fontWeight = FontWeight.ExtraBold,
+                            color = EmeraldInk,
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        Text(
+                            "Hold the backs together to add their app",
+                            color = Color(0xFF047857),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            PasteCodeButton(label = "Paste a link", onPaste = onScanned)
         }
     }
 }

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -1,11 +1,5 @@
 package app.myco.ui.screens
 
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -34,11 +28,15 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Contactless
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MarkEmailUnread
+import androidx.compose.material.icons.filled.PersonRemove
 import androidx.compose.material.icons.filled.QrCode2
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -54,11 +52,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -101,7 +96,7 @@ private enum class Badge { NONE, PLUS, SENT }
  * scan / show / paste. While this screen is open the device presents over NFC, so
  * two phones both here pair on a single bump.
  */
-@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun CircleScreen(
     state: AppState,
@@ -112,7 +107,9 @@ fun CircleScreen(
     val context = LocalContext.current
     var name by remember(state.ownNpub) { mutableStateOf(DeviceName.current(context, state.ownNpub)) }
     var editing by remember { mutableStateOf(false) }
-    var forget by remember { mutableStateOf<CircleContact?>(null) }
+    // Tap/long-press a circle member → a menu sheet; "Remove" opens a confirm.
+    var sheetFor by remember { mutableStateOf<CircleContact?>(null) }
+    var confirmRemove by remember { mutableStateOf<CircleContact?>(null) }
     val sent = remember { mutableStateListOf<String>() }
 
     // NFC availability, re-checked on resume (e.g. back from NFC settings).
@@ -220,7 +217,9 @@ fun CircleScreen(
                                 ring = if (online) Ring.ONLINE else Ring.NONE,
                                 badge = Badge.NONE,
                                 dim = !online,
-                                onLongClick = { forget = c },
+                                // "Holding or tapping" both open the menu sheet.
+                                onClick = { sheetFor = c },
+                                onLongClick = { sheetFor = c },
                             )
                         }
                     }
@@ -262,18 +261,64 @@ fun CircleScreen(
         )
     }
 
-    forget?.let { c ->
+    sheetFor?.let { c ->
+        ModalBottomSheet(onDismissRequest = { sheetFor = null }) {
+            PersonSheet(
+                contact = c,
+                onRemove = { sheetFor = null; confirmRemove = c },
+            )
+        }
+    }
+
+    confirmRemove?.let { c ->
         AlertDialog(
-            onDismissRequest = { forget = null },
+            onDismissRequest = { confirmRemove = null },
             confirmButton = {
-                TextButton(onClick = { client.dispatch(NativeActions.removeFromCircle(c.npub)); forget = null }) { Text("Forget") }
+                TextButton(onClick = { client.dispatch(NativeActions.removeFromCircle(c.npub)); confirmRemove = null }) {
+                    Text("Remove", color = MaterialTheme.colorScheme.error)
+                }
             },
-            dismissButton = { TextButton(onClick = { forget = null }) { Text("Cancel") } },
-            title = { Text("Forget ${c.name.ifEmpty { "this peer" }}?") },
+            dismissButton = { TextButton(onClick = { confirmRemove = null }) { Text("Cancel") } },
+            title = { Text("Remove ${c.name.ifEmpty { "this peer" }}?") },
             text = { Text("They'll be removed from your Circle. You can re-pair anytime.") },
         )
     }
 }
+
+/**
+ * The menu sheet for a person in your Circle — mirrors the app long-press sheet
+ * ([AppSheet]). Remove-from-circle is the **last**, destructive action (red); the
+ * useful, non-destructive actions come first.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PersonSheet(
+    contact: CircleContact,
+    onRemove: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, bottom = 28.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier.size(44.dp).clip(CircleShape).background(avatarColorFor(contact.npub)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(contact.name.firstOrNull()?.uppercase() ?: "?", color = Color.White, fontWeight = FontWeight.Bold)
+            }
+            Spacer(Modifier.width(12.dp))
+            Column {
+                Text(contact.name.ifEmpty { "unknown" }, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text("in your circle", color = Slate, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        SheetAction(Icons.Filled.Info, shortNpub(contact.npub)) { }
+        SheetAction(Icons.Filled.PersonRemove, "Remove from circle", tint = MaterialTheme.colorScheme.error) { onRemove() }
+    }
+}
+
+/** A compact, recognizable npub: `npub1abcd…wxyz`. */
+private fun shortNpub(npub: String): String =
+    if (npub.length <= 20) npub else npub.take(12) + "…" + npub.takeLast(6)
 
 @Composable
 private fun IdentityChip(name: String, onEdit: () -> Unit) {
@@ -322,51 +367,19 @@ private fun TapToConnect(nfc: NfcState, onEnableNfc: () -> Unit) {
     }
 }
 
-/** The tap-to-connect bubble with a subtle, looping "signal" animation — the two
- *  outer contactless arcs breathe to draw a little attention without distracting. */
+/** The tap-to-connect bubble: a static warning glyph when NFC is off, otherwise
+ *  the shared breathing-arcs [NfcPulseBubble]. */
 @Composable
 private fun NfcBubble(warn: Boolean) {
-    Box(
-        modifier = Modifier.size(48.dp).background(if (warn) Color(0xFFB45309) else Emerald, CircleShape),
-        contentAlignment = Alignment.Center,
-    ) {
-        if (warn) {
-            Icon(
-                Icons.Filled.Contactless,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(26.dp),
-            )
-        } else {
-            val transition = rememberInfiniteTransition(label = "nfc")
-            val wave by transition.animateFloat(
-                initialValue = 0.25f,
-                targetValue = 1f,
-                animationSpec = infiniteRepeatable(tween(950, easing = FastOutSlowInEasing), RepeatMode.Reverse),
-                label = "wave",
-            )
-            Canvas(modifier = Modifier.size(28.dp)) {
-                val cx = size.width * 0.30f
-                val cy = size.height / 2f
-                val white = Color.White
-                drawCircle(white, radius = 1.8.dp.toPx(), center = Offset(cx, cy))
-                fun arc(rDp: Float, alpha: Float) {
-                    val r = rDp.dp.toPx()
-                    drawArc(
-                        color = white.copy(alpha = alpha),
-                        startAngle = -52f,
-                        sweepAngle = 104f,
-                        useCenter = false,
-                        topLeft = Offset(cx - r, cy - r),
-                        size = Size(2 * r, 2 * r),
-                        style = Stroke(width = 2.2.dp.toPx(), cap = StrokeCap.Round),
-                    )
-                }
-                arc(4.5f, 1f)
-                arc(8f, wave)
-                arc(11.5f, wave * 0.7f)
-            }
+    if (warn) {
+        Box(
+            modifier = Modifier.size(48.dp).background(Color(0xFFB45309), CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(Icons.Filled.Contactless, contentDescription = null, tint = Color.White, modifier = Modifier.size(26.dp))
         }
+    } else {
+        NfcPulseBubble()
     }
 }
 

--- a/android/app/src/main/java/app/myco/ui/screens/NfcVisuals.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/NfcVisuals.kt
@@ -1,0 +1,72 @@
+package app.myco.ui.screens
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import app.myco.ui.theme.Emerald
+
+/**
+ * The animated "tap to connect" NFC bubble — a filled circle whose two outer
+ * contactless arcs breathe to draw a little attention without distracting. Shared
+ * by the Circle tab's tap-to-connect hint and the share-an-app sheet, so both NFC
+ * surfaces read the same. Radii scale with [size], so callers can size it freely.
+ */
+@Composable
+internal fun NfcPulseBubble(
+    modifier: Modifier = Modifier,
+    size: Dp = 48.dp,
+    background: Color = Emerald,
+) {
+    androidx.compose.foundation.layout.Box(
+        modifier = modifier.size(size).background(background, CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        val transition = rememberInfiniteTransition(label = "nfc")
+        val wave by transition.animateFloat(
+            initialValue = 0.25f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(tween(950, easing = FastOutSlowInEasing), RepeatMode.Reverse),
+            label = "wave",
+        )
+        Canvas(modifier = Modifier.size(size * 0.58f)) {
+            val w = this.size.width
+            val cx = w * 0.30f
+            val cy = w / 2f
+            val white = Color.White
+            drawCircle(white, radius = w * 0.064f, center = Offset(cx, cy))
+            fun arc(rFraction: Float, alpha: Float) {
+                val r = w * rFraction
+                drawArc(
+                    color = white.copy(alpha = alpha),
+                    startAngle = -52f,
+                    sweepAngle = 104f,
+                    useCenter = false,
+                    topLeft = Offset(cx - r, cy - r),
+                    size = Size(2 * r, 2 * r),
+                    style = Stroke(width = w * 0.078f, cap = StrokeCap.Round),
+                )
+            }
+            arc(0.16f, 1f)
+            arc(0.286f, wave)
+            arc(0.41f, wave * 0.7f)
+        }
+    }
+}

--- a/android/app/src/main/java/app/myco/ui/screens/PairScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/PairScreen.kt
@@ -2,7 +2,6 @@ package app.myco.ui.screens
 
 import android.Manifest
 import android.content.pm.PackageManager
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Canvas
@@ -27,17 +26,14 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Contactless
-import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.material.icons.filled.FlashOff
 import androidx.compose.material.icons.filled.FlashOn
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -51,7 +47,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -64,7 +59,6 @@ import app.myco.core.AppState
 import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
 import app.myco.share.NsiteShare
-import app.myco.ui.PeersPill
 import app.myco.ui.theme.Emerald
 import app.myco.ui.theme.EmeraldSoft
 import app.myco.ui.theme.Slate
@@ -106,106 +100,12 @@ fun QrScreen(
         MyCodePanel(state = state, deviceName = name)
 
         Spacer(Modifier.height(16.dp))
-        val clipboard = LocalClipboardManager.current
-        Surface(
-            shape = RoundedCornerShape(14.dp),
-            color = Color.White,
-            border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFCBD5E1)),
-            modifier = Modifier.fillMaxWidth().height(48.dp).clickable {
-                val text = clipboard.getText()?.text?.trim().orEmpty()
-                if (text.isNotEmpty()) onScanned(text)
-                else Toast.makeText(context, "Clipboard is empty", Toast.LENGTH_SHORT).show()
-            },
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(Icons.Filled.ContentPaste, contentDescription = null, tint = Color(0xFF334155), modifier = Modifier.size(18.dp))
-                Spacer(Modifier.size(8.dp))
-                Text("Paste a code", color = Color(0xFF334155), fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelLarge)
-            }
-        }
-    }
-}
-
-/**
- * **Add an app**: the same scanner, but the alternate tab is "Enter URL" (paste an
- * nsite link). Default tab is Scan.
- */
-@Composable
-fun AddScreen(state: AppState, onScanned: (String) -> Unit, onBack: () -> Unit) {
-    var showAlt by remember { mutableStateOf(false) }
-
-    Column(modifier = Modifier.fillMaxSize().padding(20.dp)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back") }
-                Text("Add an app", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.ExtraBold)
-            }
-            PeersPill(state)
-        }
-
-        Spacer(Modifier.height(16.dp))
-        SegmentedToggle(showAlt = showAlt, altLabel = "Enter URL", onSelect = { showAlt = it })
-        Spacer(Modifier.height(20.dp))
-
-        Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
-            if (showAlt) UrlPanel(onSubmit = onScanned) else ScanPanel(onScanned = onScanned)
-        }
-
-        Spacer(Modifier.height(16.dp))
-        Text(
-            if (showAlt) "Paste a public nsite link to fetch it." else "Scan a friend's share code to add their app.",
-            color = MaterialTheme.colorScheme.onSurface,
-            style = MaterialTheme.typography.bodyLarge,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        PasteCodeButton(label = "Paste a code", onPaste = onScanned)
     }
 }
 
 @Composable
-private fun SegmentedToggle(showAlt: Boolean, altLabel: String, onSelect: (Boolean) -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(50))
-            .background(MaterialTheme.colorScheme.surfaceVariant)
-            .padding(4.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        Segment("Scan", selected = !showAlt, modifier = Modifier.weight(1f)) { onSelect(false) }
-        Segment(altLabel, selected = showAlt, modifier = Modifier.weight(1f)) { onSelect(true) }
-    }
-}
-
-@Composable
-private fun Segment(label: String, selected: Boolean, modifier: Modifier, onClick: () -> Unit) {
-    Box(
-        modifier = modifier
-            .clip(RoundedCornerShape(50))
-            .background(if (selected) MaterialTheme.colorScheme.primary else Color.Transparent)
-            .clickable(onClick = onClick)
-            .padding(vertical = 12.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            label,
-            color = if (selected) MaterialTheme.colorScheme.onPrimary else Slate,
-            fontWeight = FontWeight.Bold,
-            style = MaterialTheme.typography.titleMedium,
-        )
-    }
-}
-
-@Composable
-private fun ScanPanel(onScanned: (String) -> Unit) {
+internal fun ScanPanel(onScanned: (String) -> Unit) {
     val context = LocalContext.current
     var granted by remember {
         mutableStateOf(
@@ -342,42 +242,6 @@ private fun MyCodePanel(state: AppState, deviceName: String) {
                     Text("also tap-to-pair ready", color = Color(0xFF047857), fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun UrlPanel(onSubmit: (String) -> Unit) {
-    var link by remember { mutableStateOf("") }
-    val clipboard = LocalClipboardManager.current
-    Box(
-        modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(22.dp)).background(MaterialTheme.colorScheme.surfaceVariant),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            OutlinedTextField(
-                value = link,
-                onValueChange = { link = it },
-                singleLine = true,
-                placeholder = { Text("npub… / <npub>.nsite.lol") },
-                trailingIcon = {
-                    IconButton(onClick = {
-                        clipboard.getText()?.text?.let { if (it.isNotBlank()) link = it.trim() }
-                    }) {
-                        Icon(Icons.Filled.ContentPaste, contentDescription = "Paste")
-                    }
-                },
-                modifier = Modifier.fillMaxWidth(),
-            )
-            Spacer(Modifier.height(14.dp))
-            Button(
-                onClick = { if (link.isNotBlank()) onSubmit(link.trim()) },
-                enabled = link.isNotBlank(),
-                modifier = Modifier.fillMaxWidth(),
-            ) { Text("Fetch") }
         }
     }
 }

--- a/android/app/src/main/java/app/myco/ui/screens/PairScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/PairScreen.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -52,7 +51,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -328,9 +326,7 @@ private fun MyCodePanel(state: AppState, deviceName: String) {
             modifier = Modifier.fillMaxWidth().padding(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Box(modifier = Modifier.clip(RoundedCornerShape(16.dp)).background(Color.White).padding(14.dp)) {
-                Image(qr.asImageBitmap(), contentDescription = "Your pairing code", modifier = Modifier.size(180.dp))
-            }
+            QrCodeCard(qr, contentDescription = "Your pairing code")
             Spacer(Modifier.height(12.dp))
             Text(deviceName, fontWeight = FontWeight.ExtraBold, style = MaterialTheme.typography.titleMedium)
             Spacer(Modifier.height(4.dp))

--- a/android/app/src/main/java/app/myco/ui/screens/SheetComponents.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SheetComponents.kt
@@ -1,18 +1,26 @@
 package app.myco.ui.screens
 
 import android.graphics.Bitmap
+import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -21,6 +29,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -64,5 +75,33 @@ internal fun QrCodeCard(bitmap: Bitmap, contentDescription: String, size: Dp = 1
         modifier = Modifier.clip(RoundedCornerShape(16.dp)).background(Color.White).padding(14.dp),
     ) {
         Image(bitmap.asImageBitmap(), contentDescription = contentDescription, modifier = Modifier.size(size))
+    }
+}
+
+/** The outlined "paste a code/link from the clipboard" button used under the
+ *  scanners (QR screen, add-app sheet). Empty clipboard shows a toast. */
+@Composable
+internal fun PasteCodeButton(label: String, onPaste: (String) -> Unit) {
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = Color.White,
+        border = BorderStroke(1.dp, Color(0xFFCBD5E1)),
+        modifier = Modifier.fillMaxWidth().height(48.dp).clickable {
+            val text = clipboard.getText()?.text?.trim().orEmpty()
+            if (text.isNotEmpty()) onPaste(text)
+            else Toast.makeText(context, "Clipboard is empty", Toast.LENGTH_SHORT).show()
+        },
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Filled.ContentPaste, contentDescription = null, tint = Color(0xFF334155), modifier = Modifier.size(18.dp))
+            Spacer(Modifier.size(8.dp))
+            Text(label, color = Color(0xFF334155), fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelLarge)
+        }
     }
 }

--- a/android/app/src/main/java/app/myco/ui/screens/SheetComponents.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SheetComponents.kt
@@ -1,0 +1,68 @@
+package app.myco.ui.screens
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared building blocks for the modal bottom-sheet menus (app long-press,
+ * circle-person long-press) and the QR surfaces (pair / share).
+ */
+
+@OptIn(ExperimentalFoundationApi::class)
+internal fun Modifier.combinedClickableSafe(onClick: () -> Unit): Modifier =
+    this.combinedClickable(onClick = onClick)
+
+/** A single tappable row in a [androidx.compose.material3.ModalBottomSheet] menu:
+ *  leading icon + label. Destructive actions pass the error color as [tint]. */
+@Composable
+internal fun SheetAction(
+    icon: ImageVector,
+    label: String,
+    tint: Color = MaterialTheme.colorScheme.primary,
+    onClick: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickableSafe(onClick)
+            .padding(vertical = 12.dp),
+    ) {
+        Icon(icon, contentDescription = null, tint = tint)
+        Spacer(Modifier.size(14.dp))
+        Text(label, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
+}
+
+/** The white, rounded QR "card" shown on the pair and share surfaces — a QR
+ *  bitmap padded on white so it scans well against the soft panel behind it. */
+@Composable
+internal fun QrCodeCard(bitmap: Bitmap, contentDescription: String, size: Dp = 180.dp) {
+    androidx.compose.foundation.layout.Box(
+        modifier = Modifier.clip(RoundedCornerShape(16.dp)).background(Color.White).padding(14.dp),
+    ) {
+        Image(bitmap.asImageBitmap(), contentDescription = contentDescription, modifier = Modifier.size(size))
+    }
+}

--- a/docs/design/identity-pairing.md
+++ b/docs/design/identity-pairing.md
@@ -346,6 +346,19 @@ delivers the `myco://` link to the app via an intent filter, reaching the same
 add-peer code path as a scan. Both phones present-and-poll at once, so a single
 bump can pair symmetrically.
 
+**Sharing an app over NFC, and the reader-mode exception.** The same emulation also
+serves the app-share payload: the share sheet presents a `myco://share/<base64>`
+URI (`{nsite, npub, name, secret}`), so a tap opens the shared app *and* pairs,
+exactly like scanning its QR. This needed one carve-out from the "no reader mode"
+rule above. The share and *Add an app* surfaces are modal bottom sheets, each shown
+in its **own focused window**, where the OS's passive `NDEF_DISCOVERED` dispatch
+(which reaches the Activity fine from the full-screen Circle tab) no longer arrives.
+So while the *Add an app* sheet is open the app claims foreground NFC **reader
+mode** and reads the tapped peer's tag itself. It is scoped strictly to that sheet
+(the Circle bump path is unchanged and still uses passive dispatch), and it forwards
+**only `myco://`-scheme URIs** to the same handler as a scan — an unrelated URL tag
+held to the phone is read but ignored, never opened.
+
 **Where the secret lives.** §6.1 framed the `pairSecret` as echoed back inside the
 Noise-encrypted channel to `<npub_A>.fips`. The implementation keeps that property:
 the scanner/tapper sends a signed pair **request** (kind 9101) to


### PR DESCRIPTION
Reshapes three Android surfaces into bottom sheets and makes NFC work from inside them. Android-only; no `myco-core` / Rust changes, no new dependencies, no manifest/permission changes.

## What changed

- **Circle member menu.** Tapping or long-pressing someone in your Circle now opens an action sheet (avatar header, short npub, "Remove from circle") instead of a bare "Forget?" dialog. Remove is the last, destructive, still-confirmed action, and still uses `NativeActions.removeFromCircle`.
- **Share an app.** The plain share-QR dialog becomes a bottom sheet styled like the pairing "My code" panel — a larger QR, a prominent animated "tap phones together to share" prompt — and it presents the `myco://share` payload over NFC, so a phone tap opens the app and pairs exactly like scanning the QR. The sheet auto-dismisses once the recipient pairs.
- **Add an app.** Replaces the full-screen add view with a bottom sheet: a live camera scanner, a paste-a-link button, and a "tap a friend's phone" NFC option.

## NFC reader-mode carve-out

A `ModalBottomSheet` renders in its own focused window, where the OS's passive `NDEF_DISCOVERED` dispatch (what the full-screen Circle tab relies on) no longer reaches the Activity — so a tap went unnoticed in the Add sheet. The Add sheet now drives a process-global `NfcReader` flag; `MainActivity` claims foreground reader mode while it's set and reads the tapped tag's NDEF URI directly, routing **only `myco://`-scheme URIs** through the same handler as a scan. This is scoped strictly to the Add sheet — the Circle present-and-poll bump path is unchanged and still uses passive dispatch.

## Refactors (in service of the above)

- Factored shared building blocks out of the screens: `SheetAction` / `combinedClickableSafe` / `QrCodeCard` / `PasteCodeButton` (`SheetComponents.kt`) and the animated `NfcPulseBubble` (`NfcVisuals.kt`), reused across Circle / Apps / Pair.
- `ScanPanel` promoted to `internal` for reuse; deleted the old `AddScreen` / `SegmentedToggle` / `UrlPanel` and the `"add"` nav route.

## Docs

- `CHANGELOG.md` `[Unreleased]` updated.
- `docs/design/identity-pairing.md` §7 notes the reader-mode exception (the design previously stated "no reader mode on either side").

## Testing

Built and hands-on tested on device: share → tap → app downloads on the receiver; the share sheet hands off to the normal accept prompt once the pair request lands; in-sheet NFC reads while the Add sheet is open. The Android module has no existing unit tests; these changes are UI/NFC.