### PR TITLE
Settings sub-pages with storage controls, plus Circle Nearby polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `myco://share` code over NFC, so a bump opens the app and pairs with the
   sharer — the same result as scanning its QR. Receiving a tapped share also
   works from the new *Add an app* sheet.
+- A **Storage** settings page with a usage gauge and two deletes: *Delete
+  cache* reclaims space while keeping your pinned apps working offline, and
+  *Delete all data, including apps* wipes the local relay + Blossom entirely.
+  Your identity and Circle survive both.
 
 ### Changed
+
+- Settings is reorganised into focused pages. Everyday controls stay up front
+  (your device-name identity, storage, and the mesh with Bluetooth as a
+  sub-toggle); the mesh-only switch and the raw identity fields (npub /
+  node_addr / .fips / mesh ULA) move behind a developer-only page.
+- The Circle *Nearby* list is always shown — with a hint when no one's around —
+  and is sorted by name, so bubbles no longer reshuffle as Bluetooth signal
+  strength fluctuates.
 
 - The "Share this app" surface is now a bottom sheet styled like the pairing
   QR — a larger code and a prominent "tap phones together" prompt — and it
@@ -27,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dialog; removal stays the last, destructive, confirmed action.
 
 ### Fixed
+
+- The main app no longer flips to landscape on a slight tilt — it's locked to
+  portrait, matching the QR scanner.
 
 ## [0.0.3] - 2026-06-29
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.Myco.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -396,6 +396,8 @@ object NativeActions {
         JSONObject().put("type", "forget_nsite").put("link", link)
     fun checkNsiteUpdates(): JSONObject = JSONObject().put("type", "check_nsite_updates")
     fun wipeStores(): JSONObject = JSONObject().put("type", "wipe_stores")
+    /** Clear cached relay/Blossom data but keep pinned nsites (Storage → "Delete cache"). */
+    fun wipeCache(): JSONObject = JSONObject().put("type", "wipe_cache")
 
     // --- circle (paired peers) ---
     /** Add a paired peer (from a scanned share QR) to the Circle. */

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -131,9 +131,11 @@ fun CircleScreen(
 
     val connected = state.blePeers.filter { it.connected }.map { it.npub }.toSet()
     val circleNpubs = remember(state.circle) { state.circle.map { it.npub }.toSet() }
+    // Sorted by display name (stable per npub) rather than the radio's signal-
+    // strength/discovery order, so bubbles don't reshuffle as RSSI fluctuates.
     val nearby = state.blePeers.filter {
         it.connected && it.npub.isNotEmpty() && it.npub != state.ownNpub && it.npub !in circleNpubs
-    }
+    }.sortedWith(compareBy({ DeviceName.generated(it.npub).lowercase() }, { it.npub }))
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
@@ -161,8 +163,22 @@ fun CircleScreen(
                 item { TapToConnect(nfc = nfc, onEnableNfc = { NfcStatus.openSettings(context) }) }
             }
 
-            if (nearby.isNotEmpty()) {
-                item { SectionLabel("NEARBY", trailing = "· tap to add", scanning = state.bleScanning) }
+            item {
+                SectionLabel(
+                    "NEARBY",
+                    trailing = if (nearby.isNotEmpty()) "· tap to add" else null,
+                    scanning = state.bleScanning,
+                )
+            }
+            if (nearby.isEmpty()) {
+                item {
+                    Text(
+                        "Nobody nearby yet. Keep this screen open near another phone.",
+                        color = Slate,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            } else {
                 item {
                     FlowRow(
                         modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package app.myco.ui.screens
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -17,18 +18,25 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.DeveloperMode
-import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Lan
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -40,20 +48,30 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import app.myco.core.AppCoreClient
 import app.myco.core.AppState
 import app.myco.core.NativeActions
+import app.myco.share.DeviceName
 import app.myco.ui.GroupLabel
 import app.myco.ui.ScreenHeader
 import app.myco.ui.SectionCard
 import app.myco.ui.theme.Slate
 
+/** The Settings surfaces: the root list and its three drill-in sub-pages. */
+private enum class SettingsPage { Root, Identity, Storage, Developer }
+
+/** Cap used for the storage gauge (matches the LRU target in the core). */
+private const val STORAGE_CAP_BYTES = 2_000_000_000.0
+
 /**
- * **Settings** — grouped Device (identity, storage) and Mesh (Bluetooth mesh,
- * system-wide VPN access) controls, plus a destructive "Clear all content".
+ * **Settings** — a root list of categories (Identity, Storage, the Mesh + its
+ * transports, and Advanced) that drill into focused sub-pages. Developer-only
+ * controls (mesh-only, raw identity) live behind the Advanced → Developer settings
+ * page, shown only when developer mode is on.
  */
 @Composable
 fun SettingsScreen(
@@ -67,81 +85,113 @@ fun SettingsScreen(
     onDeveloperModeToggle: (Boolean) -> Unit,
     bleExhausted: Boolean = false,
 ) {
-    var showIdentity by remember { mutableStateOf(false) }
-    var confirmWipe by remember { mutableStateOf(false) }
+    var page by remember { mutableStateOf(SettingsPage.Root) }
 
-    val capBytes = 2_000_000_000.0
+    // Sub-pages are local state, not NavHost destinations, so the system back
+    // gesture would pop straight to the Apps start destination. Intercept it while
+    // drilled in so back returns to the Settings root first.
+    BackHandler(enabled = page != SettingsPage.Root) { page = SettingsPage.Root }
+
+    when (page) {
+        SettingsPage.Root -> RootSettings(
+            state = state,
+            onBleToggle = onBleToggle,
+            meshEnabled = meshEnabled,
+            onMeshToggle = onMeshToggle,
+            developerMode = developerMode,
+            onDeveloperModeToggle = onDeveloperModeToggle,
+            bleExhausted = bleExhausted,
+            onOpenIdentity = { page = SettingsPage.Identity },
+            onOpenStorage = { page = SettingsPage.Storage },
+            onOpenDeveloper = { page = SettingsPage.Developer },
+        )
+        SettingsPage.Identity -> IdentitySettings(state, client, onBack = { page = SettingsPage.Root })
+        SettingsPage.Storage -> StorageSettings(state, client, onBack = { page = SettingsPage.Root })
+        SettingsPage.Developer -> DeveloperSettings(
+            state = state,
+            onOfflineOnlyToggle = onOfflineOnlyToggle,
+            onBack = { page = SettingsPage.Root },
+        )
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Root
+// ----------------------------------------------------------------------------
+
+@Composable
+private fun RootSettings(
+    state: AppState,
+    onBleToggle: (Boolean) -> Unit,
+    meshEnabled: Boolean,
+    onMeshToggle: (Boolean) -> Unit,
+    developerMode: Boolean,
+    onDeveloperModeToggle: (Boolean) -> Unit,
+    bleExhausted: Boolean,
+    onOpenIdentity: () -> Unit,
+    onOpenStorage: () -> Unit,
+    onOpenDeveloper: () -> Unit,
+) {
+    val context = LocalContext.current
+    val deviceName = DeviceName.current(context, state.ownNpub)
     val used = state.cache.usedBytes.toDouble()
+    val pct = (used / STORAGE_CAP_BYTES * 100).coerceIn(0.0, 100.0)
+    val free = (STORAGE_CAP_BYTES - used).coerceAtLeast(0.0).toLong()
 
-    Column(
-        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
+    SettingsColumn {
         ScreenHeader("Settings", state)
         Spacer(Modifier.height(8.dp))
 
         GroupLabel("DEVICE")
         SectionCard {
             SettingRow(
-                icon = Icons.Filled.Key,
-                title = "Device identity",
-                subtitle = shortNpub(state.ownNpub),
-                onClick = { showIdentity = true },
+                icon = Icons.Filled.Person,
+                title = "Identity",
+                subtitle = deviceName,
+                onClick = onOpenIdentity,
             )
             RowDivider()
-            StorageRow(usedBytes = state.cache.usedBytes, fraction = (used / capBytes).coerceIn(0.0, 1.0).toFloat(),
-                blobs = state.cache.blobCount, events = state.cache.relayEvents)
+            SettingRow(
+                icon = Icons.Filled.Storage,
+                title = "Storage",
+                subtitle = "${"%.0f".format(pct)}% used · ${humanBytes(free)} free",
+                onClick = onOpenStorage,
+            )
         }
 
         Spacer(Modifier.height(8.dp))
-        GroupLabel("NETWORK")
+        GroupLabel("MESH")
         SectionCard {
-            // The master mesh switch (an app-owned VPN/TUN under the hood). Required
-            // for this device to reach the mesh, so it's just "Mesh" and on by default.
+            // The master switch (an app-owned VPN/TUN under the hood). Required for
+            // this device to reach the mesh; its transports below ride on top of it,
+            // so they grey out when the mesh is off.
             ToggleRow(
                 icon = Icons.Filled.Lan,
-                title = "Mesh",
+                title = "Enable",
                 subtitle = "Connect this device to the mesh",
                 checked = meshEnabled,
                 onToggle = onMeshToggle,
             )
-        }
-
-        Spacer(Modifier.height(8.dp))
-        GroupLabel("TRANSPORTS")
-        SectionCard {
+            RowDivider()
             ToggleRow(
                 icon = Icons.Filled.Bluetooth,
                 title = "Bluetooth",
                 subtitle = "Find & link nearby peers offline",
                 checked = state.bleEnabled,
                 onToggle = onBleToggle,
+                enabled = meshEnabled,
             )
             RowDivider()
-            ToggleRow(
-                icon = Icons.Filled.CloudOff,
-                title = "Mesh-only",
-                subtitle = "Never use the internet relay/Blossom fallback — pull only over the mesh",
-                checked = state.offlineOnly,
-                onToggle = onOfflineOnlyToggle,
+            SoonRow(
+                icon = Icons.Filled.Public,
+                title = "Internet",
+                subtitle = "Mesh over the internet",
             )
         }
 
         if (bleExhausted) {
             Spacer(Modifier.height(8.dp))
             BleExhaustedCard()
-        }
-
-        Spacer(Modifier.height(8.dp))
-        GroupLabel("DATA")
-        SectionCard {
-            SettingRow(
-                icon = null,
-                title = "Clear all content",
-                subtitle = "Wipe local relay + Blossom (keeps identity & Circle)",
-                titleColor = MaterialTheme.colorScheme.error,
-                onClick = { confirmWipe = true },
-            )
         }
 
         Spacer(Modifier.height(8.dp))
@@ -154,6 +204,15 @@ fun SettingsScreen(
                 checked = developerMode,
                 onToggle = onDeveloperModeToggle,
             )
+            if (developerMode) {
+                RowDivider()
+                SettingRow(
+                    icon = Icons.Filled.Code,
+                    title = "Developer settings",
+                    subtitle = "Mesh-only mode, raw identity",
+                    onClick = onOpenDeveloper,
+                )
+            }
         }
 
         if (state.error.isNotEmpty()) {
@@ -167,38 +226,227 @@ fun SettingsScreen(
             modifier = Modifier.padding(top = 8.dp, start = 4.dp),
         )
     }
+}
 
-    if (showIdentity) {
-        AlertDialog(
-            onDismissRequest = { showIdentity = false },
-            confirmButton = { TextButton(onClick = { showIdentity = false }) { Text("Close") } },
-            title = { Text("Device identity") },
-            text = {
-                SelectionContainer {
-                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                        IdField("npub", state.ownNpub)
-                        IdField("node_addr", state.nodeAddrHex)
-                        IdField(".fips", state.fipsAddr)
-                        IdField("mesh ULA", state.fipsIpv6)
-                    }
+// ----------------------------------------------------------------------------
+// Identity sub-page — the memorable name shown to peers when pairing.
+// ----------------------------------------------------------------------------
+
+@Composable
+private fun IdentitySettings(state: AppState, client: AppCoreClient, onBack: () -> Unit) {
+    val context = LocalContext.current
+    var name by remember { mutableStateOf(DeviceName.current(context, state.ownNpub)) }
+    val saved = DeviceName.current(context, state.ownNpub)
+
+    SettingsColumn {
+        SubHeader("Identity", onBack)
+        Spacer(Modifier.height(4.dp))
+
+        GroupLabel("DEVICE NAME")
+        SectionCard {
+            Column(modifier = Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text(
+                    "Nearby devices see this name when you pair, so they can confirm " +
+                        "they're connecting to the right device.",
+                    color = Slate,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it.take(40) },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    TextButton(
+                        onClick = {
+                            // Empty resets to the npub-derived default.
+                            DeviceName.set(context, "")
+                            name = DeviceName.generated(state.ownNpub)
+                            client.dispatch(NativeActions.setDeviceName(name))
+                        },
+                    ) { Text("Reset") }
+                    Spacer(Modifier.weight(1f))
+                    TextButton(
+                        enabled = name.isNotBlank() && name.trim() != saved,
+                        onClick = {
+                            val trimmed = name.trim()
+                            DeviceName.set(context, trimmed)
+                            client.dispatch(NativeActions.setDeviceName(trimmed))
+                            onBack()
+                        },
+                    ) { Text("Save") }
                 }
-            },
-        )
+            }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Storage sub-page — usage + the two destructive deletes.
+// ----------------------------------------------------------------------------
+
+@Composable
+private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -> Unit) {
+    var confirmCache by remember { mutableStateOf(false) }
+    var confirmAll by remember { mutableStateOf(false) }
+
+    val used = state.cache.usedBytes
+    val fraction = (used.toDouble() / STORAGE_CAP_BYTES).coerceIn(0.0, 1.0).toFloat()
+    val free = (STORAGE_CAP_BYTES - used).coerceAtLeast(0.0).toLong()
+
+    SettingsColumn {
+        SubHeader("Storage", onBack)
+        Spacer(Modifier.height(4.dp))
+
+        GroupLabel("USAGE")
+        SectionCard {
+            Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp)) {
+                Text(
+                    "${"%.0f".format(fraction * 100)}% used",
+                    fontWeight = FontWeight.SemiBold,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Spacer(Modifier.height(8.dp))
+                LinearProgressIndicator(
+                    progress = { fraction },
+                    modifier = Modifier.fillMaxWidth().height(8.dp),
+                    trackColor = MaterialTheme.colorScheme.outline,
+                )
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    "${humanBytes(used)} of 2 GB · ${humanBytes(free)} free · " +
+                        "${state.cache.blobCount} blobs · ${state.cache.relayEvents} events",
+                    color = Slate,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+
+        Spacer(Modifier.height(8.dp))
+        GroupLabel("DELETE")
+        SectionCard {
+            SettingRow(
+                icon = null,
+                title = "Delete cache",
+                subtitle = "Free up space — keeps your pinned apps, clears everything else",
+                titleColor = MaterialTheme.colorScheme.error,
+                onClick = { confirmCache = true },
+            )
+            RowDivider()
+            SettingRow(
+                icon = null,
+                title = "Delete all data, including apps",
+                subtitle = "Wipe entirely (keeps identity & Circle)",
+                titleColor = MaterialTheme.colorScheme.error,
+                onClick = { confirmAll = true },
+            )
+        }
     }
 
-    if (confirmWipe) {
-        AlertDialog(
-            onDismissRequest = { confirmWipe = false },
-            confirmButton = {
-                TextButton(onClick = { client.dispatch(NativeActions.wipeStores()); confirmWipe = false }) {
-                    Text("Clear", color = MaterialTheme.colorScheme.error)
-                }
-            },
-            dismissButton = { TextButton(onClick = { confirmWipe = false }) { Text("Cancel") } },
-            title = { Text("Clear all content?") },
-            text = { Text("Removes every downloaded nsite (relay events + blobs). Your identity and Circle stay.") },
+    if (confirmCache) {
+        ConfirmDialog(
+            title = "Delete cache?",
+            body = "Clears all downloaded relay events and blobs except your pinned apps, " +
+                "which keep working offline.",
+            confirmLabel = "Delete cache",
+            onConfirm = { client.dispatch(NativeActions.wipeCache()); confirmCache = false },
+            onDismiss = { confirmCache = false },
         )
     }
+    if (confirmAll) {
+        ConfirmDialog(
+            title = "Delete all data?",
+            body = "Removes every downloaded nsite, including pinned apps (relay events + blobs). " +
+                "Your identity and Circle stay.",
+            confirmLabel = "Delete all",
+            onConfirm = { client.dispatch(NativeActions.wipeStores()); confirmAll = false },
+            onDismiss = { confirmAll = false },
+        )
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Developer sub-page — mesh-only + raw identity (gated by developer mode).
+// ----------------------------------------------------------------------------
+
+@Composable
+private fun DeveloperSettings(state: AppState, onOfflineOnlyToggle: (Boolean) -> Unit, onBack: () -> Unit) {
+    SettingsColumn {
+        SubHeader("Developer settings", onBack)
+        Spacer(Modifier.height(4.dp))
+
+        GroupLabel("NETWORK")
+        SectionCard {
+            ToggleRow(
+                icon = Icons.Filled.CloudOff,
+                title = "Mesh-only",
+                subtitle = "Never use the internet relay/Blossom fallback — pull only over the mesh",
+                checked = state.offlineOnly,
+                onToggle = onOfflineOnlyToggle,
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+        GroupLabel("IDENTITY")
+        SectionCard {
+            SelectionContainer {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    IdField("npub", state.ownNpub)
+                    IdField("node_addr", state.nodeAddrHex)
+                    IdField(".fips", state.fipsAddr)
+                    IdField("mesh ULA", state.fipsIpv6)
+                }
+            }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Shared building blocks
+// ----------------------------------------------------------------------------
+
+@Composable
+private fun SettingsColumn(content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) { content() }
+}
+
+/** A sub-page header: a back arrow + the page title. */
+@Composable
+private fun SubHeader(title: String, onBack: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        IconButton(onClick = onBack) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+        }
+        Spacer(Modifier.size(4.dp))
+        Text(title, style = MaterialTheme.typography.headlineSmall)
+    }
+}
+
+@Composable
+private fun ConfirmDialog(
+    title: String,
+    body: String,
+    confirmLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text(confirmLabel, color = MaterialTheme.colorScheme.error) }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text(title) },
+        text = { Text(body) },
+    )
 }
 
 /** Warning shown when the OS denied our BLE advertiser (TOO_MANY_ADVERTISERS):
@@ -273,49 +521,57 @@ private fun ToggleRow(
     subtitle: String,
     checked: Boolean,
     onToggle: (Boolean) -> Unit,
+    enabled: Boolean = true,
 ) {
+    val contentColor = if (enabled) MaterialTheme.colorScheme.onSurface else Slate
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        LeadingIcon(icon)
+        LeadingIcon(icon, tint = contentColor)
         Spacer(Modifier.size(14.dp))
         Column(modifier = Modifier.weight(1f)) {
-            Text(title, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.titleMedium)
+            Text(title, color = contentColor, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.titleMedium)
             Text(subtitle, color = Slate, style = MaterialTheme.typography.bodySmall)
         }
-        Switch(checked = checked, onCheckedChange = onToggle)
+        Switch(checked = checked, onCheckedChange = onToggle, enabled = enabled)
+    }
+}
+
+/** A disabled row standing in for a not-yet-shipped option, tagged "SOON". */
+@Composable
+private fun SoonRow(icon: ImageVector, title: String, subtitle: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LeadingIcon(icon, tint = Slate)
+        Spacer(Modifier.size(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, color = Slate, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.titleMedium)
+            Text(subtitle, color = Slate, style = MaterialTheme.typography.bodySmall)
+        }
+        Surface(shape = RoundedCornerShape(8.dp), color = MaterialTheme.colorScheme.surface) {
+            Text(
+                "SOON",
+                color = Slate,
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
     }
 }
 
 @Composable
-private fun StorageRow(usedBytes: Long, fraction: Float, blobs: Long, events: Long) {
-    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp)) {
-        Text("Storage", fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.titleMedium)
-        Spacer(Modifier.height(8.dp))
-        LinearProgressIndicator(
-            progress = { fraction },
-            modifier = Modifier.fillMaxWidth().height(8.dp),
-            trackColor = MaterialTheme.colorScheme.outline,
-        )
-        Spacer(Modifier.height(6.dp))
-        Text(
-            "${humanBytes(usedBytes)} of 2 GB used · $blobs blobs · $events events",
-            color = Slate,
-            style = MaterialTheme.typography.bodySmall,
-        )
-    }
-}
-
-@Composable
-private fun LeadingIcon(icon: ImageVector) {
+private fun LeadingIcon(icon: ImageVector, tint: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface) {
     Box(
         modifier = Modifier
             .size(38.dp)
             .background(MaterialTheme.colorScheme.background, androidx.compose.foundation.shape.CircleShape),
         contentAlignment = Alignment.Center,
     ) {
-        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.onSurface)
+        Icon(icon, contentDescription = null, tint = tint)
     }
 }
 
@@ -341,6 +597,3 @@ private fun humanBytes(b: Long): String = when {
     b >= 1_000 -> "%.0f KB".format(b / 1_000.0)
     else -> "$b B"
 }
-
-private fun shortNpub(npub: String): String =
-    if (npub.length > 16) "${npub.take(12)}…${npub.takeLast(4)}" else npub

--- a/docs/design/app-shell.md
+++ b/docs/design/app-shell.md
@@ -195,7 +195,31 @@ serves.** Neither owns the other's concern.
 
 ---
 
-## 8. Open questions
+## 8. Storage: clearing the cache vs. wiping everything
+
+**Settings → Storage** shows local usage (against the ~2 GB cache target) and
+offers two destructive actions, neither of which touches the device identity or
+the Circle:
+
+- **Delete cache** (`wipe_cache`) — reclaim space *without* breaking installed
+  apps. It keeps every **pinned** Library entry working offline by computing a
+  keep-set from the pinned sites — each one's *served* manifest event plus the
+  blob hashes that manifest references — and retaining only those, then dropping
+  everything else: unpinned opened sites, discovered listings, and staged
+  updates. A pinned site whose manifest isn't local stays pinned and simply
+  re-downloads on next open.
+- **Delete all data, including apps** (`wipe_stores`) — clear the local relay +
+  Blossom + Library + status wholesale, pinned apps included.
+
+The keep-set is derived through the same **active-manifest** pointer the gateway
+serves from (see [nsite-updates.md §1](./nsite-updates.md)), so a cache wipe
+preserves exactly the version currently served, not whatever newest manifest the
+relay happens to hold. A general size-based eviction pass (P5) is still open;
+until then these two explicit actions are the only reclamation path.
+
+---
+
+## 9. Open questions
 
 - **Impersonation without chrome (§3).** No trusted, always-visible signal of
   which verified author npub a fullscreen nsite belongs to; `TaskDescription`

--- a/myco-blossom/src/lib.rs
+++ b/myco-blossom/src/lib.rs
@@ -47,6 +47,23 @@ impl FsBlobStore {
             .unwrap_or(0)
     }
 
+    /// Delete every blob whose hash is **not** in `keep`. Used by the selective
+    /// cache wipe to retain the blobs backing pinned nsites while clearing the rest.
+    /// `keep` holds lowercase-hex sha256 names (the manifest's `path -> hash` values).
+    pub fn retain_blobs(&self, keep: &std::collections::HashSet<String>) {
+        if let Ok(rd) = std::fs::read_dir(&self.root) {
+            for entry in rd.filter_map(Result::ok).filter(is_blob_name) {
+                let kept = entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| keep.contains(name));
+                if !kept {
+                    let _ = std::fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
+
     /// Total bytes on disk (for the LRU cap accounting; eviction itself is P5).
     pub fn total_bytes(&self) -> u64 {
         std::fs::read_dir(&self.root)

--- a/myco-core/src/action.rs
+++ b/myco-core/src/action.rs
@@ -60,6 +60,10 @@ pub enum NativeAppAction {
     /// Clear the local relay + Blossom + Library + site status (dev/test reset).
     /// Content only — the device identity (and the Circle) are untouched.
     WipeStores,
+    /// Clear cached relay events + Blossom blobs **except** those backing pinned
+    /// nsites (Settings → Storage → "Delete cache"). Pinned apps keep working
+    /// offline; unpinned opened sites, discovered listings and staged updates go.
+    WipeCache,
 
     // --- circle (paired peers) ---
     /// Add a paired peer to the **Circle**: the contact list of devices we pull

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -1624,6 +1624,72 @@ impl Content {
         Ok(())
     }
 
+    /// Clear cached relay events + Blossom blobs **except** those backing pinned
+    /// nsites (Settings → Storage → "Delete cache"). The served manifest version of
+    /// each pinned site and every blob it references survive, so installed apps keep
+    /// working offline; everything else — unpinned opened sites, discovered
+    /// listings, staged updates — is dropped. Identity and Circle are untouched.
+    pub async fn wipe_cache(&self) -> anyhow::Result<()> {
+        // Pinned Library entries are the apps we must keep working.
+        let pinned: Vec<LibraryItem> = self
+            .library
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|i| i.pinned)
+            .cloned()
+            .collect();
+
+        // Build the keep-sets: the served manifest event id of each pinned site,
+        // plus every blob hash that manifest references.
+        let mut keep_events: HashSet<[u8; 32]> = HashSet::new();
+        let mut keep_blobs: HashSet<String> = HashSet::new();
+        let mut keep_active: HashSet<String> = HashSet::new();
+        let backend = self.active_backend();
+        for item in &pinned {
+            let Some(addr) = library_addr(item) else {
+                continue;
+            };
+            let kind = nsite_deck::kind_for(addr.d_tag.as_deref());
+            if let Ok(Some(ev)) = backend
+                .get_manifest(kind, &addr.author, addr.d_tag.as_deref())
+                .await
+            {
+                keep_events.insert(ev.id.to_bytes());
+                if let Ok(m) = nsite_deck::Manifest::from_event(ev) {
+                    keep_blobs.extend(m.paths.into_values());
+                }
+                keep_active.insert(manifest_key(kind, &addr.author, addr.d_tag.as_deref()));
+            }
+        }
+
+        self.relay.retain_events(&keep_events);
+        self.blobs.retain_blobs(&keep_blobs);
+
+        // Drop unpinned Library entries and the live status of anything unpinned.
+        let pinned_hosts: HashSet<String> = pinned.iter().map(|i| i.url_host.clone()).collect();
+        {
+            let mut lib = self.library.lock().unwrap();
+            lib.retain(|i| i.pinned);
+            let snapshot = lib.clone();
+            drop(lib);
+            save_library(&self.library_path, &snapshot);
+        }
+        self.sites
+            .lock()
+            .unwrap()
+            .retain(|host, _| pinned_hosts.contains(host));
+        self.discovered.lock().unwrap().clear();
+        self.pending_updates.lock().unwrap().clear();
+        let active_snapshot = {
+            let mut m = self.active_manifests.lock().unwrap();
+            m.retain(|k, _| keep_active.contains(k));
+            m.values().cloned().collect::<Vec<_>>()
+        };
+        save_active(&self.active_path, &active_snapshot);
+        Ok(())
+    }
+
     // --- snapshots for state() ---
 
     pub fn sites_snapshot(&self) -> Vec<SiteStatusView> {
@@ -1985,6 +2051,46 @@ mod tests {
         assert_eq!(content.cache_view().blob_count, 0);
         let after = content.gateway_get(&host, "/", None).await;
         assert_eq!(after.status, 503, "wiped site must not serve content");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn wipe_cache_keeps_pinned_drops_the_rest() {
+        let dir = tmp("wipe-cache");
+        let _ = std::fs::remove_dir_all(&dir);
+        let content = Arc::new(Content::open(&dir).unwrap());
+
+        // Two distinct sites; both land in the Library as pinned on import.
+        let keep = build_test_site(&[("/index.html", b"<h1>keep</h1>")], None, Some("Keep"));
+        let drop = build_test_site(&[("/index.html", b"<h1>drop</h1>")], None, Some("Drop"));
+        let keep_host = format!("{}.nsite", keep.author.to_bech32().unwrap());
+        let drop_host = format!("{}.nsite", drop.author.to_bech32().unwrap());
+
+        for (tag, site) in [("keep", &keep), ("drop", &drop)] {
+            let bundle = dir.join(tag);
+            write_bundle(&bundle, site);
+            assert_eq!(
+                content.import_dir(&bundle).await.unwrap(),
+                SyncOutcome::Ready
+            );
+        }
+        assert_eq!(content.cache_view().relay_events, 2);
+        assert_eq!(content.cache_view().blob_count, 2);
+
+        // Unpin the second site (no longer a kept app), then drop the cache.
+        content.remove_from_library(&SiteAddr {
+            author: drop.author,
+            d_tag: None,
+        });
+        content.wipe_cache().await.unwrap();
+
+        // The pinned site still serves from local stores; the unpinned one is gone.
+        assert_eq!(content.cache_view().relay_events, 1);
+        assert_eq!(content.cache_view().blob_count, 1);
+        assert_eq!(content.gateway_get(&keep_host, "/", None).await.status, 200);
+        assert_eq!(content.gateway_get(&drop_host, "/", None).await.status, 503);
+        assert_eq!(content.library_snapshot().len(), 1);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -333,6 +333,10 @@ impl AppRuntime {
                 self.wipe_stores();
                 self.rev += 1;
             }
+            NativeAppAction::WipeCache => {
+                self.wipe_cache();
+                self.rev += 1;
+            }
             NativeAppAction::AddToCircle { npub, name } => {
                 if let Some(content) = &self.content {
                     content.add_to_circle(&npub, &name);
@@ -418,6 +422,18 @@ impl AppRuntime {
         };
         if let Err(e) = rt.block_on(content.wipe()) {
             self.error = format!("wipe failed: {e}");
+        }
+    }
+
+    /// Clear cached content but preserve pinned nsites (the "delete cache" half of
+    /// Settings → Storage). Blocks like `wipe_stores` so the next `state()` reflects
+    /// the reclaimed space immediately.
+    fn wipe_cache(&mut self) {
+        let (Some(content), Some(rt)) = (self.content.clone(), self.rt.as_ref()) else {
+            return;
+        };
+        if let Err(e) = rt.block_on(content.wipe_cache()) {
+            self.error = format!("cache wipe failed: {e}");
         }
     }
 

--- a/myco-relay/src/lib.rs
+++ b/myco-relay/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! [`RelayBackend`]: nsite_deck::seams::RelayBackend
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -83,6 +83,21 @@ impl RelayStore {
             .values()
             .filter(|e| !is_expired(e, now))
             .count()
+    }
+
+    /// Drop every stored event whose id is **not** in `keep`, then re-persist the
+    /// surviving manifest set. Used by the selective cache wipe to retain the events
+    /// backing pinned nsites while clearing everything else (chat included).
+    pub fn retain_events(&self, keep: &HashSet<[u8; 32]>) {
+        let snapshot = {
+            let mut map = self.events.lock().unwrap();
+            map.retain(|id, _| keep.contains(id));
+            map.values()
+                .filter(|e| expiration(e).is_none())
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        self.persist(&snapshot);
     }
 
     /// Persist the current **persistable** (non-expiring) event set — a full


### PR DESCRIPTION
Reorganises the Android Settings panel into focused drill-in pages, adds a native selective cache wipe so Storage can offer two distinct deletes, and tidies the Circle *Nearby* list. Four small UX changes plus the one reducer action the storage UI needs — landed as one batch.

## What's here

**Settings → drill-in sub-pages** (`SettingsScreen.kt`)
- A root list of categories that open focused, back-aware (`BackHandler`) sub-pages.
- **Identity**: show & edit the memorable device name used in pairing.
- **Storage**: a usage gauge (`NN% used · X free`) and two deletes (below).
- **Developer settings** (only when developer mode is on): the mesh-only toggle and the raw identity fields (npub / node_addr / .fips / mesh ULA), no longer exposed to everyday users.
- **Mesh + transports merged**: an *Enable mesh* master with Bluetooth as a sub-toggle that greys out when mesh is off, and an inert *Internet (SOON)* placeholder.

**Native selective cache wipe** (`myco-core`, `myco-relay`, `myco-blossom`)
- New `WipeCache` reducer action. `Content::wipe_cache` builds a keep-set from pinned Library entries — each pinned site's *served* manifest event plus the blob hashes it references — and retains only those, dropping unpinned opened sites, discovered listings, and staged updates. Identity and Circle untouched.
- `RelayStore::retain_events` / `FsBlobStore::retain_blobs` are the selective deletes it drives, alongside the existing wholesale `wipe`.
- Tested: a pinned site keeps serving (200) while an unpinned one is purged (503) after a cache wipe.

**Circle Nearby** (`CircleScreen.kt`)
- The NEARBY section is always shown (empty hint when no one's around), mirroring IN YOUR CIRCLE.
- Nearby peers are sorted by display name (stable per npub) instead of the radio's signal-strength order, so bubbles stop reshuffling as RSSI fluctuates.

**Portrait lock** (`AndroidManifest.xml`)
- The main activity is locked to portrait, matching the QR scanner; it no longer flips on a slight tilt.

## Docs
CHANGELOG entries under *Unreleased*, and a Storage section in [docs/design/app-shell.md](docs/design/app-shell.md) spelling out delete-cache (the pinned keep-set, via the served active manifest) vs. delete-all.

## One thing to confirm
Switching *Enable mesh* off greys the Bluetooth toggle but doesn't stop the BLE transport — it only blocks the control while `state.bleEnabled` keeps its value. If "mesh off ⇒ transports actually off" is wanted, that's a follow-up in `onMeshToggle`; the current behaviour is "you can't toggle transports while mesh is off."

## Verification
- `cargo fmt --all --check` clean; `cargo test -p myco-core -p myco-relay -p myco-blossom` green (incl. the new `wipe_cache` test).
- `./gradlew :app:compileDebugKotlin` succeeds. Full APK assembly (cargo→jniLibs) not run locally.

Rebased onto current `main`; no wire-format or pairing-protocol changes.