### PR TITLE
fix(myco-core): fan chat to the whole Circle, not just direct neighbours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   off and on. Android throttles BLE scanning (~5 scan starts per 30s); a
   throttled scan was logged and then abandoned. The scanner now re-arms itself on
   a backoff — waiting out the throttle window — and recovers discovery on its own.
+- Chat only reached Circle members you were *directly* connected to. Once two
+  paired people moved apart and became several hops apart over the mesh, their
+  messages stopped flowing — even though the mesh could still route between them.
+  Chat now fans out to your whole Circle, so a paired peer keeps receiving your
+  messages wherever they are on the mesh, not just when they're a direct neighbour.
 
 ## [0.1.0] - 2026-06-30
 

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -835,9 +835,9 @@ impl Content {
         *self.connected_peers.lock().unwrap() = npubs;
     }
 
-    /// Circle members that are connected mesh peers right now — the pull sources
-    /// to try (besides an explicit holder) without risking an offline timeout, and
-    /// the fan-out targets for outbound chat events (`docs/design/event-gossip.md`).
+    /// Circle members that are **direct** mesh neighbours right now — the pull
+    /// sources to try (besides an explicit holder) without risking an offline
+    /// timeout, e.g. `open_site` content pulls.
     pub fn connected_circle_npubs(&self) -> Vec<String> {
         let connected = self.connected_peers.lock().unwrap();
         self.circle
@@ -845,6 +845,23 @@ impl Content {
             .unwrap()
             .iter()
             .filter(|c| connected.iter().any(|n| n == &c.npub))
+            .map(|c| c.npub.clone())
+            .collect()
+    }
+
+    /// **Every** Circle member's npub, regardless of whether they're a *direct*
+    /// mesh neighbour right now. Chat fan-out targets this: a Circle peer you've
+    /// walked away from is still reachable multi-hop over the mesh, and messages
+    /// must keep flowing to them — the routed `ws://[fd00::peer]:4869` dial reaches
+    /// them, and a truly-offline member's connect just fails fast and is dropped.
+    /// (Contrast [`connected_circle_npubs`](Self::connected_circle_npubs), the
+    /// direct-neighbour subset used where an offline dial's timeout must be
+    /// avoided.) See `docs/design/event-gossip.md`.
+    pub fn circle_npubs(&self) -> Vec<String> {
+        self.circle
+            .lock()
+            .unwrap()
+            .iter()
             .map(|c| c.npub.clone())
             .collect()
     }
@@ -2172,12 +2189,18 @@ mod tests {
                 "re-adding renames in place"
             );
 
-            // Only connected members are offered as pull sources.
+            // Only connected members are offered as offline-sensitive pull sources.
             content.set_connected_peers(vec!["npub1bob".to_string()]);
             assert_eq!(
                 content.connected_circle_npubs(),
                 vec!["npub1bob".to_string()]
             );
+            // But chat fans to the *whole* Circle — Alice isn't a direct neighbour
+            // right now, yet must still receive messages (reachable multi-hop).
+            let all = content.circle_npubs();
+            assert_eq!(all.len(), 2);
+            assert!(all.contains(&"npub1alice".to_string()));
+            assert!(all.contains(&"npub1bob".to_string()));
 
             content.remove_from_circle("npub1bob");
             assert_eq!(content.circle_snapshot().len(), 1);

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -1,8 +1,10 @@
 //! `MeshGossiper` — the [`Gossiper`] hook that fans an nsite's events out to the
 //! mesh, implementing the **push** plane of `docs/design/event-gossip.md`.
 //!
-//! **P2 — multi-hop flood.** An event is pushed to connected Circle peers'
-//! relays (`ws://[fd00::peer]:4869`) carrying a decrementing `event-ttl`:
+//! **P2 — multi-hop flood.** An event is pushed to the whole Circle's relays
+//! (`ws://[fd00::peer]:4869`) — every member, not just direct neighbours, so a
+//! peer reachable only multi-hop over the mesh still receives it — carrying a
+//! decrementing `event-ttl`:
 //!
 //! - **Local origin** (a loopback publish from the in-app nsite) originates at
 //!   `DEFAULT_EVENT_TTL`.
@@ -112,9 +114,12 @@ impl Gossiper for MeshGossiper {
         }
         let frame = serde_json::json!(["EVENT", ev_json]).to_string();
 
-        // Fan out over persistent pooled connections (no per-message connect),
-        // skipping the peer it came from (split-horizon).
-        for npub in self.content.connected_circle_npubs() {
+        // Fan out to the *whole* Circle over persistent pooled connections (no
+        // per-message connect), skipping the peer it came from (split-horizon). Not
+        // just direct neighbours: a Circle peer reachable only multi-hop (you've
+        // moved apart) must still get the message — the routed dial handles it, an
+        // offline member's connect fails fast. See `docs/design/event-gossip.md`.
+        for npub in self.content.circle_npubs() {
             let ip = match fips::PeerIdentity::from_npub(&npub) {
                 Ok(p) => IpAddr::V6(p.address().to_ipv6()),
                 Err(_) => continue,


### PR DESCRIPTION
## What

Two paired devices couldn't exchange bitchat messages once they were **more than one hop apart** on the mesh — even though the mesh still routed between them. This makes chat fan out to your **whole Circle**, so paired peers keep reaching each other as they move apart, which is the core promise of the app.

## Root cause

The gossip push fan-out targeted `connected_circle_npubs()` — the Circle **intersected with the direct-neighbour snapshot**:

`PeerView.connected` = `is_active` = the peer is in the node's **direct-link** peer table (`self.peers`, each carrying a `link_id`), which is separate from `self.sessions` (end-to-end, possibly multi-hop).

So a Circle member reachable only over a **multi-hop session** is absent from that table, gets filtered out of the chat-eligible set, and is never pushed to. Observed on a real device: A52 was paired with `teal juno`, held a live multi-hop session to it (MMP `session metrics`, and A52 was even forwarding traffic for other nodes), yet `connected_circle_npubs()` was empty because its only Circle member wasn't a *direct* neighbour — so chat went nowhere.

## Fix

- Add `circle_npubs()` — every Circle member, no direct-neighbour filter.
- Fan chat/presence to it. The routed `ws://[fd00::peer]:4869` dial reaches a multi-hop member over the existing session; a truly-offline member's connect fails fast and is dropped by the peer-relay pool.
- `connected_circle_npubs()` stays for the offline-timeout-sensitive content pulls (`open_site`), where dialling an offline member's relay would waste a timeout.

Symmetric: each device pushes to its own full Circle, so once both sides run this, messages flow both ways regardless of hop distance.

## Tests

- New assertion in the existing circle test: a non-direct Circle member appears in `circle_npubs()` but not `connected_circle_npubs()`.
- `cargo build`, `cargo test -p myco-core` (21 pass), `cargo fmt --check`, and `./gradlew assembleDebug` all pass.
- The multi-hop delivery itself is on-device behaviour (two phones, moved apart); to verify manually: pair A↔B, confirm chat, then separate them so B is only reachable via a third hop, and confirm messages still arrive.

## Scope / follow-ups

This is the **live push plane** only. Left unchanged, as deliberate follow-ups:
- **Backlog history** (`pull_recent_chat`) still fires on the *direct*-connect edge, so a multi-hop peer's prior history isn't auto-pulled (live messages still flow).
- **req-ttl discovery/pull** fan-out still uses the direct set.

Both want a proper **mesh-reachability signal** to keep the offline-dial guard and re-pull semantics — the embedder only sees the direct-peer table today, so a clean version needs a small reachability view. Filed as a follow-up rather than bolted on here.

Note: requires **mutual pairing** — the receiving peer's relay `CircleGate` still gates on its own Circle, so both sides must have each other paired.

No linked issue (searched open issues — none matched).
