### PR TITLE
Add a peer speedtest to the Dev menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cache* reclaims space while keeping your pinned apps working offline, and
   *Delete all data, including apps* wipes the local relay + Blossom entirely.
   Your identity and Circle survive both.
+- A peer **speedtest** in the Dev diagnostics tab: round-trips a small payload
+  through a connected, paired peer's mesh Blossom and reports up/down
+  throughput, so you can sanity-check a BLE link's speed.
 
 ### Changed
 

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -106,6 +106,7 @@ data class AppState(
     val pendingPairRequests: List<PairRequest>,
     val offlineOnly: Boolean,
     val updateCheck: UpdateCheck = UpdateCheck(),
+    val speedtest: SpeedtestStatus = SpeedtestStatus(),
 ) {
     companion object {
         fun parse(json: String): AppState {
@@ -259,6 +260,17 @@ data class AppState(
                 discovered = discovered,
                 pendingPairRequests = pendingPairRequests,
                 offlineOnly = o.optBoolean("offlineOnly"),
+                speedtest = o.optJSONObject("speedtest")?.let { s ->
+                    SpeedtestStatus(
+                        running = s.optBoolean("running"),
+                        peerNpub = s.optString("peerNpub"),
+                        bytes = s.optLong("bytes"),
+                        upMbps = s.optDouble("upMbps", 0.0),
+                        downMbps = s.optDouble("downMbps", 0.0),
+                        error = s.optString("error"),
+                        generation = s.optLong("generation"),
+                    )
+                } ?: SpeedtestStatus(),
                 updateCheck = o.optJSONObject("updateCheck")?.let { u ->
                     UpdateCheck(
                         checking = u.optBoolean("checking"),
@@ -270,6 +282,17 @@ data class AppState(
         }
     }
 }
+
+/** Result of the dev-menu peer speedtest (a Blossom upload+download round-trip). */
+data class SpeedtestStatus(
+    val running: Boolean = false,
+    val peerNpub: String = "",
+    val bytes: Long = 0,
+    val upMbps: Double = 0.0,
+    val downMbps: Double = 0.0,
+    val error: String = "",
+    val generation: Long = 0,
+)
 
 /** Feedback for the "Check for updates" action: in-progress + last result. */
 data class UpdateCheck(
@@ -428,4 +451,8 @@ object NativeActions {
      *  see the chosen name. The app owns the value and re-applies it on launch. */
     fun setDeviceName(name: String): JSONObject =
         JSONObject().put("type", "set_device_name").put("name", name)
+
+    /** Dev-menu speedtest: round-trip a payload through `npub`'s mesh Blossom. */
+    fun speedtestPeer(npub: String): JSONObject =
+        JSONObject().put("type", "speedtest_peer").put("npub", npub)
 }

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -214,7 +214,7 @@ fun MycoApp(
                         bleExhausted = bleExhausted,
                     )
                 }
-                composable("dev") { DevScreen(state) }
+                composable("dev") { DevScreen(state, client) }
                 composable("qr") {
                     QrScreen(
                         state = state,

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -13,14 +13,18 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import app.myco.core.AppCoreClient
 import app.myco.core.AppState
 import app.myco.core.BleAdvert
 import app.myco.core.BlePeer
+import app.myco.core.NativeActions
+import app.myco.share.DeviceName
 import app.myco.ui.KeyVal
 import app.myco.ui.ScreenHeader
 import app.myco.ui.SectionCard
@@ -35,12 +39,14 @@ import kotlin.math.pow
  * the BLE radio, connected peers, scan adverts, and cache counts. Read-only.
  */
 @Composable
-fun DevScreen(state: AppState) {
+fun DevScreen(state: AppState, client: AppCoreClient) {
     Column(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
         ScreenHeader("Dev", state, subtitle = "Technical details — myco-core state.")
+
+        SpeedtestCard(state, client)
 
         SelectionContainer {
             Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
@@ -78,6 +84,61 @@ fun DevScreen(state: AppState) {
             }
         }
         Spacer(Modifier.height(8.dp))
+    }
+}
+
+/**
+ * A peer throughput test: pick a connected, handshaken peer and round-trip a
+ * ~1 MiB payload through its mesh Blossom (PUT then GET), showing up/down Mbps.
+ * Only works against a paired peer (their Blossom gates non-loopback by Circle).
+ */
+@Composable
+private fun SpeedtestCard(state: AppState, client: AppCoreClient) {
+    val peers = state.blePeers.filter { it.connected && it.npub.isNotEmpty() }
+    val st = state.speedtest
+    DevCard("SPEEDTEST") {
+        if (peers.isEmpty()) {
+            EmptyLine("no connected peer to test")
+        } else {
+            peers.forEach { peer ->
+                val name = DeviceName.generated(peer.npub)
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+                ) {
+                    Text(name, color = MaterialTheme.colorScheme.onSurface, style = MaterialTheme.typography.bodyMedium)
+                    // "Retry" once a finished run for this peer failed; "Run" otherwise.
+                    val lastForPeer = st.peerNpub == peer.npub && st.generation > 0L
+                    val label = when {
+                        st.running && st.peerNpub == peer.npub -> "running…"
+                        lastForPeer && st.error.isNotEmpty() -> "Retry"
+                        else -> "Run"
+                    }
+                    TextButton(
+                        enabled = !st.running,
+                        onClick = { client.dispatch(NativeActions.speedtestPeer(peer.npub)) },
+                    ) { Text(label) }
+                }
+            }
+        }
+
+        val resultLine = when {
+            st.running -> "Testing ${DeviceName.generated(st.peerNpub)}…"
+            st.generation == 0L -> null
+            st.error.isNotEmpty() -> "✗ ${st.error}"
+            else -> "↑ %.1f Mbps   ↓ %.1f Mbps   (%s, %d KB)".format(
+                st.upMbps, st.downMbps, DeviceName.generated(st.peerNpub), st.bytes / 1000,
+            )
+        }
+        if (resultLine != null) {
+            Text(
+                resultLine,
+                color = if (st.error.isNotEmpty() && !st.running) MaterialTheme.colorScheme.error else Slate,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+            )
+        }
     }
 }
 

--- a/myco-core/src/action.rs
+++ b/myco-core/src/action.rs
@@ -97,4 +97,9 @@ pub enum NativeAppAction {
     /// request/accept events so peers show the name the user chose. The Android
     /// app owns the value (persisted there) and re-applies it on launch.
     SetDeviceName { name: String },
+
+    /// Dev-menu speedtest against a mesh peer: PUT a fresh payload to the peer's
+    /// Blossom and GET it back, timing each leg. Spawn-not-block; the result lands
+    /// in `speedtest`. `npub` is the target peer's device identity.
+    SpeedtestPeer { npub: String },
 }

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -9,7 +9,7 @@
 //! Gated by `sync.offline_only`: when set, no IP source is installed and Myco
 //! never reaches the internet (`docs/reference/config.md`).
 
-use std::time::Duration;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use futures_util::future::join_all;
@@ -108,6 +108,107 @@ pub fn mesh_source_for(holder_npub: &str) -> anyhow::Result<IpPeerSource> {
     )
     .with_timeout(Duration::from_secs(20))
     .ignoring_manifest_servers())
+}
+
+/// Dev-menu **speedtest** against a mesh peer: PUT a fresh `bytes`-sized payload to
+/// the peer's Blossom (`http://[fd00::peer]:24242/upload`), then GET it back, timing
+/// each leg. Returns `(up_mbps, down_mbps)` — upload (this device → peer) and
+/// download (peer → this device) throughput in megabits per second. The whole call
+/// is bounded by `timeout`. The peer's Blossom gates non-loopback sources by Circle
+/// membership, so this only succeeds against a paired, reachable peer.
+///
+/// Note: the payload is content-addressed and there is no Blossom DELETE, so a run
+/// leaves a `bytes`-sized blob on the peer until its next cache wipe — fine for the
+/// occasional dev measurement, but keep `bytes` modest.
+pub async fn speedtest_peer(
+    npub: &str,
+    bytes: usize,
+    timeout: Duration,
+) -> anyhow::Result<(f64, f64)> {
+    // Address the peer by its `<npub>.fips` hostname, but resolve it ourselves: the
+    // Android system resolver has no `.fips` entries (that resolver is the FIPS
+    // gateway's, not wired into reqwest), so a plain request fails DNS. Map the
+    // hostname to the peer's deterministic mesh ULA (`fd00:: = fd + node_addr`) and
+    // hand it to reqwest via `.resolve` — it then connects over the app-owned TUN
+    // while keeping the `<npub>.fips` Host the peer expects.
+    let peer = fips::PeerIdentity::from_npub(npub)
+        .map_err(|e| anyhow::anyhow!("invalid peer npub {npub}: {e}"))?;
+    let host = format!("{npub}.fips");
+    let socket = std::net::SocketAddr::new(std::net::IpAddr::V6(peer.address().to_ipv6()), 24242);
+    let client = reqwest::Client::builder()
+        .resolve(&host, socket)
+        // A short connect timeout so an unroutable/unreachable peer fails fast
+        // instead of burning the whole `timeout` budget; the total still bounds the
+        // (potentially slow over BLE) transfer.
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(timeout)
+        .build()?;
+    speedtest_blossom(&client, &format!("http://{host}:24242"), bytes).await
+}
+
+/// The Blossom round-trip itself, against an already-built `client` + `base` URL —
+/// split out so it can be exercised against a local server in tests.
+async fn speedtest_blossom(
+    client: &reqwest::Client,
+    base: &str,
+    bytes: usize,
+) -> anyhow::Result<(f64, f64)> {
+    // A fresh, incompressible payload each run so the peer can't already hold it
+    // (which would make the GET a local hit and the hash collide across runs).
+    let payload = random_bytes(bytes);
+
+    let t_up = Instant::now();
+    let resp = client
+        .put(format!("{base}/upload"))
+        .body(payload)
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("upload rejected ({})", resp.status());
+    }
+    let up_mbps = throughput_mbps(bytes, t_up.elapsed());
+    let descriptor: serde_json::Value = serde_json::from_str(&resp.text().await?)?;
+    let hash = descriptor["sha256"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("upload descriptor missing sha256"))?
+        .to_string();
+
+    let t_down = Instant::now();
+    let got = client.get(format!("{base}/{hash}")).send().await?;
+    if !got.status().is_success() {
+        anyhow::bail!("download rejected ({})", got.status());
+    }
+    let body = got.bytes().await?;
+    let down_mbps = throughput_mbps(body.len(), t_down.elapsed());
+
+    Ok((up_mbps, down_mbps))
+}
+
+fn throughput_mbps(bytes: usize, elapsed: Duration) -> f64 {
+    let secs = elapsed.as_secs_f64();
+    if secs <= 0.0 {
+        return 0.0;
+    }
+    (bytes as f64 * 8.0) / secs / 1_000_000.0
+}
+
+/// `n` pseudo-random bytes from a time-seeded xorshift64 — cheap and dependency-
+/// free; we only need the bytes to be fresh per run, not cryptographically random.
+fn random_bytes(n: usize) -> Vec<u8> {
+    let mut state = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0x9e37_79b9_7f4a_7c15)
+        | 1;
+    let mut out = Vec::with_capacity(n);
+    while out.len() < n {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(n);
+    out
 }
 
 /// Discover the nsite manifests a relay holds — kind 15128 (root) + 35128 (named)
@@ -293,6 +394,26 @@ mod tests {
     use std::sync::Arc;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn speedtest_round_trips_through_blossom() {
+        // A real embedded Blossom (PUT /upload + GET /<hash>) on loopback.
+        let dir = std::env::temp_dir().join(format!("myco-speedtest-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let store = Arc::new(myco_blossom::FsBlobStore::open(&dir).unwrap());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(myco_blossom::server::serve_on(store, listener));
+
+        let base = format!("http://{addr}");
+        let client = reqwest::Client::new();
+        let (up, down) = speedtest_blossom(&client, &base, 64 * 1024).await.unwrap();
+        // Loopback: both legs move bytes and yield a finite, positive rate.
+        assert!(up > 0.0 && up.is_finite(), "up_mbps = {up}");
+        assert!(down > 0.0 && down.is_finite(), "down_mbps = {down}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// A mock relay: accept one WS connection, read the REQ, reply with the given
     /// event then EOSE. Returns the `ws://` URL.

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use fips::control::read_handle::ControlReadHandle;
 use tokio::runtime::Runtime;
@@ -46,6 +46,9 @@ pub struct AppRuntime {
     /// Circle peers we've already pulled chat backlog from this connection, so we
     /// pull once per (re)connect rather than every state poll.
     pulled_chat_from: std::sync::Mutex<std::collections::HashSet<String>>,
+    /// Latest dev-menu peer speedtest result; written by the spawned run task and
+    /// read back into `state()`. Shared so the async task can update it in place.
+    speedtest: Arc<std::sync::Mutex<crate::state::SpeedtestView>>,
 }
 
 impl AppRuntime {
@@ -211,6 +214,7 @@ impl AppRuntime {
             loop_task: None,
             content: Some(content),
             pulled_chat_from: std::sync::Mutex::new(std::collections::HashSet::new()),
+            speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
         })
     }
 
@@ -257,6 +261,7 @@ impl AppRuntime {
             loop_task: None,
             content: None,
             pulled_chat_from: std::sync::Mutex::new(std::collections::HashSet::new()),
+            speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
         }
     }
 
@@ -383,7 +388,56 @@ impl AppRuntime {
                 }
                 self.rev += 1;
             }
+            NativeAppAction::SpeedtestPeer { npub } => {
+                self.start_speedtest(npub);
+                self.rev += 1;
+            }
         }
+    }
+
+    /// Spawn a peer speedtest (spawn-not-block; the result is observed via the
+    /// `speedtest` field on the next `state()`). A ~1 MiB Blossom round-trip — big
+    /// enough to dominate connection setup, small enough not to bloat the peer's
+    /// store. Ignored if a run is already in flight.
+    fn start_speedtest(&mut self, npub: String) {
+        // 256 KiB: big enough to measure past connection setup, small enough to
+        // complete each way within the timeout over a slow (~tens of KB/s) BLE link.
+        const PAYLOAD_BYTES: usize = 262_144;
+        let Some(rt) = self.rt.as_ref() else { return };
+        {
+            let mut s = self.speedtest.lock().unwrap();
+            if s.running {
+                return;
+            }
+            s.running = true;
+            s.peer_npub = npub.clone();
+            s.error.clear();
+        }
+        let slot = self.speedtest.clone();
+        rt.spawn(async move {
+            tracing::info!(peer = %npub, "speedtest: starting");
+            let result =
+                crate::ip_source::speedtest_peer(&npub, PAYLOAD_BYTES, Duration::from_secs(60))
+                    .await;
+            let mut s = slot.lock().unwrap();
+            s.running = false;
+            s.bytes = PAYLOAD_BYTES as u64;
+            s.generation += 1;
+            match result {
+                Ok((up, down)) => {
+                    tracing::info!(peer = %npub, up_mbps = up, down_mbps = down, "speedtest: ok");
+                    s.up_mbps = up;
+                    s.down_mbps = down;
+                    s.error.clear();
+                }
+                Err(e) => {
+                    tracing::warn!(peer = %npub, error = format!("{e:#}"), "speedtest: failed");
+                    s.up_mbps = 0.0;
+                    s.down_mbps = 0.0;
+                    s.error = e.to_string();
+                }
+            }
+        });
     }
 
     /// Spawn a sync-to-readiness for a pasted link / shared site (spawn-not-block;
@@ -649,6 +703,7 @@ impl AppRuntime {
                 .as_ref()
                 .map(|c| c.update_check_snapshot())
                 .unwrap_or_default(),
+            speedtest: self.speedtest.lock().unwrap().clone(),
         }
     }
 

--- a/myco-core/src/state.rs
+++ b/myco-core/src/state.rs
@@ -39,6 +39,30 @@ pub struct AppState {
     pub offline_only: bool,
     /// Status of the latest nsite update check (feedback for "Check for updates").
     pub update_check: crate::content::UpdateCheckView,
+    /// Result of the dev-menu peer speedtest (a Blossom upload+download round-trip).
+    pub speedtest: SpeedtestView,
+}
+
+/// Outcome of a peer speedtest: upload + download throughput measured by PUTting
+/// a fresh payload to the peer's mesh Blossom and GETting it back. `generation`
+/// bumps on each completion so the UI can tell a fresh result from a stale one.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeedtestView {
+    /// A run is in flight (the UI shows a spinner / disables the button).
+    pub running: bool,
+    /// The peer the latest run targeted (npub), for the result label.
+    pub peer_npub: String,
+    /// Payload size moved each way, in bytes.
+    pub bytes: u64,
+    /// Upload (this device → peer) throughput, megabits per second.
+    pub up_mbps: f64,
+    /// Download (peer → this device) throughput, megabits per second.
+    pub down_mbps: f64,
+    /// Non-empty if the last run failed (e.g. peer unreachable / not paired).
+    pub error: String,
+    /// Bumped on each completed run (success or failure).
+    pub generation: u64,
 }
 
 /// The device identity, in the derived forms the UI shows.


### PR DESCRIPTION
Adds a developer-tab throughput probe between mesh peers. Pick a connected, handshaken peer and the core round-trips a 256 KiB payload through that peer's mesh Blossom — `PUT /upload` then `GET` it back — timing each leg and reporting up/down Mbps. Developer-gated (Dev tab); no effect on the normal app surfaces.

## What's here
- **`ip_source::speedtest_peer`** does the Blossom round-trip. It addresses the peer by its `<npub>.fips` Host but resolves that name itself to the peer's deterministic mesh ULA (`fd00:: = fd + node_addr`) via reqwest `.resolve()` — the Android system resolver has no `.fips` entries, so a plain request fails DNS; this connects over the app-owned TUN exactly like the existing relay/Blossom paths (`content.rs` uses the same `PeerIdentity::from_npub(...).address().to_ipv6()` derivation). A 15s connect-timeout makes an unreachable peer fail fast; a time-seeded xorshift fills the payload so it's fresh per run.
- **`SpeedtestPeer { npub }`** action → spawn-not-block in the runtime; the result lands in a new `speedtest` state field (running / up_mbps / down_mbps / error / generation), logged and surfaced each poll.
- **DevScreen** gains a SPEEDTEST card: a Run/Retry button per connected peer and the latest result line.

Only works against a **paired** peer (their Blossom gates non-loopback sources by Circle membership); an unpaired target fails fast with a 403. 256 KiB keeps the round-trip inside the timeout on a slow (~tens of KB/s) BLE link; the payload persists on the peer until its next cache wipe.

## Testing
- New `cargo test`: `speedtest_round_trips_through_blossom` exercises the round-trip against a real embedded Blossom on loopback.
- Verified end-to-end **on-device** (two paired phones): a run reports up/down Mbps; the button shows Run → running… → Retry on failure.
- `cargo fmt --check` clean; `myco-core` tests pass; `./gradlew assembleDebug` builds the native lib + APK.

## Heads-up for CI
`cargo clippy --all-targets -- -D warnings` is currently **red on pre-existing issues outside this branch's footprint** — 5 "useless conversion" errors in `myco-relay` tests (already present on `main`) and a "duplicated attribute" in the `fips` reference crate. This branch touches neither (only `myco-core` + Android + CHANGELOG); `myco-core` clippy is clean on the changed files. Worth a separate cleanup PR for the relay-test conversions.

## Follow-up (separate task)
App-wide `.fips` DNS resolution — a mesh DNS responder in the embedded node + `VpnService.addDnsServer` wiring — so any client (reqwest, the WebView, humans) can use `.fips` without per-client `.resolve()`. Tracked separately; this PR uses the per-client resolve as the consistent interim.