### PR TITLE
fix: keepwarm Circle relay links + resubscribe on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   messages stopped flowing — even though the mesh could still route between them.
   Chat now fans out to your whole Circle, so a paired peer keeps receiving your
   messages wherever they are on the mesh, not just when they're a direct neighbour.
+- When a device in the middle of a mesh chain dropped and reconnected, the relay
+  links between Circle members restored slowly and often only one-way, so messages
+  stalled or flowed in a single direction for up to a minute. Each device now
+  proactively keeps a live relay connection to every Circle member and re-establishes
+  it within seconds of a flap — both directions — and on reconnect it recreates the
+  app's open subscriptions against the returned peer to pull back anything missed,
+  wherever that peer sits in the mesh.
 
 ## [0.1.0] - 2026-06-30
 

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -229,6 +229,15 @@ pub struct Content {
     /// fetches don't pay a fresh connect per message (slow over BLE). `Arc` so a
     /// mesh `PeerSource` can borrow the same pool for its manifest REQs.
     peer_relays: Arc<crate::peer_relay::PeerRelayPool>,
+    /// Raw filters of the subscriptions in-app clients currently have open on our
+    /// loopback relay, keyed by the relay's per-connection sub key. Fed by the relay
+    /// via the gossiper hooks; the core stores them **verbatim** (it never interprets
+    /// kinds). On a Circle peer reappearing, these are replayed to it to pull the
+    /// backlog the client missed — see [`Content::resync_from_peer`].
+    active_local_subs: Mutex<HashMap<String, Vec<serde_json::Value>>>,
+    /// The set of Circle peers the pool last reported as connected — diffed each
+    /// keepwarm tick to spot the absent→present (reappeared) edge.
+    prev_pool_connected: Mutex<HashSet<String>>,
     /// host_label -> a newer version being staged (downloaded) before activation.
     /// See `docs/design/nsite-updates.md` §2. P-U1: staged outside the relay store;
     /// activation stores the manifest (making it the served version).
@@ -354,6 +363,8 @@ impl Content {
             device_name_override: Mutex::new(None),
             pending_pairs: Mutex::new(Vec::new()),
             peer_relays: Arc::new(crate::peer_relay::PeerRelayPool::new()),
+            active_local_subs: Mutex::new(HashMap::new()),
+            prev_pool_connected: Mutex::new(HashSet::new()),
             pending_updates: Mutex::new(HashMap::new()),
             update_check: Mutex::new(UpdateCheckView::default()),
             active_manifests: Mutex::new(active_manifests),
@@ -1075,33 +1086,85 @@ impl Content {
         );
     }
 
-    // --- backlog pull (the read counterpart of fan-out) ---
+    // --- local subscription registry (recreated against reappearing peers) ---
 
-    /// Pull recent chat (kind 9) from a peer's relay into the local store, so a
-    /// freshly-opened nsite sees history it missed while the push flood is the live
-    /// path. Best-effort, hard-bounded; stored events surface on the nsite's next
-    /// REQ. (The efficient negentropy version is future work — needs NIP-77 on the
-    /// relay.) `npub` is a connected Circle peer.
-    pub async fn pull_recent_chat(&self, npub: &str) {
+    /// The relay reports a local (in-app) client opening a `REQ`. We keep its raw
+    /// filters — **without interpreting them** — so we can recreate the subscription
+    /// against Circle peers as they (re)appear. Called from the gossiper hook.
+    pub fn record_local_sub(&self, key: String, filters: Vec<serde_json::Value>) {
+        self.active_local_subs.lock().unwrap().insert(key, filters);
+    }
+
+    /// The relay reports a local client's subscription closing (`CLOSE` or the
+    /// connection dropping).
+    pub fn drop_local_sub(&self, key: &str) {
+        self.active_local_subs.lock().unwrap().remove(key);
+    }
+
+    // --- backlog resync (the read counterpart of fan-out) ---
+
+    /// Recreate every open local subscription against `npub`'s relay: replay each
+    /// client's filters to the peer and fold its matching events into our store, so
+    /// a freshly-reachable Circle peer delivers the backlog our clients missed while
+    /// it was away. myco is filter-agnostic here — it just re-runs whatever the
+    /// in-app clients are subscribed to; it has no notion of chat vs anything else.
+    /// Best-effort and hard-bounded. Runs on the pool's (re)connect edge — so it
+    /// covers a Circle peer reachable only multi-hop, which the direct-neighbour
+    /// snapshot never surfaced.
+    pub async fn resync_from_peer(&self, npub: &str) {
+        let subs = {
+            let guard = self.active_local_subs.lock().unwrap();
+            if guard.is_empty() {
+                return;
+            }
+            guard.values().cloned().collect::<Vec<_>>()
+        };
         let Ok(peer) = fips::PeerIdentity::from_npub(npub) else {
             return;
         };
         let url = format!("ws://[{}]:4869", peer.address().to_ipv6());
-        // kind 9 is the v1 chat kind (myco-bitchat); generalize when more apps land.
-        let filter = serde_json::json!({ "kinds": [9], "limit": 100 });
-        let events = self
-            .peer_relays
-            .request(npub, &url, vec![filter], std::time::Duration::from_secs(15))
-            .await;
         let mut stored = 0u32;
-        for ev in events {
-            if ev.verify().is_ok() && self.relay.store_event(ev).await.unwrap_or(false) {
-                stored += 1;
+        for filters in subs {
+            let events = self
+                .peer_relays
+                .request(npub, &url, filters, std::time::Duration::from_secs(15))
+                .await;
+            for ev in events {
+                if ev.verify().is_ok() && self.relay.store_event(ev).await.unwrap_or(false) {
+                    stored += 1;
+                }
             }
         }
         if stored > 0 {
-            tracing::debug!(npub, stored, "pulled chat backlog from peer");
+            tracing::debug!(npub, stored, "resynced backlog from reappeared peer");
         }
+    }
+
+    /// One keepwarm pass (driven by a runtime tick): ensure a live pooled connection
+    /// to every Circle member — so a dropped connection is respawned promptly, not
+    /// lazily on the next outbound frame — and, for each member the pool has just
+    /// (re)connected (absent→present since last pass), spawn a backlog resync. This
+    /// is what restores a Circle relay link **mutually and fast** after a mesh flap,
+    /// regardless of where the peer sits in the mesh.
+    pub fn keepwarm_tick(self: &Arc<Self>) {
+        let circle: HashSet<String> = self.circle_npubs().into_iter().collect();
+        for npub in &circle {
+            if let Ok(peer) = fips::PeerIdentity::from_npub(npub) {
+                let url = format!("ws://[{}]:4869", peer.address().to_ipv6());
+                self.peer_relays.ensure(npub, &url);
+            }
+        }
+        let now = self.peer_relays.connected_npubs();
+        let mut prev = self.prev_pool_connected.lock().unwrap();
+        // Newly-connected Circle members → recreate their subscriptions.
+        for npub in now.difference(&prev) {
+            if circle.contains(npub) {
+                let me = self.clone();
+                let npub = npub.clone();
+                tokio::spawn(async move { me.resync_from_peer(&npub).await });
+            }
+        }
+        *prev = now;
     }
 
     // --- mesh fan-out ---

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -144,6 +144,14 @@ impl Gossiper for MeshGossiper {
             .pull_from_peers(filters, req_ttl, exclude)
             .await
     }
+
+    fn on_local_subscribe(&self, key: &str, filters: Vec<serde_json::Value>) {
+        self.content.record_local_sub(key.to_string(), filters);
+    }
+
+    fn on_local_unsubscribe(&self, key: &str) {
+        self.content.drop_local_sub(key);
+    }
 }
 
 #[cfg(test)]

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -25,8 +25,8 @@
 //! interval catches the silent half-open; either drops the task, and the next
 //! command lazily reopens a fresh connection.
 
-use std::collections::HashMap;
-use std::sync::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
@@ -36,10 +36,11 @@ use tokio_tungstenite::tungstenite::Message;
 
 /// Keepalive cadence: send a WS ping this often on an otherwise-idle connection.
 /// If a whole interval passes with **no inbound frame at all** (not even the pong),
-/// the connection is treated as dead and the task exits so the next command
-/// reconnects. Short enough to catch a silent half-open in seconds, not the TCP
-/// retransmit horizon; long enough not to chatter over BLE.
-const PING_INTERVAL: Duration = Duration::from_secs(20);
+/// the connection is treated as dead and the task exits so it can reconnect. Short
+/// enough to catch a silent half-open in seconds (a middle-node flap blackholes the
+/// route with no RST), not the TCP retransmit horizon; long enough not to chatter
+/// over BLE. The runtime's keepwarm loop respawns the dropped task promptly.
+const PING_INTERVAL: Duration = Duration::from_secs(10);
 
 /// A command sent to a peer's connection actor over its channel.
 enum Command {
@@ -66,6 +67,12 @@ pub struct PeerRelayPool {
     /// Per-peer command channel to its live actor task. A closed sender means the
     /// task exited (connection died / connect failed); the next use respawns it.
     peers: Mutex<HashMap<String, mpsc::UnboundedSender<Command>>>,
+    /// npubs whose actor currently holds a **live, connected** socket — set once
+    /// `connect_async` succeeds, cleared when the task exits. The runtime diffs this
+    /// each keepwarm tick: a peer transitioning absent→present is the "reappeared"
+    /// edge that drives a resubscribe. Distinct from `peers` (which has an entry
+    /// during the connecting window too).
+    connected: Arc<Mutex<HashSet<String>>>,
 }
 
 impl PeerRelayPool {
@@ -73,10 +80,25 @@ impl PeerRelayPool {
         Self::default()
     }
 
+    /// npubs that currently hold a live connected socket (see [`Self::connected`]).
+    pub fn connected_npubs(&self) -> HashSet<String> {
+        self.connected.lock().unwrap().clone()
+    }
+
+    /// Ensure `npub` has a running actor (which lazily connects) at `url`, without
+    /// sending anything. The runtime's keepwarm loop calls this for every Circle
+    /// member so a dropped connection is respawned promptly — not lazily on the next
+    /// outbound frame — restoring both directions fast after a mesh flap.
+    pub fn ensure(&self, npub: &str, url: &str) {
+        let mut peers = self.peers.lock().unwrap();
+        let _ = self.spawn_or_get(&mut peers, npub, url);
+    }
+
     /// Get a live command channel for `npub`'s connection at `url`, spawning the
     /// actor (which lazily connects) if there isn't a running one. Caller holds the
     /// map lock.
-    fn actor(
+    fn spawn_or_get(
+        &self,
         peers: &mut HashMap<String, mpsc::UnboundedSender<Command>>,
         npub: &str,
         url: &str,
@@ -89,8 +111,12 @@ impl PeerRelayPool {
         }
         let (tx, rx) = mpsc::unbounded_channel::<Command>();
         peers.insert(npub.to_string(), tx.clone());
-        let url = url.to_string();
-        tokio::spawn(run(url, rx));
+        tokio::spawn(run(
+            url.to_string(),
+            npub.to_string(),
+            rx,
+            self.connected.clone(),
+        ));
         tx
     }
 
@@ -100,7 +126,7 @@ impl PeerRelayPool {
     /// buffered in the channel and flushed on connect.
     pub fn send(&self, npub: &str, url: &str, frame: String) {
         let mut peers = self.peers.lock().unwrap();
-        let tx = Self::actor(&mut peers, npub, url);
+        let tx = self.spawn_or_get(&mut peers, npub, url);
         // Lost the race with a task that just exited: drop the entry so the next
         // publish respawns. Rare, and the push plane is best-effort (the pull plane
         // recovers backlog on reconnect).
@@ -123,7 +149,7 @@ impl PeerRelayPool {
         let (reply_tx, reply_rx) = oneshot::channel();
         {
             let mut peers = self.peers.lock().unwrap();
-            let tx = Self::actor(&mut peers, npub, url);
+            let tx = self.spawn_or_get(&mut peers, npub, url);
             if tx
                 .send(Command::Request {
                     filters,
@@ -145,10 +171,17 @@ impl PeerRelayPool {
 
 /// The per-peer connection actor: connect once, then multiplex push + pull + ping
 /// over the one socket until it dies or the pool drops the command channel.
-async fn run(url: String, mut cmd_rx: mpsc::UnboundedReceiver<Command>) {
+async fn run(
+    url: String,
+    npub: String,
+    mut cmd_rx: mpsc::UnboundedReceiver<Command>,
+    connected: Arc<Mutex<HashSet<String>>>,
+) {
     let Ok((ws, _)) = tokio_tungstenite::connect_async(&url).await else {
         return; // connect failed → channel drops with this task → next command respawns
     };
+    // Live now — mark reachable so the keepwarm loop sees the (re)connect edge.
+    connected.lock().unwrap().insert(npub.clone());
     let (mut sink, mut stream) = ws.split();
     let mut pending: HashMap<String, Pending> = HashMap::new();
     let mut next_sub: u64 = 0;
@@ -227,6 +260,9 @@ async fn run(url: String, mut cmd_rx: mpsc::UnboundedReceiver<Command>) {
             }
         }
     }
+    // No longer reachable — clear the flag so the keepwarm loop respawns us and
+    // sees a fresh (re)connect edge when the peer comes back.
+    connected.lock().unwrap().remove(&npub);
     // Pending replies drop here → their `request` callers get an empty batch.
     let _ = sink.send(Message::Close(None)).await;
 }
@@ -329,5 +365,36 @@ mod tests {
             )
             .await;
         assert!(got.is_empty());
+    }
+
+    /// `ensure` connects without a frame to send, and marks the peer connected —
+    /// this is the keepwarm reconnect-edge signal the runtime diffs.
+    #[tokio::test]
+    async fn ensure_connects_and_reports_connected() {
+        let (_store, url) = spawn_relay().await;
+        let pool = PeerRelayPool::new();
+        assert!(!pool.connected_npubs().contains("peerZ"));
+        pool.ensure("peerZ", &url);
+        let up = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if pool.connected_npubs().contains("peerZ") {
+                    return true;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap_or(false);
+        assert!(up, "ensure should connect and mark the peer connected");
+    }
+
+    /// `ensure` to an unreachable peer never reports it connected (connect fails, the
+    /// actor exits without inserting into the connected set).
+    #[tokio::test]
+    async fn ensure_dead_peer_stays_absent() {
+        let pool = PeerRelayPool::new();
+        pool.ensure("peerNope", "ws://127.0.0.1:1");
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert!(!pool.connected_npubs().contains("peerNope"));
     }
 }

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -43,9 +43,6 @@ pub struct AppRuntime {
     /// The content layer (embedded relay + Blossom + gateway + Library). `None`
     /// only on a startup error (no valid data dir).
     content: Option<Arc<Content>>,
-    /// Circle peers we've already pulled chat backlog from this connection, so we
-    /// pull once per (re)connect rather than every state poll.
-    pulled_chat_from: std::sync::Mutex<std::collections::HashSet<String>>,
     /// Latest dev-menu peer speedtest result; written by the spawned run task and
     /// read back into `state()`. Shared so the async task can update it in place.
     speedtest: Arc<std::sync::Mutex<crate::state::SpeedtestView>>,
@@ -197,6 +194,23 @@ impl AppRuntime {
                     mesh_warning.push_str(&format!("blossom port 24242 unavailable: {e}"));
                 }
             }
+
+            // Keepwarm: proactively hold a live relay connection to every Circle
+            // member (respawn a dropped one promptly, not lazily on the next send)
+            // and resubscribe on each peer's reconnect edge. This is what restores a
+            // Circle relay link *mutually and fast* after a mid-chain node flaps —
+            // independent of chat traffic and of where the peer sits in the mesh.
+            {
+                let content = content.clone();
+                rt.spawn(async move {
+                    let mut tick = tokio::time::interval(std::time::Duration::from_secs(8));
+                    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                    loop {
+                        tick.tick().await;
+                        content.keepwarm_tick();
+                    }
+                });
+            }
         }
 
         Ok(Self {
@@ -213,7 +227,6 @@ impl AppRuntime {
             read_handle: None,
             loop_task: None,
             content: Some(content),
-            pulled_chat_from: std::sync::Mutex::new(std::collections::HashSet::new()),
             speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
         })
     }
@@ -260,7 +273,6 @@ impl AppRuntime {
             read_handle: None,
             loop_task: None,
             content: None,
-            pulled_chat_from: std::sync::Mutex::new(std::collections::HashSet::new()),
             speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
         }
     }
@@ -609,30 +621,17 @@ impl AppRuntime {
                 .collect();
             content.set_connected_peers(connected);
 
-            // Pull chat backlog once per newly-connected Circle peer (the read
-            // counterpart of the push flood) so a freshly-opened nsite has history.
+            // Backlog resync is driven by the keepwarm loop's reconnect edge
+            // (`Content::keepwarm_tick`), which recreates each in-app subscription
+            // against a Circle peer as it (re)appears — direct *or* multi-hop.
             if let Some(rt) = self.rt.as_ref() {
-                let conn: std::collections::HashSet<String> =
-                    content.connected_circle_npubs().into_iter().collect();
-                let mut pulled = self.pulled_chat_from.lock().unwrap();
-                for npub in &conn {
-                    if pulled.insert(npub.clone()) {
-                        // First poll where this Circle peer is reachable: pull chat
-                        // backlog (the read counterpart of the push flood).
-                        let content = content.clone();
-                        let npub = npub.clone();
-                        rt.spawn(async move { content.pull_recent_chat(&npub).await });
-                    }
-                }
-                pulled.retain(|n| conn.contains(n)); // re-pull on reconnect
-                drop(pulled);
-
-                // Retry not-ready downloads while any Circle peer is reachable.
+                // Retry not-ready downloads while any direct Circle peer is reachable.
                 // open_site(_, None) tries every connected peer, and
                 // `retriable_library_addrs` skips sites already syncing — so this
                 // re-tries about once per attempt-duration (not every poll), and
                 // keeps trying as a flaky just-connected session settles, instead of
                 // firing once on the connect edge and going quiet.
+                let conn = content.connected_circle_npubs();
                 if !conn.is_empty() {
                     for addr in content.retriable_library_addrs() {
                         let content = content.clone();

--- a/myco-relay/src/server.rs
+++ b/myco-relay/src/server.rs
@@ -73,6 +73,20 @@ pub trait Gossiper: Send + Sync {
     ) -> Vec<Event> {
         Vec::new()
     }
+
+    /// A **local** (loopback / in-app) client opened a `REQ`. The implementor
+    /// records the raw `filters` so it can *recreate* this subscription against a
+    /// Circle peer that (re)appears on the mesh — pulling that peer's matching
+    /// backlog into the store so the client sees what it missed. The relay passes
+    /// the filters verbatim; the core never interprets them (it has no notion of
+    /// which kinds a given nsite cares about). `key` is unique per open
+    /// subscription for the lifetime of the connection. Mesh-origin `REQ`s are
+    /// never reported here — only local clients' own interests. Default: no-op.
+    fn on_local_subscribe(&self, _key: &str, _filters: Vec<serde_json::Value>) {}
+
+    /// A local client's subscription `key` closed (explicit `CLOSE`, or the
+    /// connection dropped). Default: no-op.
+    fn on_local_unsubscribe(&self, _key: &str) {}
 }
 
 /// Access policy for **mesh** connections: only paired (Circle) peers may read or
@@ -217,19 +231,22 @@ async fn handle_ws(socket: WebSocket, hub: Arc<RelayHub>, peer_ip: IpAddr) {
     } else {
         Origin::Mesh
     };
+    // A per-connection id so a local client's `REQ` sub_ids are globally unique in
+    // the core's active-subscription registry (two connections can both use "s1").
+    let conn_id = NEXT_CONN_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let (mut ws_tx, mut ws_rx) = socket.split();
     let mut live = hub.live.subscribe();
     // Active subscriptions on this connection: sub_id -> its filters.
     let mut subs: HashMap<String, Vec<ManifestFilter>> = HashMap::new();
 
-    loop {
+    'conn: loop {
         tokio::select! {
             incoming = ws_rx.next() => {
                 match incoming {
                     Some(Ok(Message::Text(text))) => {
-                        for reply in handle_client_frame(text.as_str(), &hub, origin, peer_ip, &mut subs).await {
+                        for reply in handle_client_frame(text.as_str(), &hub, origin, peer_ip, conn_id, &mut subs).await {
                             if ws_tx.send(Message::text(reply)).await.is_err() {
-                                return;
+                                break 'conn;
                             }
                         }
                     }
@@ -241,11 +258,11 @@ async fn handle_ws(socket: WebSocket, hub: Arc<RelayHub>, peer_ip: IpAddr) {
                         // explicitly guarantees the pong is flushed on an otherwise
                         // idle subscription.
                         if ws_tx.send(Message::Pong(payload)).await.is_err() {
-                            return;
+                            break 'conn;
                         }
                     }
-                    Some(Ok(Message::Close(_))) | None => return,
-                    Some(Err(_)) => return,
+                    Some(Ok(Message::Close(_))) | None => break 'conn,
+                    Some(Err(_)) => break 'conn,
                     _ => {}
                 }
             }
@@ -256,7 +273,7 @@ async fn handle_ws(socket: WebSocket, hub: Arc<RelayHub>, peer_ip: IpAddr) {
                             if filters.iter().any(|f| matches_filter(&ev, f)) {
                                 let frame = serde_json::json!(["EVENT", sub_id, ev]).to_string();
                                 if ws_tx.send(Message::text(frame)).await.is_err() {
-                                    return;
+                                    break 'conn;
                                 }
                             }
                         }
@@ -264,12 +281,39 @@ async fn handle_ws(socket: WebSocket, hub: Arc<RelayHub>, peer_ip: IpAddr) {
                     // Lagged: this slow subscriber missed some events — skip them
                     // and carry on rather than dropping the connection.
                     Err(broadcast::error::RecvError::Lagged(_)) => {}
-                    Err(broadcast::error::RecvError::Closed) => return,
+                    Err(broadcast::error::RecvError::Closed) => break 'conn,
                 }
             }
         }
     }
+    finish_conn(&hub, origin, conn_id, &subs);
 }
+
+/// Tear down a connection's local subscriptions in the core's registry (so a
+/// dropped in-app client stops being replayed to reappearing peers).
+fn finish_conn(
+    hub: &Arc<RelayHub>,
+    origin: Origin,
+    conn_id: u64,
+    subs: &HashMap<String, Vec<ManifestFilter>>,
+) {
+    if origin != Origin::Local {
+        return;
+    }
+    if let Some(gossip) = &hub.gossip {
+        for sub_id in subs.keys() {
+            gossip.on_local_unsubscribe(&sub_key(conn_id, sub_id));
+        }
+    }
+}
+
+/// The registry key for one local subscription: unique across connections.
+fn sub_key(conn_id: u64, sub_id: &str) -> String {
+    format!("{conn_id}:{sub_id}")
+}
+
+/// Monotonic per-connection id source (see [`handle_ws`]).
+static NEXT_CONN_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Handle one client frame, mutating `subs` and returning the frames to send back.
 async fn handle_client_frame(
@@ -277,6 +321,7 @@ async fn handle_client_frame(
     hub: &Arc<RelayHub>,
     origin: Origin,
     peer_ip: IpAddr,
+    conn_id: u64,
     subs: &mut HashMap<String, Vec<ManifestFilter>>,
 ) -> Vec<String> {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
@@ -347,6 +392,17 @@ async fn handle_client_frame(
             // Keep the subscription open so matching new events stream live.
             subs.insert(sub_id.clone(), filters);
 
+            // Record a *local* client's interest so the core can recreate this
+            // subscription against Circle peers that reappear on the mesh (pulling
+            // their missed backlog). Mesh REQs are peers' interests, not ours, and
+            // are never recorded. The filters are passed verbatim — the core does
+            // not interpret them.
+            if origin == Origin::Local {
+                if let Some(gossip) = &hub.gossip {
+                    gossip.on_local_subscribe(&sub_key(conn_id, &sub_id), raw_filters.clone());
+                }
+            }
+
             let mut out: Vec<String> = events
                 .iter()
                 .map(|e| serde_json::json!(["EVENT", sub_id, e]).to_string())
@@ -415,6 +471,11 @@ async fn handle_client_frame(
         Some("CLOSE") => {
             if let Some(sub_id) = array.get(1).and_then(|v| v.as_str()) {
                 subs.remove(sub_id);
+                if origin == Origin::Local {
+                    if let Some(gossip) = &hub.gossip {
+                        gossip.on_local_unsubscribe(&sub_key(conn_id, sub_id));
+                    }
+                }
             }
             Vec::new()
         }
@@ -641,5 +702,79 @@ mod tests {
         // 127.0.0.1 is loopback → Local origin, no sender (originator stamps TTL).
         assert_eq!(seen[0].1.origin, Origin::Local);
         assert_eq!(seen[0].1.sender, None);
+    }
+
+    /// A loopback client's REQ is reported to the gossiper as a local subscription
+    /// (raw filters passed verbatim), and its CLOSE as an unsubscribe — the seam the
+    /// core uses to recreate subscriptions against reappearing peers, filter-blind.
+    #[tokio::test]
+    async fn local_req_reports_subscription_to_gossiper() {
+        use std::sync::Mutex;
+
+        struct SubCap {
+            subs: Mutex<Vec<(String, Vec<serde_json::Value>)>>,
+            unsubs: Mutex<Vec<String>>,
+        }
+        #[async_trait]
+        impl Gossiper for SubCap {
+            async fn on_event(&self, _event: Event, _inbound: Inbound) {}
+            fn on_local_subscribe(&self, key: &str, filters: Vec<serde_json::Value>) {
+                self.subs.lock().unwrap().push((key.to_string(), filters));
+            }
+            fn on_local_unsubscribe(&self, key: &str) {
+                self.unsubs.lock().unwrap().push(key.to_string());
+            }
+        }
+
+        let store = Arc::new(RelayStore::in_memory());
+        let cap = Arc::new(SubCap {
+            subs: Mutex::new(Vec::new()),
+            unsubs: Mutex::new(Vec::new()),
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_on_with(store, listener, Some(cap.clone())));
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+            .await
+            .unwrap();
+        let filter = serde_json::json!({ "kinds": [9], "#d": ["mesh"] });
+        ws.send(WsMessage::Text(
+            serde_json::json!(["REQ", "s1", filter]).to_string().into(),
+        ))
+        .await
+        .unwrap();
+        // Drain to EOSE so the REQ has been handled.
+        while let Some(Ok(WsMessage::Text(t))) = ws.next().await {
+            let v: serde_json::Value = serde_json::from_str(&t).unwrap();
+            if v[0] == "EOSE" {
+                break;
+            }
+        }
+
+        let subs = cap.subs.lock().unwrap().clone();
+        assert_eq!(
+            subs.len(),
+            1,
+            "loopback REQ reported as a local subscription"
+        );
+        assert_eq!(
+            subs[0].1,
+            vec![serde_json::json!({ "kinds": [9], "#d": ["mesh"] })],
+            "raw filters passed through verbatim (core never interprets them)"
+        );
+
+        ws.send(WsMessage::Text(
+            serde_json::json!(["CLOSE", "s1"]).to_string().into(),
+        ))
+        .await
+        .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let unsubs = cap.unsubs.lock().unwrap().clone();
+        assert_eq!(
+            unsubs,
+            vec![subs[0].0.clone()],
+            "CLOSE reports the same key"
+        );
     }
 }


### PR DESCRIPTION
> **Stacked on #8** (`fix/chat-mesh-reach`) — it needs `circle_npubs()`. Based on that branch so the diff is only this change; retarget to `main` once #8 merges.

## What

When a paired device in the **middle** of a mesh chain dropped and reconnected, the relay links between Circle members restored **slowly and often only one-way** — messages stalled or flowed in a single direction for up to a minute. This makes those links restore **mutually, fast, and reliably**, wherever the peer sits in the mesh.

## Root cause

- The peer-relay pool reconnected **lazily and per-direction**: a dead connection was respawned only on that device's *next* outbound frame (a chat message, or the 60s presence beat). A quiet direction stayed dead for up to a minute → one-way.
- Detection of a **blackholed route** (a middle-node drop vanishes the route with no RST) lagged by up to one ~20s ping interval.
- Backlog recovery (`pull_recent_chat`) fired only on the **direct-connect edge** and **hardcoded `{kinds:[9]}`** — blind to multi-hop peers and to any nsite that isn't bitchat.

## Fix — three parts, all myco-layer

1. **Pool** (`peer_relay.rs`): track per-peer *connected* state; add `ensure(npub, url)` (spawn/connect without a frame). `PING_INTERVAL` 20s → 10s for faster half-open catch.
2. **Runtime keepwarm** (`runtime.rs`): an 8s background tick ensures a live connection to every Circle member (proactive, both directions) and diffs the pool's connected set — a member going absent→present is the reconnect edge.
3. **Resubscribe, filter-agnostically** (`server.rs` + `content.rs`): the relay now reports each **local** client's open `REQ` filters to the core via new `Gossiper` hooks (`on_local_subscribe` / `on_local_unsubscribe`). The core stores them **verbatim — it never interprets kinds** — and, on a peer's reconnect edge, replays them to that peer to pull the backlog the client missed. This replaces the kind-9 `pull_recent_chat` and its direct-edge trigger, and works for multi-hop Circle peers and any nsite.

myco stays a dumb pipe here: it has no notion of what a subscription *means*; it just recreates whatever the in-app clients are subscribed to when a peer reappears.

## Result

After a mid-chain flap, both directions restore within ~8–10s (not up to 60s / one-way), and the returned peer's missed messages are pulled by replaying whatever the app was subscribed to.

## Tests

- `peer_relay`: `ensure` connects and reports connected; a dead peer stays absent.
- `myco-relay`: a loopback `REQ`/`CLOSE` is reported as a local sub/unsub with **verbatim** filters.
- `cargo test` (22 core + 10 relay), `cargo fmt --check`, `./gradlew assembleDebug` all pass.
- On-device behaviour (a real mid-chain flap across three phones) isn't unit-testable; to verify manually: A—B—C, drop/restore B, confirm A↔C chat resumes both ways within seconds and backlog fills in.

## Tradeoffs

Keepwarm attempts a connect to *offline* Circle members every 8s (cheap — an unroutable `fd00::` fails fast, no BLE dial), and the 10s ping is slightly more keepalive per live link. The cost of fast + reliable.

No linked issue (searched open issues — none matched).
