### PR TITLE
fix(android): recover BLE scanning after a scan failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   two-way relay connection that detects a dead link (read side + keepalive) and
   reconnects, and manifest fetches share that one connection instead of opening a
   second socket per peer.
+- Bluetooth peer discovery could stop for good after a burst of
+  connects/disconnects and stay stuck at zero peers until you toggled the mesh
+  off and on. Android throttles BLE scanning (~5 scan starts per 30s); a
+  throttled scan was logged and then abandoned. The scanner now re-arms itself on
+  a backoff — waiting out the throttle window — and recovers discovery on its own.
 
 ## [0.1.0] - 2026-06-30
 

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -76,6 +76,10 @@ class BleRadio(context: Context) {
     private val retryExec = Executors.newSingleThreadScheduledExecutor()
     @Volatile private var advertisePsm = 0
     private var advertiseRetries = 0
+    // Scanner-retry state: a failed scan (Android throttles ~5 startScan/30s →
+    // SCAN_FAILED_SCANNING_TOO_FREQUENTLY) used to be logged and abandoned, which
+    // permanently killed peer discovery until the mesh was toggled. We re-arm it.
+    private var scanRetries = 0
 
     fun bindBridge(handle: Long) {
         bridgeHandle = handle
@@ -197,6 +201,9 @@ class BleRadio(context: Context) {
 
     fun startScanning() {
         if (stopped) return
+        // Stop-before-start hygiene: a re-arm (retry / radio restart) must not
+        // orphan a prior scan callback.
+        stopScanning()
         val sc = adapter?.bluetoothLeScanner ?: return
         scanner = sc
         val filters = listOf(ScanFilter.Builder().setServiceUuid(FIPS_PARCEL_UUID).build())
@@ -205,6 +212,7 @@ class BleRadio(context: Context) {
             .build()
         val cb = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
+                scanRetries = 0 // a result proves scanning is live; reset backoff
                 val addr = "$ADAPTER/${result.device.address}"
                 // PSM rides in the primary advert under the compact 16-bit UUID;
                 // fall back to the legacy 128-bit-keyed service-data for any peer
@@ -227,7 +235,8 @@ class BleRadio(context: Context) {
             }
 
             override fun onScanFailed(errorCode: Int) {
-                Log.e(TAG, "scan failed: $errorCode")
+                Log.e(TAG, "scan failed: $errorCode (2=APP_REGISTRATION_FAILED, 6=TOO_FREQUENT)")
+                scheduleScanRetry(errorCode)
             }
         }
         scanCallback = cb
@@ -236,6 +245,33 @@ class BleRadio(context: Context) {
             Log.i(TAG, "scanning for FIPS peers")
         } catch (e: Exception) {
             Log.e(TAG, "startScanning failed", e)
+            scheduleScanRetry(-1)
+        }
+    }
+
+    /** Re-arm scanning after a failure, so a transient throttle/error doesn't
+     *  permanently stop peer discovery. Android caps ~5 `startScan` calls per 30s
+     *  (SCAN_FAILED_SCANNING_TOO_FREQUENTLY) — restarting inside that window just
+     *  re-trips it, so the throttle case gets a 30s floor; other errors use the
+     *  same exponential backoff (5→10→20→40s, capped 60s) as the advertiser. The
+     *  backoff resets once a scan result comes in. */
+    private fun scheduleScanRetry(errorCode: Int) {
+        if (stopped) return
+        val backoff = minOf(60L, 5L shl minOf(scanRetries, 3))
+        val delay =
+            if (errorCode == ScanCallback.SCAN_FAILED_SCANNING_TOO_FREQUENTLY) {
+                maxOf(30L, backoff)
+            } else {
+                backoff
+            }
+        scanRetries++
+        Log.i(TAG, "scan retry in ${delay}s (error $errorCode)")
+        runCatching {
+            retryExec.schedule(
+                { if (!stopped) startScanning() },
+                delay,
+                TimeUnit.SECONDS,
+            )
         }
     }
 


### PR DESCRIPTION
## What

A device could **drop to zero peers and stay there** after a burst of BLE connect/disconnect churn — discovery dead until you toggled the mesh off and on. Foregrounding the app did nothing. This makes the scanner recover on its own.

## Root cause

`onScanFailed` only logged and gave up:

```kotlin
override fun onScanFailed(errorCode: Int) {
    Log.e(TAG, "scan failed: $errorCode")
}
```

Android throttles BLE scanning to ~5 `startScan` calls per 30s → `SCAN_FAILED_SCANNING_TOO_FREQUENTLY (6)`. A burst of connect/disconnect (each cycling the scan) trips it; once tripped the scan callback was abandoned and never re-armed, so no `onScanResult` ever fired again and discovery stayed dead. The **advertiser** already self-recovers (`scheduleAdvertiseRetry`); the scanner had no equivalent, and scanning is armed once by the core — so only a full radio re-init (mesh toggle) brought it back. That's exactly why foreground didn't help but toggling Bluetooth did.

## Fix

Re-arm scanning on a backoff from `onScanFailed`:

- Throttle case (`SCAN_FAILED_SCANNING_TOO_FREQUENTLY`) gets a **30s floor** — restarting inside the throttle window just re-trips it.
- Other errors reuse the advertiser's exponential backoff (5→10→20→40s, capped 60s).
- The backoff resets on the next `ScanResult` (scanning proven live).
- `startScanning` now stops-before-start, so a re-arm can't orphan a prior callback.

## Tests

- `./gradlew assembleDebug` passes (Kotlin-only change).
- On-device behavior (scan throttle + auto-recovery) isn't unit-testable in-process; to verify manually: churn connects/disconnects until discovery stalls, then confirm peers reappear on their own within ~30s instead of needing a mesh toggle.

## Scope

This fixes the **permanent** stuck-at-zero-peers state. The **trigger** — connect/disconnect churn from bulk traffic starving keepalive/rekey on the shared L2CAP send FIFO (dead-link timeout under load) — is a separate `reference/fips` transport issue, tracked as a follow-up.

No linked issue (searched open issues — none matched).
