### PR TITLE
fix(myco-core): persistent bidirectional peer-relay connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Chat and other mesh events could silently stop reaching a paired peer after a
+  Bluetooth link dropped and came back. The reused relay connection went stale —
+  a half-open socket the app never noticed — and quietly swallowed every message
+  while the mesh still looked healthy. Each peer now holds a single persistent,
+  two-way relay connection that detects a dead link (read side + keepalive) and
+  reconnects, and manifest fetches share that one connection instead of opening a
+  second socket per peer.
+
 ## [0.1.0] - 2026-06-30
 
 ### Added

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -225,9 +225,10 @@ pub struct Content {
     device_name_override: Mutex<Option<String>>,
     /// Incoming pair requests awaiting the user's accept/decline (UI pop-up).
     pending_pairs: Mutex<Vec<PairRequestView>>,
-    /// Persistent WS connections to peers' relays, so chat fan-out doesn't pay a
-    /// fresh connect per message (slow over BLE).
-    peer_relays: crate::peer_relay::PeerRelayPool,
+    /// Persistent WS connections to peers' relays, so chat fan-out and manifest
+    /// fetches don't pay a fresh connect per message (slow over BLE). `Arc` so a
+    /// mesh `PeerSource` can borrow the same pool for its manifest REQs.
+    peer_relays: Arc<crate::peer_relay::PeerRelayPool>,
     /// host_label -> a newer version being staged (downloaded) before activation.
     /// See `docs/design/nsite-updates.md` §2. P-U1: staged outside the relay store;
     /// activation stores the manifest (making it the served version).
@@ -352,7 +353,7 @@ impl Content {
             device_keys: Mutex::new(None),
             device_name_override: Mutex::new(None),
             pending_pairs: Mutex::new(Vec::new()),
-            peer_relays: crate::peer_relay::PeerRelayPool::new(),
+            peer_relays: Arc::new(crate::peer_relay::PeerRelayPool::new()),
             pending_updates: Mutex::new(HashMap::new()),
             update_check: Mutex::new(UpdateCheckView::default()),
             active_manifests: Mutex::new(active_manifests),
@@ -505,7 +506,7 @@ impl Content {
         let mut tried: HashSet<String> = HashSet::new();
         if let Some(npub) = holder.as_deref() {
             if tried.insert(npub.to_string()) {
-                match crate::ip_source::mesh_source_for(npub) {
+                match crate::ip_source::mesh_source_for(self.peer_relays.clone(), npub) {
                     Ok(mesh) => sources.push(Arc::new(mesh)),
                     Err(e) => tracing::warn!(error = %e, "skipping mesh source"),
                 }
@@ -513,7 +514,7 @@ impl Content {
         }
         for npub in self.connected_circle_npubs() {
             if tried.insert(npub.clone()) {
-                match crate::ip_source::mesh_source_for(&npub) {
+                match crate::ip_source::mesh_source_for(self.peer_relays.clone(), &npub) {
                     Ok(mesh) => sources.push(Arc::new(mesh)),
                     Err(e) => tracing::warn!(error = %e, npub, "skipping circle mesh source"),
                 }
@@ -1177,7 +1178,12 @@ impl Content {
                 "req-ttl": 1,
             });
             let events = pool
-                .request(&npub, &relay_url, vec![filter], std::time::Duration::from_secs(15))
+                .request(
+                    &npub,
+                    &relay_url,
+                    vec![filter],
+                    std::time::Duration::from_secs(15),
+                )
                 .await;
             events
                 .into_iter()
@@ -1427,7 +1433,7 @@ impl Content {
         // option under mesh-only), then the online fallback unless mesh-only.
         let mut sources: Vec<Arc<dyn PeerSource>> = Vec::new();
         for npub in self.connected_circle_npubs() {
-            if let Ok(m) = crate::ip_source::mesh_source_for(&npub) {
+            if let Ok(m) = crate::ip_source::mesh_source_for(self.peer_relays.clone(), &npub) {
                 sources.push(Arc::new(m));
             }
         }

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -1071,15 +1071,10 @@ impl Content {
         let url = format!("ws://[{}]:4869", peer.address().to_ipv6());
         // kind 9 is the v1 chat kind (myco-bitchat); generalize when more apps land.
         let filter = serde_json::json!({ "kinds": [9], "limit": 100 });
-        let events = match tokio::time::timeout(
-            std::time::Duration::from_secs(15),
-            crate::ip_source::query_relay(&url, filter),
-        )
-        .await
-        {
-            Ok(Ok(evs)) => evs,
-            _ => return,
-        };
+        let events = self
+            .peer_relays
+            .request(npub, &url, vec![filter], std::time::Duration::from_secs(15))
+            .await;
         let mut stored = 0u32;
         for ev in events {
             if ev.verify().is_ok() && self.relay.store_event(ev).await.unwrap_or(false) {
@@ -1131,6 +1126,10 @@ impl Content {
             })
             .collect();
 
+        // All filters ride in one REQ per peer over the shared connection (the relay
+        // any-matches across them), so a pull is a single round-trip, not one socket
+        // per filter.
+        let pool = &self.peer_relays;
         let queries = self
             .connected_circle_npubs()
             .into_iter()
@@ -1143,18 +1142,8 @@ impl Content {
                 let url = format!("ws://[{}]:4869", ip);
                 let filters = filters.clone();
                 Some(async move {
-                    let mut out = Vec::new();
-                    for f in &filters {
-                        if let Ok(Ok(evs)) = tokio::time::timeout(
-                            std::time::Duration::from_secs(8),
-                            crate::ip_source::query_relay(&url, f.clone()),
-                        )
+                    pool.request(&npub, &url, filters, std::time::Duration::from_secs(8))
                         .await
-                        {
-                            out.extend(evs);
-                        }
-                    }
-                    out
                 })
             });
 
@@ -1174,19 +1163,25 @@ impl Content {
     /// `discovered`. Opening a result pulls from that peer (its npub is the holder).
     pub async fn discover_from_circle(self: Arc<Self>) {
         let members = self.connected_circle_contacts();
-        let queries = members.into_iter().map(|(npub, name)| async move {
+        let pool = &self.peer_relays;
+        let queries = members.into_iter().map(move |(npub, name)| async move {
             let Ok(peer) = fips::PeerIdentity::from_npub(&npub) else {
                 return Vec::new();
             };
             let relay_url = format!("ws://[{}]:4869", peer.address().to_ipv6());
-            let events = crate::ip_source::discover_manifests(
-                &relay_url,
-                std::time::Duration::from_secs(15),
-                200,
-            )
-            .await;
+            // Manifest kinds only; `req-ttl: 1` reaches our peers' peers (2 hops),
+            // matching the old `discover_manifests` helper.
+            let filter = serde_json::json!({
+                "kinds": [nsite_deck::KIND_ROOT, nsite_deck::KIND_NAMED],
+                "limit": 200,
+                "req-ttl": 1,
+            });
+            let events = pool
+                .request(&npub, &relay_url, vec![filter], std::time::Duration::from_secs(15))
+                .await;
             events
                 .into_iter()
+                .filter(|e| e.verify().is_ok())
                 .filter_map(|ev| nsite_deck::Manifest::from_event(ev).ok())
                 .map(|m| {
                     let addr = SiteAddr {
@@ -1264,48 +1259,63 @@ impl Content {
             "kinds": [nsite_deck::KIND_ROOT, nsite_deck::KIND_NAMED],
             "authors": authors,
         });
-        let mut targets: Vec<(String, serde_json::Value)> = Vec::new();
-        for npub in self.connected_circle_npubs() {
-            if let Ok(peer) = fips::PeerIdentity::from_npub(&npub) {
-                targets.push((
-                    format!("ws://[{}]:4869", peer.address().to_ipv6()),
-                    mesh_filter.clone(),
-                ));
-            }
-        }
-        if !self.is_offline_only() {
-            for url in crate::ip_source::default_relays() {
-                targets.push((url, online_filter.clone()));
-            }
-        }
-        if targets.is_empty() {
+        let mesh_peers: Vec<(String, String)> = self
+            .connected_circle_npubs()
+            .into_iter()
+            .filter_map(|npub| {
+                let peer = fips::PeerIdentity::from_npub(&npub).ok()?;
+                Some((npub, format!("ws://[{}]:4869", peer.address().to_ipv6())))
+            })
+            .collect();
+        let online: Vec<String> = if self.is_offline_only() {
+            Vec::new()
+        } else {
+            crate::ip_source::default_relays()
+        };
+        if mesh_peers.is_empty() && online.is_empty() {
             self.finish_update_check("No peers or relays to check");
             return;
         }
-        let mesh_count = self.connected_circle_npubs().len();
+        let mesh_count = mesh_peers.len();
         tracing::info!(
             apps = addrs.len(),
             mesh_peers = mesh_count,
-            targets = targets.len(),
+            targets = mesh_count + online.len(),
             offline_only = self.is_offline_only(),
             "update check: querying"
         );
-        let queries = targets.into_iter().map(|(url, f)| async move {
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(15),
-                crate::ip_source::query_relay(&url, f),
-            )
-            .await
-            {
-                Ok(Ok(evs)) => evs,
-                _ => Vec::new(),
+
+        // Mesh peers pull over the shared persistent connection; public relays stay
+        // one-shot (we don't hold long-lived sockets — or leak presence — to them).
+        let pool = &self.peer_relays;
+        let mesh_q = mesh_peers.into_iter().map(|(npub, url)| {
+            let f = mesh_filter.clone();
+            async move {
+                pool.request(&npub, &url, vec![f], std::time::Duration::from_secs(15))
+                    .await
             }
         });
+        let online_q = online.into_iter().map(|url| {
+            let f = online_filter.clone();
+            async move {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(15),
+                    crate::ip_source::query_relay(&url, f),
+                )
+                .await
+                {
+                    Ok(Ok(evs)) => evs,
+                    _ => Vec::new(),
+                }
+            }
+        });
+        let (mesh_res, online_res) =
+            futures_util::future::join(join_all(mesh_q), join_all(online_q)).await;
 
         // Newest verified manifest per slot across all relays.
         let mut newest: HashMap<String, Event> = HashMap::new();
         let mut received = 0usize;
-        for batch in join_all(queries).await {
+        for batch in mesh_res.into_iter().chain(online_res) {
             received += batch.len();
             for ev in batch {
                 let kind = ev.kind.as_u16();

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -211,25 +211,6 @@ fn random_bytes(n: usize) -> Vec<u8> {
     out
 }
 
-/// Discover the nsite manifests a relay holds — kind 15128 (root) + 35128 (named)
-/// — for "nsites around me" (querying a Circle peer's mesh relay). The whole call
-/// is hard-bounded by `timeout`; returns signature-verified manifest events. A
-/// dead/slow peer relay yields an empty set rather than stalling discovery.
-pub async fn discover_manifests(relay_url: &str, timeout: Duration, limit: usize) -> Vec<Event> {
-    // `req-ttl: 1` makes each directly-queried (1-hop) peer forward this REQ one
-    // more hop, so discovery also surfaces sites held by our peers' peers (2 hops).
-    // The transient key rides inside the filter object; plain relays ignore it.
-    let filter = serde_json::json!({
-        "kinds": [nsite_deck::KIND_ROOT, nsite_deck::KIND_NAMED],
-        "limit": limit,
-        "req-ttl": 1,
-    });
-    match tokio::time::timeout(timeout, query_relay(relay_url, filter)).await {
-        Ok(Ok(events)) => events.into_iter().filter(|e| e.verify().is_ok()).collect(),
-        _ => Vec::new(),
-    }
-}
-
 /// Publish one signed event to a relay (`["EVENT", …]`), best-effort: connect,
 /// send, briefly await the `OK`, close. The whole call is hard-bounded by
 /// `timeout` so an unreachable peer relay can't stall the fan-out. Returns whether
@@ -536,23 +517,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(miss, None);
-    }
-
-    #[tokio::test]
-    async fn discover_manifests_reads_kind_filtered_sites() {
-        // A signed manifest advertised on a peer's (mock) mesh relay.
-        let site = nsite_deck::testing::build_test_site(
-            &[("/index.html", b"<h1>around me</h1>")],
-            None,
-            Some("Nearby Site"),
-        );
-        let relay_url = mock_relay(serde_json::to_string(&site.manifest).unwrap()).await;
-
-        let events = discover_manifests(&relay_url, Duration::from_secs(5), 50).await;
-        assert_eq!(events.len(), 1, "discovery returns the verified manifest");
-        let m = nsite_deck::Manifest::from_event(events.into_iter().next().unwrap()).unwrap();
-        assert_eq!(m.title.as_deref(), Some("Nearby Site"));
-        assert_eq!(m.author, site.author);
     }
 
     /// Live network check against a real public nsite (the link the user gave).

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -56,6 +56,10 @@ pub struct IpPeerSource {
     /// use only `blossom_servers` — so a **mesh** source never reaches out to
     /// public Blossom over the internet (it stays on the peer's `[fd00::]:24242`).
     ignore_manifest_servers: bool,
+    /// For a **mesh** source: the shared peer-relay pool + the holder's npub, so a
+    /// manifest REQ reuses the one persistent WS connection to the peer instead of
+    /// opening a fresh `query_relay` socket. `None` for a public-relay source.
+    peer_relay: Option<(std::sync::Arc<crate::peer_relay::PeerRelayPool>, String)>,
 }
 
 impl IpPeerSource {
@@ -70,7 +74,19 @@ impl IpPeerSource {
                 .unwrap_or_default(),
             timeout: Duration::from_secs(8),
             ignore_manifest_servers: false,
+            peer_relay: None,
         }
+    }
+
+    /// Route this (mesh) source's manifest REQs through the shared peer-relay pool,
+    /// reusing the persistent WS connection to `npub` instead of a one-shot socket.
+    pub fn over_peer_relay(
+        mut self,
+        pool: std::sync::Arc<crate::peer_relay::PeerRelayPool>,
+        npub: &str,
+    ) -> Self {
+        self.peer_relay = Some((pool, npub.to_string()));
+        self
     }
 
     /// Fetch blobs only from this source's own servers, never the manifest's
@@ -98,7 +114,10 @@ impl IpPeerSource {
 /// `ws://[fd00::holder]:4869` / `http://[fd00::holder]:24242`. Requires the
 /// app-owned TUN to be up so the IPv6 socket routes over the mesh. A longer
 /// timeout than the IP source absorbs BLE latency + first-contact session setup.
-pub fn mesh_source_for(holder_npub: &str) -> anyhow::Result<IpPeerSource> {
+pub fn mesh_source_for(
+    pool: std::sync::Arc<crate::peer_relay::PeerRelayPool>,
+    holder_npub: &str,
+) -> anyhow::Result<IpPeerSource> {
     let peer = fips::PeerIdentity::from_npub(holder_npub)
         .map_err(|e| anyhow::anyhow!("invalid holder npub {holder_npub}: {e}"))?;
     let ip = peer.address().to_ipv6();
@@ -107,7 +126,8 @@ pub fn mesh_source_for(holder_npub: &str) -> anyhow::Result<IpPeerSource> {
         vec![format!("http://[{ip}]:24242")],
     )
     .with_timeout(Duration::from_secs(20))
-    .ignoring_manifest_servers())
+    .ignoring_manifest_servers()
+    .over_peer_relay(pool, holder_npub))
 }
 
 /// Dev-menu **speedtest** against a mesh peer: PUT a fresh `bytes`-sized payload to
@@ -292,16 +312,23 @@ impl PeerSource for IpPeerSource {
             filter["#d"] = serde_json::json!([d]);
         }
 
-        // Each relay is hard-bounded by `self.timeout` (connect + read), so a dead
-        // relay can't stall the whole sync on a slow TCP/TLS connect; the rest
-        // still answer. A timeout/error yields an empty set for that relay.
-        let queries = self.relays.iter().map(|url| async {
-            match tokio::time::timeout(self.timeout, query_relay(url, filter.clone())).await {
-                Ok(Ok(events)) => events,
-                _ => Vec::new(),
-            }
-        });
-        let results = join_all(queries).await;
+        // Mesh source: reuse the persistent pooled WS to the peer (one socket per
+        // peer, shared with chat fan-out) rather than a fresh per-fetch connect.
+        let results: Vec<Vec<Event>> = if let Some((pool, npub)) = &self.peer_relay {
+            let url = self.relays.first().cloned().unwrap_or_default();
+            vec![pool.request(npub, &url, vec![filter], self.timeout).await]
+        } else {
+            // Public relays: each hard-bounded by `self.timeout` (connect + read), so
+            // a dead relay can't stall the whole sync on a slow TCP/TLS connect; the
+            // rest still answer. A timeout/error yields an empty set for that relay.
+            let queries = self.relays.iter().map(|url| async {
+                match tokio::time::timeout(self.timeout, query_relay(url, filter.clone())).await {
+                    Ok(Ok(events)) => events,
+                    _ => Vec::new(),
+                }
+            });
+            join_all(queries).await
+        };
 
         // Pick the newest event that verifies and matches the requested slot.
         let mut newest: Option<Event> = None;

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -1,22 +1,71 @@
-//! A pool of **persistent** WebSocket connections to peers' mesh relays.
+//! A pool of **persistent, bidirectional** WebSocket connections to peers' mesh
+//! relays — **one socket per peer**, shared by both propagation planes:
 //!
-//! Fan-out used to open a fresh `ws://[fd00::peer]:4869` per message — over BLE a
-//! TCP+WS handshake is several round-trips, and two concurrent connects contend
-//! for the one radio, so the second peer lagged ~1-2s. Here each peer gets a
-//! long-lived writer task fed by an unbounded channel: the first frame pays the
-//! connect, every later frame is just a socket write. A dead connection is
-//! dropped and lazily reopened on the next send.
+//! - **push** ([`PeerRelayPool::send`]): fan an `["EVENT", …]` frame to a peer
+//!   (fire-and-forget) — the multi-hop flood of `docs/design/event-gossip.md`.
+//! - **pull** ([`PeerRelayPool::request`]): open a `REQ`, collect the peer's
+//!   matching events until `EOSE`/`CLOSED`, then close the subscription.
+//!
+//! A Nostr relay connection is two-way, so there is no reason to hold more than one
+//! socket per destination: event fan-out, every REQ + its event replies, and the
+//! keepalive all multiplex over the single connection via subscription ids (NIP-01).
+//! Over BLE a TCP+WS handshake is several round-trips and concurrent connects
+//! contend for the one radio, so a fresh socket per message (or a second socket for
+//! pulls) is exactly what we avoid.
+//!
+//! Each peer gets a long-lived actor task ([`run`]) owning the split socket. It
+//! `select!`s over (a) commands from the pool, (b) inbound frames, and (c) a
+//! keepalive ping. **The read half is the point.** The previous pool was
+//! write-only, so it never noticed a *half-open* connection: after a mesh flap the
+//! peer keeps the same identity-derived `fd00::` address, but the pre-flap socket is
+//! dead — and a write to a dead-but-not-yet-reset TCP socket *buffers and
+//! "succeeds"* for as long as the OS retransmits (minutes on mobile). Fan-out then
+//! vanished into a black hole while the mesh looked healthy. Reading the socket
+//! surfaces a peer close/error at once, and a ping the peer never answers within one
+//! interval catches the silent half-open; either drops the task, and the next
+//! command lazily reopens a fresh connection.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::Duration;
 
-use futures_util::SinkExt;
-use tokio::sync::mpsc;
+use futures_util::{SinkExt, StreamExt};
+use nostr::Event;
+use tokio::sync::{mpsc, oneshot};
 use tokio_tungstenite::tungstenite::Message;
+
+/// Keepalive cadence: send a WS ping this often on an otherwise-idle connection.
+/// If a whole interval passes with **no inbound frame at all** (not even the pong),
+/// the connection is treated as dead and the task exits so the next command
+/// reconnects. Short enough to catch a silent half-open in seconds, not the TCP
+/// retransmit horizon; long enough not to chatter over BLE.
+const PING_INTERVAL: Duration = Duration::from_secs(20);
+
+/// A command sent to a peer's connection actor over its channel.
+enum Command {
+    /// Fire-and-forget: write a pre-built `["EVENT", …]` frame (the push plane).
+    Publish(String),
+    /// Open a `REQ` for `filters`, accumulate matching events until `EOSE`/`CLOSED`,
+    /// then reply once with the batch and close the subscription (the pull plane).
+    Request {
+        filters: Vec<serde_json::Value>,
+        reply: oneshot::Sender<Vec<Event>>,
+    },
+}
+
+/// An in-flight `REQ` on a connection: events seen so far, and where to deliver them
+/// on `EOSE`. The events are returned unverified — callers verify (matching the old
+/// `query_relay` contract).
+struct Pending {
+    events: Vec<Event>,
+    reply: oneshot::Sender<Vec<Event>>,
+}
 
 #[derive(Default)]
 pub struct PeerRelayPool {
-    conns: Mutex<HashMap<String, mpsc::UnboundedSender<String>>>,
+    /// Per-peer command channel to its live actor task. A closed sender means the
+    /// task exited (connection died / connect failed); the next use respawns it.
+    peers: Mutex<HashMap<String, mpsc::UnboundedSender<Command>>>,
 }
 
 impl PeerRelayPool {
@@ -24,40 +73,261 @@ impl PeerRelayPool {
         Self::default()
     }
 
-    /// Queue `frame` to the peer's relay at `url`, keeping the connection open for
-    /// the next send. Non-blocking; must be called from within the Tokio runtime
-    /// (the gossiper's task is). A frame sent before the socket finishes
-    /// connecting is buffered in the channel and flushed on connect.
+    /// Get a live command channel for `npub`'s connection at `url`, spawning the
+    /// actor (which lazily connects) if there isn't a running one. Caller holds the
+    /// map lock.
+    fn actor(
+        peers: &mut HashMap<String, mpsc::UnboundedSender<Command>>,
+        npub: &str,
+        url: &str,
+    ) -> mpsc::UnboundedSender<Command> {
+        if let Some(tx) = peers.get(npub) {
+            if !tx.is_closed() {
+                return tx.clone();
+            }
+            peers.remove(npub);
+        }
+        let (tx, rx) = mpsc::unbounded_channel::<Command>();
+        peers.insert(npub.to_string(), tx.clone());
+        let url = url.to_string();
+        tokio::spawn(run(url, rx));
+        tx
+    }
+
+    /// Queue a pre-built relay frame (`["EVENT", {…}]`) to a peer's relay over the
+    /// persistent connection (push plane). Non-blocking; must be called from within
+    /// the Tokio runtime. A frame sent before the socket finishes connecting is
+    /// buffered in the channel and flushed on connect.
     pub fn send(&self, npub: &str, url: &str, frame: String) {
-        let mut conns = self.conns.lock().unwrap();
-        // Reuse a live writer; on a closed channel (task gone) recover the frame
-        // and fall through to reopen.
-        let frame = match conns.get(npub) {
-            Some(tx) => match tx.send(frame) {
-                Ok(()) => return,
-                Err(err) => {
-                    conns.remove(npub);
-                    err.0
+        let mut peers = self.peers.lock().unwrap();
+        let tx = Self::actor(&mut peers, npub, url);
+        // Lost the race with a task that just exited: drop the entry so the next
+        // publish respawns. Rare, and the push plane is best-effort (the pull plane
+        // recovers backlog on reconnect).
+        if tx.send(Command::Publish(frame)).is_err() {
+            peers.remove(npub);
+        }
+    }
+
+    /// Query a peer's relay (pull plane): open a `REQ` for `filters` over the shared
+    /// connection and collect its matching events until `EOSE`. Bounded by
+    /// `timeout` — a slow/dead peer yields an empty batch rather than stalling.
+    /// Events are returned as received; the caller verifies signatures.
+    pub async fn request(
+        &self,
+        npub: &str,
+        url: &str,
+        filters: Vec<serde_json::Value>,
+        timeout: Duration,
+    ) -> Vec<Event> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        {
+            let mut peers = self.peers.lock().unwrap();
+            let tx = Self::actor(&mut peers, npub, url);
+            if tx
+                .send(Command::Request {
+                    filters,
+                    reply: reply_tx,
+                })
+                .is_err()
+            {
+                peers.remove(npub);
+                return Vec::new();
+            }
+        } // release the lock before awaiting the reply
+        match tokio::time::timeout(timeout, reply_rx).await {
+            Ok(Ok(events)) => events,
+            // Timed out, or the actor died before EOSE (connection dropped).
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// The per-peer connection actor: connect once, then multiplex push + pull + ping
+/// over the one socket until it dies or the pool drops the command channel.
+async fn run(url: String, mut cmd_rx: mpsc::UnboundedReceiver<Command>) {
+    let Ok((ws, _)) = tokio_tungstenite::connect_async(&url).await else {
+        return; // connect failed → channel drops with this task → next command respawns
+    };
+    let (mut sink, mut stream) = ws.split();
+    let mut pending: HashMap<String, Pending> = HashMap::new();
+    let mut next_sub: u64 = 0;
+    // First tick fires one interval out (not immediately) so a just-opened idle
+    // connection isn't pinged before it's had a chance to carry traffic.
+    let mut ping =
+        tokio::time::interval_at(tokio::time::Instant::now() + PING_INTERVAL, PING_INTERVAL);
+    let mut awaiting_pong = false;
+
+    loop {
+        tokio::select! {
+            cmd = cmd_rx.recv() => match cmd {
+                None => break, // pool dropped the sender: shut the socket down
+                Some(Command::Publish(frame)) => {
+                    if sink.send(Message::Text(frame)).await.is_err() {
+                        break;
+                    }
+                }
+                Some(Command::Request { filters, reply }) => {
+                    let sub_id = format!("r{next_sub}");
+                    next_sub += 1;
+                    let mut req: Vec<serde_json::Value> = Vec::with_capacity(filters.len() + 2);
+                    req.push(serde_json::Value::from("REQ"));
+                    req.push(serde_json::Value::from(sub_id.clone()));
+                    req.extend(filters);
+                    let frame = serde_json::Value::Array(req).to_string();
+                    if sink.send(Message::Text(frame)).await.is_err() {
+                        let _ = reply.send(Vec::new());
+                        break;
+                    }
+                    pending.insert(sub_id, Pending { events: Vec::new(), reply });
                 }
             },
-            None => frame,
-        };
-
-        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-        let _ = tx.send(frame);
-        conns.insert(npub.to_string(), tx);
-
-        let url = url.to_string();
-        tokio::spawn(async move {
-            let Ok((mut ws, _)) = tokio_tungstenite::connect_async(&url).await else {
-                return; // channel drops with this task → next send reopens
-            };
-            while let Some(f) = rx.recv().await {
-                if ws.send(Message::Text(f)).await.is_err() {
+            msg = stream.next() => match msg {
+                // Any inbound frame proves the peer is alive this interval.
+                Some(Ok(frame)) => {
+                    awaiting_pong = false;
+                    match frame {
+                        Message::Text(txt) => {
+                            if let Some(done) = handle_inbound(&txt, &mut pending) {
+                                // Tell the relay to drop the (now-satisfied) sub, so a
+                                // never-closed sub doesn't accumulate on its side over
+                                // this long-lived connection.
+                                let close = serde_json::json!(["CLOSE", done]).to_string();
+                                let _ = sink.send(Message::Text(close)).await;
+                            }
+                        }
+                        Message::Close(_) => break,
+                        _ => {} // pong / ping / binary — liveness already noted
+                    }
+                }
+                Some(Err(_)) | None => break, // socket error or clean EOF → reconnect on next command
+            },
+            _ = ping.tick() => {
+                // The previous ping went a whole interval unanswered by any frame →
+                // treat the connection as dead (this is the half-open catch).
+                if awaiting_pong {
                     break;
                 }
+                if sink.send(Message::Ping(Vec::new())).await.is_err() {
+                    break;
+                }
+                awaiting_pong = true;
+                // Reap subs whose caller already timed out and dropped the receiver,
+                // so they don't linger until the connection closes.
+                let dead: Vec<String> = pending
+                    .iter()
+                    .filter(|(_, p)| p.reply.is_closed())
+                    .map(|(id, _)| id.clone())
+                    .collect();
+                for id in dead {
+                    pending.remove(&id);
+                    let close = serde_json::json!(["CLOSE", id]).to_string();
+                    let _ = sink.send(Message::Text(close)).await;
+                }
             }
-            let _ = ws.send(Message::Close(None)).await;
-        });
+        }
+    }
+    // Pending replies drop here → their `request` callers get an empty batch.
+    let _ = sink.send(Message::Close(None)).await;
+}
+
+/// Route one inbound relay frame to its pending `REQ`. Returns the sub id that just
+/// completed (on `EOSE`/`CLOSED`) so the caller can `CLOSE` it, else `None`.
+fn handle_inbound(txt: &str, pending: &mut HashMap<String, Pending>) -> Option<String> {
+    let val: serde_json::Value = serde_json::from_str(txt).ok()?;
+    let arr = val.as_array()?;
+    match arr.first().and_then(|v| v.as_str())? {
+        "EVENT" => {
+            // ["EVENT", <sub_id>, <event>]
+            let sub_id = arr.get(1)?.as_str()?;
+            let p = pending.get_mut(sub_id)?;
+            let event = serde_json::from_value::<Event>(arr.get(2)?.clone()).ok()?;
+            p.events.push(event);
+            None
+        }
+        "EOSE" | "CLOSED" => {
+            let sub_id = arr.get(1)?.as_str()?.to_string();
+            let p = pending.remove(&sub_id)?;
+            let _ = p.reply.send(p.events);
+            Some(sub_id)
+        }
+        _ => None, // OK (for our EVENT publishes), NOTICE, … — nothing to route
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use myco_relay::server::serve_on;
+    use myco_relay::RelayStore;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+    use std::sync::Arc;
+
+    async fn spawn_relay() -> (Arc<RelayStore>, String) {
+        let store = Arc::new(RelayStore::in_memory());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_on(store.clone(), listener));
+        (store, format!("ws://{addr}"))
+    }
+
+    fn chat(keys: &Keys, content: &str) -> Event {
+        EventBuilder::new(Kind::from(9u16), content)
+            .tags([Tag::identifier("mesh".to_string())])
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    /// A pushed EVENT lands in the peer's store, and a later `request` reads it back
+    /// over the **same** pooled connection (both planes, one socket).
+    #[tokio::test]
+    async fn push_then_pull_over_one_connection() {
+        let (store, url) = spawn_relay().await;
+        let pool = PeerRelayPool::new();
+        let keys = Keys::generate();
+        let ev = chat(&keys, "hello mesh");
+
+        let frame = serde_json::json!(["EVENT", ev]).to_string();
+        pool.send("peerX", &url, frame);
+
+        // Poll the store until the pushed event is stored (the push is async).
+        let stored = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if store.count() > 0 {
+                    return true;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap_or(false);
+        assert!(stored, "pushed event should reach the peer's store");
+
+        let got = pool
+            .request(
+                "peerX",
+                &url,
+                vec![serde_json::json!({ "kinds": [9] })],
+                Duration::from_secs(5),
+            )
+            .await;
+        assert_eq!(got.len(), 1, "request reads the event back");
+        assert_eq!(got[0].id, ev.id);
+    }
+
+    /// A request to an unreachable peer returns empty within the timeout (no hang).
+    #[tokio::test]
+    async fn request_to_dead_peer_times_out_empty() {
+        let pool = PeerRelayPool::new();
+        // Port 1 is not listening; connect fails fast, actor exits, reply drops.
+        let got = pool
+            .request(
+                "peerDead",
+                "ws://127.0.0.1:1",
+                vec![serde_json::json!({ "kinds": [9] })],
+                Duration::from_secs(2),
+            )
+            .await;
+        assert!(got.is_empty());
     }
 }

--- a/myco-relay/src/server.rs
+++ b/myco-relay/src/server.rs
@@ -233,6 +233,17 @@ async fn handle_ws(socket: WebSocket, hub: Arc<RelayHub>, peer_ip: IpAddr) {
                             }
                         }
                     }
+                    Some(Ok(Message::Ping(payload))) => {
+                        // Answer the peer-relay pool's keepalive so it can tell a
+                        // live connection from a silent half-open one (its liveness
+                        // check is a ping that must draw a frame back within its
+                        // interval). tungstenite may also auto-pong, but replying
+                        // explicitly guarantees the pong is flushed on an otherwise
+                        // idle subscription.
+                        if ws_tx.send(Message::Pong(payload)).await.is_err() {
+                            return;
+                        }
+                    }
                     Some(Ok(Message::Close(_))) | None => return,
                     Some(Err(_)) => return,
                     _ => {}


### PR DESCRIPTION
## What

Chat and other mesh events could **silently stop reaching a paired peer after a Bluetooth link dropped and came back**. This makes each peer hold a single persistent, bidirectional relay connection that detects a dead link and reconnects, and routes manifest fetches over that same connection instead of opening a second socket per peer.

Two commits:

- **`fix(myco-core): persistent bidirectional peer relay connection`** — the actual bug fix.
- **`refactor(myco-core): fetch manifests over the persistent peer-relay pool`** — reuse that one connection for the mesh manifest REQ too (was a separate one-shot socket).

## Root cause

The peer-relay pool was **write-only** — it fanned `EVENT`s to a peer's mesh relay but never read the socket. After a BLE flap the peer keeps the same identity-derived `fd00::` address, but the pre-flap TCP/WS connection is dead. A write to a dead-but-not-yet-reset socket *buffers and "succeeds"* until the OS gives up (minutes on mobile), so fan-out vanished into a black hole while the mesh still looked healthy. Pulls (`REQ`) worked around it by opening a fresh socket each time, leaving one persistent + N transient sockets per peer.

## Fix

One persistent, bidirectional connection per peer, carrying both planes over NIP-01 subscription ids:

- **push** — `EVENT`, fire-and-forget
- **pull** — `REQ` → collect until `EOSE` → `CLOSE`

The **read half** surfaces a peer close/error immediately, and a 20s keepalive ping the peer never answers within one interval catches the silent half-open; either drops the task and the next command lazily reconnects. `pull_recent_chat`, `pull_from_peers` (now one multi-filter `REQ`, not one socket per filter), discovery, the mesh half of `check_updates`, and manifest fetch all share the pooled connection. Public relays stay one-shot (no long-lived sockets or presence leak to third parties). `myco-relay` now answers WS `Ping` explicitly so an idle subscription isn't misread as dead — all frames remain standard NIP-01 / RFC 6455.

## Wire / interop

No protocol change. Application frames are standard NIP-01 (`EVENT`/`REQ`/`CLOSE`); the keepalive is RFC 6455 WS control (a layer below Nostr, universally handled). The pool only ever dials `myco-relay` peers; public relays keep the one-shot path.

## Tests

- New `cargo test` coverage in `peer_relay`: push→pull over one connection; request to a dead peer times out empty.
- `cargo fmt --check`, `cargo build`, `cargo test`, and `./gradlew assembleDebug` all pass.
- Not unit-tested (not tractable in-process): the half-open detection / keepalive / reconnect path — that's on-device behavior.

## Manual-test caveat (please read)

The end-to-end multi-device win is **not yet confirmed on hardware**. On the two phones I tested, the device logs are dominated by a **separate** BLE-transport problem — a single shared L2CAP send FIFO whose bulk traffic starves keepalive/rekey under load, tripping the 30s dead-link timeout — which masks the reconnect behavior this PR fixes. This change is unit-tested and reasoned; it should be re-verified on a stable link (Wi-Fi Aware) or once that transport issue is addressed.

## Follow-ups (out of scope here)

- fips BLE **link-death-under-load**: bulk data shares one FIFO with control frames (keepalive/rekey), starving them → dead-link timeout. Needs a priority send lane and/or progress-based liveness.
- BLE **scanner has no failure recovery**: `onScanFailed` only logs (advertiser retries, scanner doesn't) → a scan-throttle event permanently kills discovery until the mesh is toggled.
- **Blob-fetch parallelism**: prepared but held — at the current ~1 kB/s mesh goodput it's counterproductive (saturates the FIFO above), revisit after the transport fix.

No linked issue (searched open issues — none matched). Happy to file the follow-ups as separate issues.
