### PR TITLE
chore: bump embedded relay/Blossom ports to 4870 / 24243

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The in-app Blossom store now accepts uploads up to 64 MiB, so larger nsite
   blobs and the new speedtest payload transfer in a single request.
+- The embedded Nostr relay and Blossom server now listen on **4870** and
+  **24243** — one above the previous `4869` / `24242`. This stops Myco from
+  squatting on the ports a developer's own localhost relay or Blossom may
+  already use. The localhost and mesh binds share the same port number, so both
+  moved together and peer sync is unaffected. Temporary until the ports become
+  configurable. The experimental Wi-Fi Aware lane moves to **4871** so it no
+  longer shares 4870 with the relay.
 
 ### Fixed
 

--- a/android/app/src/main/java/app/myco/NsiteActivity.kt
+++ b/android/app/src/main/java/app/myco/NsiteActivity.kt
@@ -119,7 +119,7 @@ class NsiteActivity : ComponentActivity() {
 
         // Serve the WebView under `.localhost` (not `.nsite`): Chromium treats
         // `*.localhost` as loopback + a secure context, so the nsite's
-        // `ws://localhost:4869` to the embedded relay isn't blocked by Private/
+        // `ws://localhost:4870` to the embedded relay isn't blocked by Private/
         // Local Network Access (a `.nsite` page is classed "public" → blocked).
         webView.loadUrl("http://$hostLabel.localhost/")
     }

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -252,16 +252,16 @@ fun MycoApp(
         }
     }
 
-    // Loud warning if our local relay couldn't bind 4869 (another relay holds it):
+    // Loud warning if our local relay couldn't bind 4870 (another relay holds it):
     // nsites would talk to that foreign relay and show messages that aren't yours.
     var relayWarnDismissed by remember { mutableStateOf(false) }
-    if (state.error.contains("4869") && !relayWarnDismissed) {
+    if (state.error.contains("4870") && !relayWarnDismissed) {
         AlertDialog(
             onDismissRequest = { relayWarnDismissed = true },
             title = { Text("Another relay is running") },
             text = {
                 Text(
-                    "Port 4869 is in use by another app, so Myco's own relay couldn't " +
+                    "Port 4870 is in use by another app, so Myco's own relay couldn't " +
                         "start. Your apps may talk to the wrong relay — including showing " +
                         "messages that aren't yours. Close the other app and restart Myco.\n\n" +
                         state.error,

--- a/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
+++ b/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * normal internet traffic is untouched — this is not a full-tunnel VPN.
  *
  * The node installs the bridge channels when it starts (BLE on); this service just
- * moves bytes. With it up, a native socket to `[fd00::peer]:4869/:24242` routes
+ * moves bytes. With it up, a native socket to `[fd00::peer]:4870/:24243` routes
  * over the mesh, so the sync engine can pull a shared nsite from a peer's device.
  */
 class MycoVpnService : VpnService() {

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   The in-app nsite WebView talks to the device's embedded relay
-  (ws://localhost:4869) and Blossom (http://localhost:24242) over **cleartext
+  (ws://localhost:4870) and Blossom (http://localhost:24243) over **cleartext
   loopback**. targetSdk >= 28 blocks cleartext by default, which surfaces in the
   WebView as net::ERR_CLEARTEXT_NOT_PERMITTED on the WebSocket. Permit cleartext
   for loopback only; every other destination stays TLS-only (the default).

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,8 +86,8 @@ tooling, and an nsite's **author** is a separate, external key that appears only
 as the `<npub_author>.nsite` URL host and the `authors` filter in relay queries.
 The app holds and serves authors' already-signed events but never holds their
 secret key and never signs on their behalf. The backend is **Rust** — the
-embedded relay (`ws://localhost:4869`), Blossom server
-(`http://localhost:24242`), and FIPS endpoint are unified into one `myco-core`
+embedded relay (`ws://localhost:4870`), Blossom server
+(`http://localhost:24243`), and FIPS endpoint are unified into one `myco-core`
 crate behind a single JNI/JSON FFI surface. Kotlin owns the UI, the WebView, the
 BLE radio, and the kept Android `VpnService`/TUN; the TUN routes only `fd00::/8`
 and DNS-intercepts `*.fips` (→ `fd00::`, IPv6 mesh sync) and `*.nsite`
@@ -133,7 +133,7 @@ look-it-up surface.
 
 | Doc | Description |
 | --- | --- |
-| [ports.md](./reference/ports.md) | The localhost ports (relay 4869, Blossom 24242, gateway) and exactly how each is — or is deliberately not — exposed over FIPS; the WebView/localhost vs sync-engine/`.fips` split. |
+| [ports.md](./reference/ports.md) | The localhost ports (relay 4870, Blossom 24243, gateway) and exactly how each is — or is deliberately not — exposed over FIPS; the WebView/localhost vs sync-engine/`.fips` split. |
 | [nostr-kinds.md](./reference/nostr-kinds.md) | The Nostr event kinds Myco reads, stores, and replicates: nsite manifests (15128 root / 35128 named) and FIPS discovery kinds. The app authors none of them. |
 | [config.md](./reference/config.md) | The proposed `config.toml` model (identity, node, cache, peers, BLE, propagation, DNS), the field reference, and what is explicitly stripped relative to nostr-vpn. |
 | [ffi-surface.md](./reference/ffi-surface.md) | The Kotlin↔Rust JNI/JSON reducer contract: opaque-handle lifecycle, the `dispatch(actionJson)→stateJson` reducer with a `rev` counter, the action/state shapes, and the BLE byte-bridge. |

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -45,7 +45,7 @@ The stack, top to bottom:
   1  Android UI            (Jetpack Compose) — Myco manager: Library, Pair, Discover, Settings
   2  NsiteActivity         (fullscreen WebView, one task per nsite) — loads http://<host>.nsite, no chrome
   3  Local gateway + DNS   — *.nsite → 127.0.0.1; resolve manifest; serve files
-  4  Embedded relay+Blossom (Rust) — myco-relay :4869 / myco-blossom :24242 + S&F cache
+  4  Embedded relay+Blossom (Rust) — myco-relay :4870 / myco-blossom :24243 + S&F cache
   5  myco-core / FFI      (Rust) — wires nsite-deck + relay + Blossom; binds into FIPS
   6  FIPS core + transports (upstream fips crate)  — mesh, crypto, BLE/UDP/TCP/Tor
      ── plus ── Android VpnService/TUN: routes fd00::/8, intercepts .fips/.nsite
@@ -67,8 +67,8 @@ any particular relay, blob store, or transport:
 | --- | --- | --- |
 | `myco-core` | app crate: FIPS endpoint, `AndroidBleIo`, JNI/JSON FFI, and the wiring that picks which backends to plug in | no — Myco-specific |
 | `nsite-deck` | the nsite host: gateway (manifest → path → sha256 → serve) + sync engine + the **propagator** (a process that subscribes to local + peer relays and publishes accepted events onward, and eager-refreshes pinned sites); impl-agnostic | **yes** — the reusable core |
-| `myco-relay` | a generic embedded Nostr relay (event store + `ws://…:4869` server) | yes — any Nostr app |
-| `myco-blossom` | a generic embedded Blossom blob store (content-addressed store + `http://…:24242` server) | yes — any Blossom need |
+| `myco-relay` | a generic embedded Nostr relay (event store + `ws://…:4870` server) | yes — any Nostr app |
+| `myco-blossom` | a generic embedded Blossom blob store (content-addressed store + `http://…:24243` server) | yes — any Blossom need |
 
 `nsite-deck` never names a concrete relay, blob store, or radio. It reaches
 everything outside itself through **four trait seams**, which `myco-core` wires up:
@@ -175,12 +175,12 @@ resolution logic ports from site-deck.
 and to peers. **Both are embedded from day one** — they are simple, and there is
 no good Android app to forward to:
 
-- the **relay** (`ws://localhost:4869`) stores/serves signed manifest events
+- the **relay** (`ws://localhost:4870`) stores/serves signed manifest events
   (kinds 15128/35128). The relay *backend* is a **pluggable seam**: the default
   is the embedded relay; optionally it can **forward to a local relay app (e.g.
   Citrine)** for devs who already run one. Embedding is the default and earliest
   path,
-- **Blossom** (`http://localhost:24242`) is **always embedded** — a small
+- **Blossom** (`http://localhost:24243`) is **always embedded** — a small
   content-addressed HTTP store (`GET /<sha256>`, `PUT /upload`, `HEAD`). There is
   no good Android Blossom app to forward to, so embedding is the only sensible
   path.
@@ -216,13 +216,13 @@ impls it plugs into `nsite-deck`'s storage seams). `myco-core`:
 - holds the device **identity** (the `nsec`) in `filesDir`,
 - instantiates `myco-relay` + `myco-blossom` (or a Citrine-forward `RelayBackend`),
   wires them into `nsite-deck` as the `RelayBackend` / `BlobStore`, and **binds
-  them into FIPS** so peers reach them at `<npub>.fips:4869` / `:24242` via FSP
+  them into FIPS** so peers reach them at `<npub>.fips:4870` / `:24243` via FSP
   port multiplexing,
 - drives the FIPS endpoint (layer 6) and implements `AndroidBleIo`,
 - implements the **transport seams** the content + relay crates consume over FIPS:
   the **`PeerSource`** (fetch a manifest + blobs from a holder at `<npub>.fips`,
   verify each against its sha256, retain in the local relay + Blossom) and the
-  **`FanoutSink`** (`EVENT` to each connected `<peer>.fips:4869`).
+  **`FanoutSink`** (`EVENT` to each connected `<peer>.fips:4870`).
 
 `myco-core`, `nsite-deck`, `myco-relay`, and `myco-blossom` cross-compile into one
 `libmyco_core.so`.
@@ -268,7 +268,7 @@ byte/­radio paths Kotlin must own:
 (npub → node_addr → `fd00::/8`), `.fips` DNS, spanning-tree formation,
 coordinate-based greedy routing, and two-layer Noise crypto (XK end-to-end +
 IK hop-by-hop). FSP **port multiplexing** delivers mesh datagrams to the
-localhost relay/Blossom ports, which is what exposes `<npub>.fips:4869`/`:24242`.
+localhost relay/Blossom ports, which is what exposes `<npub>.fips:4870`/`:24243`.
 
 **Transports.** UDP / TCP / Tor are reused from fips-core unchanged. **BLE** is
 the v1 transport and the one net-new transport piece:
@@ -355,8 +355,8 @@ Provenance for each band, matching the legend in
 | QR pairing (CameraX + ML Kit, deep-link intent) | **reuse (nostr-vpn)** | re-pointed at `myco://pair/<base64>` (npub + memorable name) |
 | `NsiteActivity` (fullscreen WebView per nsite, no chrome) | **net-new (thin)** | own task/instance; standard WebView; nsite-deck "loads localhost" pattern |
 | Local gateway + `*.nsite` resolution | **port (site-deck)** | Go → **Rust** in `nsite-deck`; HTTP-listener placement TBD/open |
-| Embedded Nostr relay (`:4869`) | **port (site-deck) → Rust** | was Khatru/Go; now the **`myco-relay`** crate (impl `RelayBackend`); embedded default, optional Citrine-forward backend |
-| Embedded Blossom (`:24242`) | **port (site-deck) → Rust** | now the **`myco-blossom`** crate (impl `BlobStore`); always embedded; content-addressed blobs, BUD-01 |
+| Embedded Nostr relay (`:4870`) | **port (site-deck) → Rust** | was Khatru/Go; now the **`myco-relay`** crate (impl `RelayBackend`); embedded default, optional Citrine-forward backend |
+| Embedded Blossom (`:24243`) | **port (site-deck) → Rust** | now the **`myco-blossom`** crate (impl `BlobStore`); always embedded; content-addressed blobs, BUD-01 |
 | Store-and-forward cache (re-serve peers' events/blobs) | **net-new** | the offline-propagation mechanism; Blossom blob store, LRU 2 GB, Library = pinned |
 | nsite sync (fetch + verify + retain over `.fips`) | **net-new** | runs in **`nsite-deck`**; v0 serves direct from relay + Blossom |
 | htdocs serving cache (path-named files under `current/`) | **deferred** | nsite-deck speed optimization; not needed for v0 |

--- a/docs/design/concepts.md
+++ b/docs/design/concepts.md
@@ -24,7 +24,7 @@ keypair**, the **device key**:
 - your **mesh network identity** (who you are on the FIPS network),
 - your **BLE link authentication** (who the radio link is talking to), and
 - your **app/device identity** in Myco — the address of *this* device's
-  embedded relay + Blossom (`<npub_device>.fips:4869` / `:24242`).
+  embedded relay + Blossom (`<npub_device>.fips:4870` / `:24243`).
 
 The device key is **never** used to author nsites. nsites are authored
 elsewhere, by external tooling, under separate keys (see *nsite author identity*
@@ -169,13 +169,13 @@ home-screen pinning, per-nsite origin isolation — is in
 Every Myco device runs **its own** Nostr relay and Blossom server in-process.
 No external services are required.
 
-- **Embedded Nostr relay** — default `ws://localhost:4869`. A plain NIP-01 store +
+- **Embedded Nostr relay** — default `ws://localhost:4870`. A plain NIP-01 store +
   socket: it **stores and serves** the signed manifest events (kinds 15128/35128).
   It does **not** fan out on its own — a separate **nsite-deck propagator** does the
   forwarding, by subscribing to the relevant relays (local + connected peers) and
   publishing those events on to peer relays (events only, source-excluded; see
   [propagation.md](./propagation.md)).
-- **Embedded Blossom server** — default `http://localhost:24242`. Stores and
+- **Embedded Blossom server** — default `http://localhost:24243`. Stores and
   serves the sha256-addressed blobs (Blossom BUD-01).
 
 Both are implemented in **Rust**, unified with the FIPS endpoint into a single
@@ -188,8 +188,8 @@ propagation (below).
 
 These services are exposed to peers over the mesh by FIPS **FSP port
 multiplexing**, which delivers mesh datagrams to localhost ports. A reachable
-peer reaches your relay at `<npub_device>.fips:4869` and your Blossom at
-`<npub_device>.fips:24242` — no separate gateway is needed on a reachable path.
+peer reaches your relay at `<npub_device>.fips:4870` and your Blossom at
+`<npub_device>.fips:24243` — no separate gateway is needed on a reachable path.
 That address is *this device's* (the holder's) address; the nsites it serves are
 filtered by their own author keys, which are unrelated to it.
 
@@ -311,11 +311,11 @@ nsite layer for survival across partition — is drawn in
 | **manifest** | the Nostr event whose `path` tags map paths → blob hashes (kind 15128 root / 35128 named) |
 | **blob** | a content-addressed file, retrieved by sha256 (Blossom BUD-01) |
 | **the Library** | the Myco home grid of nsites-as-apps |
-| **embedded relay** | in-process Nostr relay, `ws://localhost:4869` |
-| **embedded Blossom** | in-process blob server, `http://localhost:24242` |
+| **embedded relay** | in-process Nostr relay, `ws://localhost:4870` |
+| **embedded Blossom** | in-process blob server, `http://localhost:24243` |
 | **FIPS mesh** | self-organizing, transport-agnostic mesh; live-path-only routing |
 | **FMP / FSP** | FIPS Mesh Protocol (hop-by-hop, Noise IK) / FIPS Session Protocol (end-to-end, Noise XK) |
-| **FSP port-mux** | delivery of mesh datagrams to localhost ports, exposing `<npub>.fips:4869`/`:24242` |
+| **FSP port-mux** | delivery of mesh datagrams to localhost ports, exposing `<npub>.fips:4870`/`:24243` |
 | **TUN** | the kept `VpnService`; routes `fd00::/8`, intercepts `.fips`/`.nsite`; not tunnel-all |
 | **store-and-forward** | net-new nsite-layer caching that lets a device re-serve a site offline |
 | **myco-core** | the app crate that wires `nsite-deck` + `myco-relay` + `myco-blossom` behind one FFI `.so`; the only crate that names FIPS or a concrete relay/Blossom |

--- a/docs/design/diagrams/01-system-layering.svg
+++ b/docs/design/diagrams/01-system-layering.svg
@@ -47,7 +47,7 @@
     <rect x="40" y="314" width="900" height="98" rx="10" fill="#f8fafc" stroke="#cbd5e1"/>
     <rect x="40" y="314" width="8" height="98" rx="4" fill="#d97706"/>
     <text x="66" y="344" font-size="16" font-weight="700" fill="#0f172a">Embedded Nostr relay  +  Blossom server</text>
-    <text x="66" y="370" font-size="13" fill="#475569">relay ws://localhost:4869   ·   Blossom http://localhost:24242   ·   kind 15128/35128 manifests + sha256 blobs</text>
+    <text x="66" y="370" font-size="13" fill="#475569">relay ws://localhost:4870   ·   Blossom http://localhost:24243   ·   kind 15128/35128 manifests + sha256 blobs</text>
     <text x="66" y="391" font-size="13" fill="#475569">store-and-forward cache: holds peers' signed events/blobs and re-serves them (relay-of-relays)</text>
     <text x="930" y="336" font-size="11" font-weight="700" fill="#d97706" text-anchor="end">PORT · lang TBD</text>
   </g>
@@ -59,7 +59,7 @@
     <rect x="40" y="426" width="8" height="98" rx="4" fill="#2563eb"/>
     <text x="66" y="456" font-size="16" font-weight="700" fill="#0f172a">fips-mobile  (Rust)  —  FFI to Kotlin</text>
     <text x="66" y="482" font-size="13" fill="#475569">JNI/JSON FFI, cdylib via cargo-ndk   ·   dispatch→state(rev) reducer   ·   identity (nsec) in filesDir</text>
-    <text x="66" y="503" font-size="13" fill="#475569">binds relay+blossom into FIPS (peers reach &lt;npub&gt;.fips:4869 / :24242)   ·   KEEP TUN: routes fd00::/8 + .fips/.nsite DNS, system-wide   ·   drop exit-node / tunnel-all / roster</text>
+    <text x="66" y="503" font-size="13" fill="#475569">binds relay+blossom into FIPS (peers reach &lt;npub&gt;.fips:4870 / :24243)   ·   KEEP TUN: routes fd00::/8 + .fips/.nsite DNS, system-wide   ·   drop exit-node / tunnel-all / roster</text>
     <text x="930" y="448" font-size="11" font-weight="700" fill="#2563eb" text-anchor="end">REUSE</text>
   </g>
   <line x1="120" y1="524" x2="120" y2="538" stroke="#94a3b8" stroke-width="2" marker-end="url(#arr)"/>

--- a/docs/design/diagrams/02-pairing-transitive-discovery.svg
+++ b/docs/design/diagrams/02-pairing-transitive-discovery.svg
@@ -44,7 +44,7 @@
   <path d="M730,256 C560,266 430,266 272,256" fill="none" stroke="#475569" stroke-width="2.2" marker-end="url(#aSlate)"/>
   <text x="500" y="284" font-size="12" fill="#334155" text-anchor="middle">Ben matches the secret + taps OK  →  returns ack (now mutual)</text>
 
-  <text x="500" y="318" font-size="12.5" font-weight="600" fill="#0d9488" text-anchor="middle">npub = FIPS address  ⇒  reach that peer's relay (:4869) + Blossom (:24242) over the mesh</text>
+  <text x="500" y="318" font-size="12.5" font-weight="600" fill="#0d9488" text-anchor="middle">npub = FIPS address  ⇒  reach that peer's relay (:4870) + Blossom (:24243) over the mesh</text>
 
   <!-- ===================== BOTTOM PANEL: transitive reach ===================== -->
   <rect x="40" y="362" width="920" height="332" rx="12" fill="#f8fafc" stroke="#cbd5e1"/>

--- a/docs/design/diagrams/05-nsite-layer-architecture.svg
+++ b/docs/design/diagrams/05-nsite-layer-architecture.svg
@@ -44,14 +44,14 @@
   <!-- Embedded relay -->
   <rect x="320" y="282" width="210" height="96" rx="12" fill="#eff6ff" stroke="#2563eb" stroke-width="2"/>
   <text x="425" y="309" font-size="14" font-weight="700" fill="#0f172a" text-anchor="middle">Embedded relay</text>
-  <text x="425" y="330" font-size="10.5" fill="#475569" text-anchor="middle">ws://localhost:4869</text>
+  <text x="425" y="330" font-size="10.5" fill="#475569" text-anchor="middle">ws://localhost:4870</text>
   <text x="425" y="346" font-size="10.5" fill="#475569" text-anchor="middle">stores + serves</text>
   <text x="425" y="362" font-size="10.5" fill="#475569" text-anchor="middle">manifest events 15128 / 35128</text>
 
   <!-- Embedded Blossom -->
   <rect x="576" y="282" width="200" height="96" rx="12" fill="#fff7ed" stroke="#d97706" stroke-width="2"/>
   <text x="676" y="309" font-size="14" font-weight="700" fill="#0f172a" text-anchor="middle">Embedded Blossom</text>
-  <text x="676" y="330" font-size="10.5" fill="#475569" text-anchor="middle">http://localhost:24242</text>
+  <text x="676" y="330" font-size="10.5" fill="#475569" text-anchor="middle">http://localhost:24243</text>
   <text x="676" y="346" font-size="10.5" fill="#475569" text-anchor="middle">blobs by sha256</text>
 
   <!-- Sync engine -->
@@ -64,7 +64,7 @@
   <!-- FIPS endpoint -->
   <rect x="320" y="442" width="456" height="100" rx="12" fill="#f0fdfa" stroke="#0d9488" stroke-width="2"/>
   <text x="548" y="469" font-size="14" font-weight="700" fill="#0f172a" text-anchor="middle">FIPS endpoint — the mesh</text>
-  <text x="548" y="490" font-size="10.5" fill="#475569" text-anchor="middle">FSP port-mux exposes localhost ports (4869 / 24242) to peers</text>
+  <text x="548" y="490" font-size="10.5" fill="#475569" text-anchor="middle">FSP port-mux exposes localhost ports (4870 / 24243) to peers</text>
   <text x="548" y="506" font-size="10.5" fill="#475569" text-anchor="middle">reachable as &lt;npub&gt;.fips · Noise XK end-to-end</text>
   <text x="548" y="522" font-size="10.5" fill="#475569" text-anchor="middle">spanning-tree routing over UDP / TCP / BLE</text>
 
@@ -89,8 +89,8 @@
   <rect x="836" y="424" width="160" height="100" rx="12" fill="#ecfdf5" stroke="#16a34a" stroke-width="2"/>
   <text x="916" y="451" font-size="13" font-weight="700" fill="#0f172a" text-anchor="middle">Peer</text>
   <text x="916" y="470" font-size="10.5" fill="#475569" text-anchor="middle">relay + Blossom</text>
-  <text x="916" y="490" font-size="10" fill="#15803d" text-anchor="middle">&lt;peer&gt;.fips:4869</text>
-  <text x="916" y="505" font-size="10" fill="#15803d" text-anchor="middle">&lt;peer&gt;.fips:24242</text>
+  <text x="916" y="490" font-size="10" fill="#15803d" text-anchor="middle">&lt;peer&gt;.fips:4870</text>
+  <text x="916" y="505" font-size="10" fill="#15803d" text-anchor="middle">&lt;peer&gt;.fips:24243</text>
 
   <!-- FIPS endpoint -> peer (pull over FIPS) -->
   <path d="M776,486 L832,478" fill="none" stroke="#0d9488" stroke-width="2.6" marker-end="url(#cTeal)"/>

--- a/docs/design/diagrams/07-relay-mesh-fanout.svg
+++ b/docs/design/diagrams/07-relay-mesh-fanout.svg
@@ -40,7 +40,7 @@
   <!-- ============ YOUR relay (center, purple) ============ -->
   <rect x="552" y="232" width="190" height="120" rx="14" fill="#f5f3ff" stroke="#7c3aed" stroke-width="2.6"/>
   <text x="647" y="266" font-size="15" font-weight="700" fill="#0f172a" text-anchor="middle">YOUR node</text>
-  <text x="647" y="290" font-size="12" font-weight="700" fill="#7c3aed" text-anchor="middle">relay :4869 — stores</text>
+  <text x="647" y="290" font-size="12" font-weight="700" fill="#7c3aed" text-anchor="middle">relay :4870 — stores</text>
   <text x="647" y="312" font-size="11" fill="#475569" text-anchor="middle">propagator —</text>
   <text x="647" y="328" font-size="11" fill="#475569" text-anchor="middle">subscribes + fans out</text>
 

--- a/docs/design/diagrams/09-identity-model.svg
+++ b/docs/design/diagrams/09-identity-model.svg
@@ -46,8 +46,8 @@
   <!-- footer note -->
   <rect x="66" y="424" width="398" height="92" rx="10" fill="#ecfdf5" stroke="#16a34a"/>
   <text x="80" y="448" font-size="11.5" font-weight="700" fill="#15803d">Reaches your services:</text>
-  <text x="80" y="467" font-size="11" fill="#166534">&lt;npub_device&gt;.fips:4869  (relay)</text>
-  <text x="80" y="483" font-size="11" fill="#166534">&lt;npub_device&gt;.fips:24242  (Blossom)</text>
+  <text x="80" y="467" font-size="11" fill="#166534">&lt;npub_device&gt;.fips:4870  (relay)</text>
+  <text x="80" y="483" font-size="11" fill="#166534">&lt;npub_device&gt;.fips:24243  (Blossom)</text>
   <text x="80" y="505" font-size="11.5" font-weight="700" fill="#b91c1c">NEVER authors nsites.</text>
 
   <!-- ===================== RIGHT COLUMN: NSITE AUTHOR KEY ===================== -->

--- a/docs/design/event-gossip.md
+++ b/docs/design/event-gossip.md
@@ -8,7 +8,7 @@
 document covers the sibling problem: how an **in-app Nostr client** (e.g.
 [`myco-bitchat`](../../myco-bitchat/README.md)) gets *arbitrary* app events — a
 chat message, a reaction — to the people physically around it, when the only
-relay it can reach is the device's own embedded relay (`ws://localhost:4869`).
+relay it can reach is the device's own embedded relay (`ws://localhost:4870`).
 
 The enabling idea is the same one the whole project rests on: **the embedded
 relay is fed by the FIPS mesh, so physical proximity *is* the transport.** A

--- a/docs/design/identity-pairing.md
+++ b/docs/design/identity-pairing.md
@@ -41,8 +41,8 @@ This chain is established in
 The load-bearing consequence for pairing: **once you have a peer's device npub,
 you can compute where they live on the mesh with no further exchange.** No
 directory, no lookup, no signed announcement. Scanning a QR that carries a device
-npub is sufficient to address that peer's services at `<npub>.fips:4869` (relay)
-and `<npub>.fips:24242` (Blossom), via the local DNS interceptor
+npub is sufficient to address that peer's services at `<npub>.fips:4870` (relay)
+and `<npub>.fips:24243` (Blossom), via the local DNS interceptor
 ([fips-ipv6-adapter.md](../../reference/fips/docs/design/fips-ipv6-adapter.md)).
 
 ### 1.1 Device identity vs. nsite author identity (do not conflate)
@@ -204,8 +204,8 @@ When you scan a peer's `myco://pair/<base64>` (or open the deep link), the app:
    Noise-encrypted channel, the inviter matches it and confirms.
 4. On a completed handshake, adds two sources to your source set, addressed
    deterministically:
-   - relay at `<npub>.fips:4869`
-   - Blossom at `<npub>.fips:24242`
+   - relay at `<npub>.fips:4870`
+   - Blossom at `<npub>.fips:24243`
 5. Stores the npub (and memorable name) in your **circle** (the local peer list).
 
 Pairing is **handshake-mandatory and always mutual**: scanning is not a purely
@@ -362,7 +362,7 @@ held to the phone is read but ignored, never opened.
 **Where the secret lives.** §6.1 framed the `pairSecret` as echoed back inside the
 Noise-encrypted channel to `<npub_A>.fips`. The implementation keeps that property:
 the scanner/tapper sends a signed pair **request** (kind 9101) to
-`<npub_A>.fips:4869` — already Noise-XK encrypted and authenticated to A — carrying
+`<npub_A>.fips:4870` — already Noise-XK encrypted and authenticated to A — carrying
 the secret. What differs from the doc is *who matches it*: A enforces single-use
 locally, via a small persisted ledger of the secrets it has issued. Each presented
 code mints a fresh secret; it is consumed on first accept and the presented payload

--- a/docs/design/nsite-layer.md
+++ b/docs/design/nsite-layer.md
@@ -37,14 +37,14 @@ Local gateway (HTTP)  ───────────────────�
    │  serve blob direct from local Blossom        │
    │  blobs missing? ↓ (still syncing)           │
    ▼                                             │
-Embedded relay (ws://localhost:4869)             │  all in-process,
+Embedded relay (ws://localhost:4870)             │  all in-process,
    │  manifest event: kind 15128 / 35128         │  across the
    ▼                                             │  myco-* crates
-Embedded Blossom (http://localhost:24242)        │  (one .so)
+Embedded Blossom (http://localhost:24243)        │  (one .so)
    │  blobs by sha256                            │
    ▼                                             │
 Sync engine ── over FIPS ──► reachable holder ───┘
-   <npub_holder>.fips:4869 (relay)  ·  <npub_holder>.fips:24242 (blossom)
+   <npub_holder>.fips:4870 (relay)  ·  <npub_holder>.fips:24243 (blossom)
 ```
 
 ### The crate workspace
@@ -60,9 +60,9 @@ blob store, or radio:
   **nothing** about FIPS, BLE, Android, *or* any concrete relay/Blossom: it is
   "an embedded nsite host" and no more.
 - **`myco-relay`** *(reusable primitive)* — a generic embedded Nostr relay: the
-  event store + the `ws://localhost:4869` server. Useful to any Nostr app.
+  event store + the `ws://localhost:4870` server. Useful to any Nostr app.
 - **`myco-blossom`** *(reusable primitive)* — a generic embedded Blossom blob
-  store: the content-addressed store + the `http://localhost:24242` server.
+  store: the content-addressed store + the `http://localhost:24243` server.
   Useful to anything that needs Blossom (notably: there is **no good Android
   Blossom app**, which is exactly why this is worth having standalone).
 - **`myco-core`** *(app crate)* — the thin Myco-specific glue: the FIPS
@@ -91,7 +91,7 @@ mirroring how `fips-core` abstracts its radio behind `BleIo`:
 So `myco-core` is the only crate that names FIPS *or* a concrete relay/Blossom: it
 instantiates `myco-relay` + `myco-blossom`, hands them to `nsite-deck` as the
 `RelayBackend` / `BlobStore`, implements `PeerSource` / `FanoutSink` over FIPS, and
-binds the relay/Blossom ports into the mesh (`<npub>.fips:4869` / `:24242`). All
+binds the relay/Blossom ports into the mesh (`<npub>.fips:4870` / `:24243`). All
 four crates cross-compile into the single `libmyco_core.so`. Kotlin owns the radio
 and the TUN; Rust owns the content layer and the mesh. See
 [diagrams/01-system-layering.svg](diagrams/01-system-layering.svg) and
@@ -126,7 +126,7 @@ and the TUN; Rust owns the content layer and the mesh. See
 
 ### 2.1 Embedded relay
 
-A NIP-01 relay with a local event store, listening on `ws://localhost:4869` — the
+A NIP-01 relay with a local event store, listening on `ws://localhost:4870` — the
 **`myco-relay`** crate, which implements `nsite-deck`'s `RelayBackend` seam.
 The Go reference uses [Khatru](https://github.com/fiatjaf/khatru) over a BoltDB
 event store and advertises NIPs 1, 9, 11, 12, 15, 16, 20, 33
@@ -172,7 +172,7 @@ sync does by `(kind, d-tag)`
 relays (the local relay plus every connected peer's relay) and, when a new Nostr
 manifest arrives — whether pushed in by a peer or pulled in by the sync engine —
 it **publishes that event to every other connected peer** (an `["EVENT", …]` to
-each `<peer>.fips:4869`), excluding the peer it came from. This is what makes the
+each `<peer>.fips:4870`), excluding the peer it came from. This is what makes the
 "announce widely" half of propagation push-based and automatic instead of a
 flood the app has to orchestrate (see [./propagation.md §2](./propagation.md)).
 Constraints:
@@ -196,7 +196,7 @@ machinery layered on later (P5). See [diagrams/07-relay-mesh-fanout.svg](diagram
 
 ### 2.2 Embedded Blossom
 
-A content-addressed blob server on `http://localhost:24242` — the **`myco-blossom`**
+A content-addressed blob server on `http://localhost:24243` — the **`myco-blossom`**
 crate, implementing the `BlobStore` seam — **always embedded**
 — unlike the relay, Blossom has **no pluggable forward-to-an-app backend**,
 because there is no good Android Blossom app to forward to, so embedding is the
@@ -465,8 +465,8 @@ localhost ports (the IPv6 adapter runs on FSP port 256, and `curl
 http://<npub>.fips:port/` already works in the FIPS Android reference), the
 holder's own relay and Blossom are reachable at:
 
-- `ws://<npub_holder>.fips:4869` — the holder's embedded relay
-- `http://<npub_holder>.fips:24242` — the holder's embedded Blossom
+- `ws://<npub_holder>.fips:4870` — the holder's embedded relay
+- `http://<npub_holder>.fips:24243` — the holder's embedded Blossom
 
 You then query that holder's relay *for the author's events*:
 `{ kinds:[15128 or 35128], authors:[<author_pubkey>] }`. The holder serves the
@@ -489,14 +489,14 @@ For a `siteKey` authored by `npub_author`, fetched from a reachable holder
 is detailed in [./propagation.md](./propagation.md)):
 
 1. **Fetch the manifest.** Query the holder's relay
-   `ws://<npub_holder>.fips:4869` for the author's manifest event:
+   `ws://<npub_holder>.fips:4870` for the author's manifest event:
    - root: `{ "kinds":[15128], "authors":[<author_pubkey>] }`
    - named: `{ "kinds":[35128], "authors":[<author_pubkey>], "#d":[<identifier>] }`
    Keep the newest per slot.
 2. **Build the file list.** Extract every `["path", <path>, <sha256>]` tag →
    `path → hash` map.
 3. **Pull blobs by hash.** For each hash, `GET <sha256>` from the holder's Blossom
-   `http://<npub_holder>.fips:24242`. Fetch concurrently (the reference caps at 8).
+   `http://<npub_holder>.fips:24243`. Fetch concurrently (the reference caps at 8).
    Because blobs are content-addressed, Myco can prefer the **local**
    Blossom first (a blob already cached for another site is the same blob) and
    only go to the peer on a miss.
@@ -583,7 +583,7 @@ Beyond loading a known `<host>.nsite`, the Library can surface sites that reacha
 holders have. The set of discoverable sites is **the author-signed manifests this
 device has** — those received via the flood (small, self-authenticating manifest
 events re-emitted unmodified by relays) plus those **queried from every reachable
-relay** (your own, plus each paired peer's relay at `<npub_holder>.fips:4869`,
+relay** (your own, plus each paired peer's relay at `<npub_holder>.fips:4870`,
 plus their collected peers — see [./propagation.md](./propagation.md) for
 transitive reach) for kinds **15128 / 35128**. Present them **newest-first,
 de-duplicated by `(author, dTag)`**. Selecting one runs the normal §4 sync/serve

--- a/docs/design/nsite-permissions.md
+++ b/docs/design/nsite-permissions.md
@@ -28,8 +28,8 @@ site, `npub:dTag` for a named one — [nsite-layer.md §3.2](./nsite-layer.md)).
 Permissions are a record stored **per-siteKey** on the device.
 
 The enforcement hook is the **WebSocket / HTTP `Origin`**. The nsite loads at
-`http://<host>.nsite` and talks to the localhost relay (`ws://localhost:4869`) and
-Blossom (`http://localhost:24242`); every request carries
+`http://<host>.nsite` and talks to the localhost relay (`ws://localhost:4870`) and
+Blossom (`http://localhost:24243`); every request carries
 `Origin: http://<host>.nsite`. The native side maps **`Origin → siteKey →
 permission record`** and applies it. (The relay does no `Origin` check today —
 this is where it is added.)

--- a/docs/design/nsite-updates.md
+++ b/docs/design/nsite-updates.md
@@ -132,7 +132,7 @@ one combined filter per relay covering every site we care about. The relay set i
 the union of:
 
 - **Relays around us** — the embedded relays of connected mesh peers
-  (`ws://[fd00::peer]:4869`), always reachable offline. (Reuse the existing
+  (`ws://[fd00::peer]:4870`), always reachable offline. (Reuse the existing
   peer-relay pool's live connections where possible rather than dialing afresh.)
 - **The manifests' listed relays** — each active manifest's own relay hints, used
   **only when online**. The author publishes updates there, so they are the

--- a/docs/design/propagation.md
+++ b/docs/design/propagation.md
@@ -102,7 +102,7 @@ out on its own. The fanout is the job of a separate **propagator** process
 inside `nsite-deck`. The propagator holds an internal **subscription** to the
 relevant relays (the local `myco-relay` plus the relays of connected peers) and,
 when it sees a manifest, **publishes** it — an `["EVENT", …]` to each
-`<peer>.fips:4869` relay, source excluded — so a manifest ripples outward one
+`<peer>.fips:4870` relay, source excluded — so a manifest ripples outward one
 relay-hop at a time. "Connected peers" are your live FIPS links (directly paired
 peers and, transitively, their peers — §3). This is push-based: a node need not
 ask for a site to learn it exists; the propagator at a connected neighbour
@@ -130,7 +130,7 @@ reconcile on a new link** — fire a one-shot reconcile the moment a peer connec
 When a user opens a site — or when the **propagator eagerly pre-fetches a pinned
 one** — the app *pulls* the actual content from a holder whose manifest it has:
 it already has (or queries for) the manifest event, then fetches each referenced
-blob by sha256 from that holder's Blossom server (`<npub_holder>.fips:24242`),
+blob by sha256 from that holder's Blossom server (`<npub_holder>.fips:24243`),
 verifies, and caches. The pre-fetch is owned by the propagator's **pinned-site
 subscription** (an internal subscription for kinds `15128`/`35128`): when a
 *newer* manifest arrives for a Library-pinned `(author, dTag)`, the propagator
@@ -163,7 +163,7 @@ transitive discovery, authorized by a **mutual pairing**. See
   Noise-encrypted channel and the inviter confirms — and completion makes **both**
   devices a source for the other. The one-time `pairSecret` (a long random string)
   authenticates the handshake but grants no membership or admin authority. A device's npub *is* its FIPS address, so once
-  paired Alice can reach Ben's relay (`:4869`) and Blossom (`:24242`) over the
+  paired Alice can reach Ben's relay (`:4870`) and Blossom (`:24243`) over the
   mesh. This invite-pairing handshake ([identity-pairing.md § 6.1](./identity-pairing.md))
   is the **only** pairing path. (The device key is only ever a mesh/relay address;
   never an nsite author key.)

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -156,7 +156,7 @@ control is a candidate later feature (TBD / open).
 
 **Inbound surface on the mesh.** FIPS FSP port-multiplexing delivers mesh
 datagrams to localhost ports, so a paired peer can reach your services at
-`<npub>.fips:4869` (relay) and `<npub>.fips:24242` (Blossom)
+`<npub>.fips:4870` (relay) and `<npub>.fips:24243` (Blossom)
 ([../../reference/fips/docs/design/fips-session-layer.md](../../reference/fips/docs/design/fips-session-layer.md)).
 On Linux, FIPS recommends a default-deny nftables baseline to bound this
 surface; **on Android there is no nftables equivalent the app controls.** The

--- a/docs/design/wifi-aware-interop.md
+++ b/docs/design/wifi-aware-interop.md
@@ -237,7 +237,7 @@ The one genuinely new piece of plumbing is the address itself. The peer's
 address is IPv6 **link-local** (`fe80::…`), which is only meaningful together
 with a scope — *which* interface to send from. Two facts make this workable:
 
-- Rust's std parses **numeric**-scope text: `"[fe80::x%3]:4869"` round-trips
+- Rust's std parses **numeric**-scope text: `"[fe80::x%3]:4871"` round-trips
   through `SocketAddr` parsing with `scope_id = 3`, so it survives
   fips-core's `resolve_socket_addr` fast path, the UDP transport's
   peer map, and the receive loop, with the kernel receiving the scope

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ of Propagation": small relays and Blossom blobs hopping over crappy links in all
 directions, surviving outages via local propagation.
 
 Under the hood, every device runs its **own** embedded Nostr relay
-(`ws://localhost:4869`) and Blossom blob server (`http://localhost:24242`),
+(`ws://localhost:4870`) and Blossom blob server (`http://localhost:24243`),
 unified with the FIPS endpoint into one Rust `myco-core` library. The app never
 authors nsites — it only stores, serves, and replicates ones authored elsewhere.
 When you browse a peer's site, your relay retains the author's signed events and
@@ -73,8 +73,8 @@ The v1 target is a **two-device Android demo over BLE, fully offline**: phone A
 **seeds** a known public nsite once (by syncing it while online, or side-loading
 it — A never authors it), the two phones QR-pair (the code carries only an npub),
 and then both go into airplane mode with Bluetooth on. Over a native L2CAP BLE
-link, phone B reaches A's embedded relay and Blossom at `<npubA>.fips:4869` /
-`:24242` (A's device/holder address), pulls the author's signed manifest event
+link, phone B reaches A's embedded relay and Blossom at `<npubA>.fips:4870` /
+`:24243` (A's device/holder address), pulls the author's signed manifest event
 and its blobs on demand, caches them locally, and serves the site to its in-app
 WebView from `127.0.0.1` — with no internet, Wi-Fi, or cell anywhere in the path.
 Afterward B has become a new holder for that site and could re-serve it to a third

--- a/docs/how-to/run-two-device-demo.md
+++ b/docs/how-to/run-two-device-demo.md
@@ -134,8 +134,8 @@ The intended procedure:
    and [../design/concepts.md](../design/concepts.md).)
 2. The site is now reachable on A locally at its nsite host —
    `<npub_author>.nsite` for a root site (resolving to `127.0.0.1`, an A record),
-   served by the embedded gateway from the relay (`ws://localhost:4869`) + Blossom
-   (`http://localhost:24242`). Note the host is the **author's** npub, not A's
+   served by the embedded gateway from the relay (`ws://localhost:4870`) + Blossom
+   (`http://localhost:24243`). Note the host is the **author's** npub, not A's
    device npub.
 3. **Pin** the site so it is exempt from LRU eviction (sites added to the Library
    are pinned by default; cache cap defaults to 2 GB).
@@ -218,8 +218,8 @@ peering) then P2–P4 (content + offline browse).)**
    [../../reference/fips/src/transport/ble/io.rs](../../reference/fips/src/transport/ble/io.rs),
    [discovery.rs](../../reference/fips/src/transport/ble/discovery.rs).)
 3. Once the link is up, B and A form a one-hop spanning tree. B can now reach A's
-   embedded services over the mesh at `<npubA>.fips:4869` (relay) and
-   `<npubA>.fips:24242` (Blossom), via FIPS FSP port-multiplexing — no separate
+   embedded services over the mesh at `<npubA>.fips:4870` (relay) and
+   `<npubA>.fips:24243` (Blossom), via FIPS FSP port-multiplexing — no separate
    gateway needed. (See
    [../../reference/fips/docs/design/fips-session-layer.md](../../reference/fips/docs/design/fips-session-layer.md).)
 4. On **B**, open the Library and **Search nsites around me** (query the holder A's

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -67,8 +67,8 @@ alias = ""                 # optional human label for this device's <alias>.fips
 # (no NIP-42 AUTH or read ACL) — aligned with propagation; see security.md §3.
 # ---------------------------------------------------------------------------
 [node]
-relay_port   = 4869        # ws://localhost:4869  (embedded Nostr relay)
-blossom_port = 24242       # http://localhost:24242 (embedded Blossom server, ALWAYS embedded)
+relay_port   = 4870        # ws://localhost:4870  (embedded Nostr relay)
+blossom_port = 24243       # http://localhost:24243 (embedded Blossom server, ALWAYS embedded)
 autostart    = true        # start relay+blossom+FIPS endpoint on app launch
 
 # ---------------------------------------------------------------------------
@@ -138,7 +138,7 @@ enabled = true             # master switch for the L2CAP CoC transport
 # ---------------------------------------------------------------------------
 [wifi_aware]
 enabled = false            # master switch for the bulk lane (adds a UDP transport)
-# The port is a fixed app constant (4870), carried where it already
+# The port is a fixed app constant (4871), carried where it already
 # belongs — the fips UDP transport's bind_addr. There is no role and no PSK.
 
 # ---------------------------------------------------------------------------
@@ -203,8 +203,8 @@ One identity per device in v1; multi-persona is a later milestone.
 
 | Key | Type | Proposed default | Notes |
 | --- | --- | --- | --- |
-| `relay_port` | u16 | `4869` | embedded Nostr relay, `ws://localhost:4869`. |
-| `blossom_port` | u16 | `24242` | embedded Blossom server, `http://localhost:24242`. **Always embedded** — not pluggable. |
+| `relay_port` | u16 | `4870` | embedded Nostr relay, `ws://localhost:4870`. |
+| `blossom_port` | u16 | `24243` | embedded Blossom server, `http://localhost:24243`. **Always embedded** — not pluggable. |
 | `autostart` | bool | `true` | start the node (relay + blossom + FIPS endpoint) on launch. |
 
 ### `[sync]`
@@ -231,7 +231,7 @@ Embedding is the default and earliest path. **Blossom is not pluggable** — it 
 | `forward_addr` | string | absent | only when `backend = "local-forward"` — the local relay's address (e.g. `ws://127.0.0.1:7777`). **TBD/open:** exact handshake/sync with the external relay. |
 
 These services are exposed to mesh peers over FIPS FSP port-multiplexing at
-`<npub>.fips:4869` and `<npub>.fips:24242` — no separate gateway on a reachable
+`<npub>.fips:4870` and `<npub>.fips:24243` — no separate gateway on a reachable
 path (see [concepts.md](../design/concepts.md) and upstream
 [fips-session-layer.md](../../reference/fips/docs/design/fips-session-layer.md)).
 The WebView never resolves `.fips`; it loads `npub.nsite` via the localhost

--- a/docs/reference/nostr-kinds.md
+++ b/docs/reference/nostr-kinds.md
@@ -124,7 +124,7 @@ not-found page is the blob mapped at `/404.html`.
 ```
 
 These run against the **local** relay first (fast path) and, on a miss, against
-the source peer's relay over `.fips` (`ws://<npub>.fips:4869`). See
+the source peer's relay over `.fips` (`ws://<npub>.fips:4870`). See
 [../design/nsite-layer.md §5](../design/nsite-layer.md).
 
 > **Set reconciliation.** Between two connected relays, Myco reconciles the

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -18,16 +18,22 @@ sync-over-FIPS), [../design/nsite-layer.md §3.2](../design/nsite-layer.md)
 
 | Service | Listen address | Default port | Reached by | Exposed over FIPS? |
 | --- | --- | --- | --- | --- |
-| Embedded Nostr relay | `127.0.0.1` (localhost) | **4869** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:4869` |
-| Embedded Blossom server | `127.0.0.1` (localhost) | **24242** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:24242` |
+| Embedded Nostr relay | `127.0.0.1` (localhost) | **4870** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:4870` |
+| Embedded Blossom server | `127.0.0.1` (localhost) | **24243** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:24243` |
 | Local HTTP gateway | `127.0.0.1` (localhost) | **80** | any browser on the device (system-wide `*.nsite` interception) | **No** — localhost-only, never over the mesh |
 | DNS interceptor | inside the VpnService/TUN reader (not a bound socket) | n/a | the whole device's resolver | n/a — it *produces* the addresses below |
 | FIPS IPv6 adapter | FSP port **256** (internal mesh port, not a localhost socket) | 256 | FIPS session layer | n/a — this is the mesh transport that *carries* IPv6 to `fd00::` |
 
-Ports 4869 (relay) and 24242 (Blossom) and the content-addressing of Blossom
-blobs by sha256 are **established defaults**
+Myco's relay listens on **4870** and Blossom on **24243** — each **one above**
+the site-deck reference defaults of `4869` / `24242`
 ([../../reference/site-deck/internal/relay/embedded.go](../../reference/site-deck/internal/relay/embedded.go),
 [../../reference/site-deck/internal/blossom/embedded.go](../../reference/site-deck/internal/blossom/embedded.go)).
+The `+1` offset is a **temporary** measure so Myco doesn't squat on the ports a
+developer's own localhost relay/Blossom already uses; it will be replaced by a
+configurable-port solution. The mesh and localhost binds use the *same* number
+(§5), so both move together — a peer dials `<npub>.fips:4870` and it lands on the
+peer's `127.0.0.1:4870`. The content-addressing of Blossom blobs by sha256 is
+unchanged.
 
 > **Note on bind address.** The site-deck reference binds the relay and Blossom
 > on `[::]` (all interfaces) "for development" and warns against it in
@@ -37,16 +43,16 @@ blobs by sha256 are **established defaults**
 
 ---
 
-## 1. Embedded Nostr relay — `4869`
+## 1. Embedded Nostr relay — `4870`
 
-- **Listen:** `ws://127.0.0.1:4869` (NIP-01 relay; also answers a NIP-11 doc on
+- **Listen:** `ws://127.0.0.1:4870` (NIP-01 relay; also answers a NIP-11 doc on
   HTTP GET).
 - **Local consumers:** the gateway queries it for manifests on the fast path;
   the loading page subscribes to it for title/description; the sync engine
   *stores* pulled manifests into it (replicating already-signed author events —
   ordinary relay behaviour, not authoring).
 - **Over FIPS:** **yes.** A peer's relay is reachable at
-  `ws://<npub_holder>.fips:4869`, where `<npub_holder>` is the device key of the
+  `ws://<npub_holder>.fips:4870`, where `<npub_holder>` is the device key of the
   peer that *holds* a copy — not the site's author. The sync engine queries that
   holder's relay for an author's site with
   `{ kinds: [15128, 35128], authors: [<author_pubkey>] }`. The site you want is
@@ -55,14 +61,14 @@ blobs by sha256 are **established defaults**
   See
   [../design/nsite-layer.md §5.2](../design/nsite-layer.md).
 
-## 2. Embedded Blossom server — `24242`
+## 2. Embedded Blossom server — `24243`
 
-- **Listen:** `http://127.0.0.1:24242` (BUD-01 content-addressed blob store).
+- **Listen:** `http://127.0.0.1:24243` (BUD-01 content-addressed blob store).
 - **Local consumers:** the gateway and sync engine `GET <sha256>` for blobs; the
   sync engine `PUT`s pulled blobs in to mirror them (so this device becomes a
   source). Localhost Blossom runs **without auth** (reference behaviour).
 - **Over FIPS:** **yes.** A peer's Blossom is reachable at
-  `http://<npub>.fips:24242`; the sync engine pulls each manifest blob by sha256
+  `http://<npub>.fips:24243`; the sync engine pulls each manifest blob by sha256
   from there and verifies it.
 
 ## 3. Local HTTP gateway — localhost-only
@@ -76,12 +82,12 @@ blobs by sha256 are **established defaults**
   localhost host works in **any** browser, including Chromium (whose AAAA/ULA
   suppression only ever affected IPv6-only `.fips`).
 - **Over FIPS:** **no — deliberately.** The gateway is never exposed on the mesh.
-  Peers do not talk to your gateway; they talk to your relay (4869) and Blossom
-  (24242) directly. There is no separate "gateway port" on a reachable path —
+  Peers do not talk to your gateway; they talk to your relay (4870) and Blossom
+  (24243) directly. There is no separate "gateway port" on a reachable path —
   the localhost relay/Blossom *are* the mesh endpoints. The gateway is a purely
   local convenience that **serves direct from the local relay + Blossom**: for a
   request `<host>.nsite/<path>` it looks up the manifest event on the relay
-  (4869), maps `<path> → sha256`, fetches that blob from Blossom (24242), and
+  (4870), maps `<path> → sha256`, fetches that blob from Blossom (24243), and
   serves it with a content-type inferred from the path extension. There is no
   derived htdocs cache in v0 (a path-named serving cache is a deferred roadmap
   optimization); the content-addressed Blossom store is the only retained store.
@@ -128,15 +134,15 @@ which the IPv6 adapter registers inside the mesh. It is the mechanism that makes
 
 1. The WebView/app stays on localhost; the sync engine resolves
    `<npub>.fips → fd00::<peer>` (AAAA, via §4).
-2. It opens a normal IPv6 socket to `[fd00::<peer>]:4869` (or `:24242`).
+2. It opens a normal IPv6 socket to `[fd00::<peer>]:4870` (or `:24243`).
 3. The OS routes `fd00::/8` to the TUN; the TUN reader compresses the IPv6
    header and prepends an FSP port header `(src=256, dst=256)`, encrypts, and
    routes the datagram through the mesh toward the destination node.
 4. On the peer, FSP delivers inbound port-256 traffic to its IPv6 adapter, which
    reconstructs the IPv6 packet and hands it to *its* TUN — landing on the peer's
-   `127.0.0.1:4869` / `:24242` localhost service.
+   `127.0.0.1:4870` / `:24243` localhost service.
 
-So the destination service port (4869 / 24242) rides **inside** the
+So the destination service port (4870 / 24243) rides **inside** the
 mesh-tunneled IPv6/TCP packet; FSP port **256** is only the outer mesh
 multiplexing port shared by all IPv6 traffic. Sources:
 [../../reference/fips/docs/design/fips-session-layer.md](../../reference/fips/docs/design/fips-session-layer.md)
@@ -157,12 +163,12 @@ delivering `curl http://<npub>.fips:port/` end to end
                                                    cache hit → serve
                                                    cache miss → sync engine ↓
 
- sync engine ──IPv6─► <npub>.fips → [fd00::peer]:4869  ─┐
- sync engine ──IPv6─► <npub>.fips → [fd00::peer]:24242 ─┤  routed via TUN
+ sync engine ──IPv6─► <npub>.fips → [fd00::peer]:4870  ─┐
+ sync engine ──IPv6─► <npub>.fips → [fd00::peer]:24243 ─┤  routed via TUN
                                                          ▼
                                             FSP port 256 (mesh) ──► peer node
                                                          │
-                                            peer TUN ──► peer 127.0.0.1:4869 / :24242
+                                            peer TUN ──► peer 127.0.0.1:4870 / :24243
 ```
 
 - The **WebView** never resolves `.fips`, never touches the mesh.
@@ -176,7 +182,7 @@ delivering `curl http://<npub>.fips:port/` end to end
 
 - [../design/nsite-layer.md](../design/nsite-layer.md) — the relay/Blossom/
   gateway design and the sync-over-FIPS flow.
-- [./nostr-kinds.md](./nostr-kinds.md) — the manifest kinds queried on port 4869.
+- [./nostr-kinds.md](./nostr-kinds.md) — the manifest kinds queried on port 4870.
 - [../design/propagation.md](../design/propagation.md) — propagation policy over
   these channels.
 - [../../reference/fips/docs/design/fips-session-layer.md](../../reference/fips/docs/design/fips-session-layer.md),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -129,10 +129,10 @@ reused macOS `BleIo`) ·
 ## P2 — Relay + Blossom + gateway (serve-direct)
 
 **Goal.** Embed, in Rust inside `myco-core`, both the relay and Blossom from day
-one — they are simple. **Blossom is always embedded** (`http://localhost:24242`,
+one — they are simple. **Blossom is always embedded** (`http://localhost:24243`,
 a small content-addressed HTTP store: `GET /<sha256>`, `PUT /upload`, `HEAD`);
 there is no good Android Blossom app to forward to. **The relay (`myco-relay`) is
-embedded too** (`ws://localhost:4869`) — a plain NIP-01 store + socket, with no
+embedded too** (`ws://localhost:4870`) — a plain NIP-01 store + socket, with no
 forwarding behavior of its own — but the relay *backend* is a pluggable seam:
 default = embedded; optional = forward to a local relay app (e.g. Citrine) for
 devs who already run one. Add the localhost HTTP gateway on `127.0.0.1:80`,
@@ -191,7 +191,7 @@ already Noise-encrypted channel, the inviter matches it and the user taps OK.
 invite (but grants no membership/admin authority); completion makes each device a
 mutual source. There
 is no one-way fetch-only scan. Wire the sync engine to pull a peer's manifest +
-blobs from `<npub>.fips:4869` / `:24242`, verify, and mirror into the local
+blobs from `<npub>.fips:4870` / `:24243`, verify, and mirror into the local
 stores — running **over the BLE link from P1, or over IP**. **Stand up the
 nsite-deck propagator:** a separate **propagator** process inside `nsite-deck`
 (not the relay — `myco-relay` stays a plain store + socket) does all forwarding

--- a/myco-blossom/src/lib.rs
+++ b/myco-blossom/src/lib.rs
@@ -10,7 +10,7 @@
 //! Reads return the named file directly: the only way bytes enter is a verified
 //! write, so re-hashing on every gateway request would be wasted work.
 //!
-//! The `http://localhost:24242` BUD-01 HTTP server (GET/PUT/HEAD) is bound by
+//! The `http://localhost:24243` BUD-01 HTTP server (GET/PUT/HEAD) is bound by
 //! `myco-core` over the shared Tokio runtime (P2 M2); this crate is the store.
 //!
 //! [`BlobStore`]: nsite_deck::seams::BlobStore

--- a/myco-blossom/src/server.rs
+++ b/myco-blossom/src/server.rs
@@ -1,5 +1,5 @@
 //! The BUD-01 Blossom HTTP server over [`FsBlobStore`], so the node can serve its
-//! blobs to mesh peers at `http://[fd00::self]:24242`. No auth on the mesh-local
+//! blobs to mesh peers at `http://[fd00::self]:24243`. No auth on the mesh-local
 //! server (the blob hash is self-authenticating). Routes:
 //!
 //! - `GET  /<sha256>` → blob bytes (`application/octet-stream`; the gateway infers

--- a/myco-core/src/aware_bridge_jni.rs
+++ b/myco-core/src/aware_bridge_jni.rs
@@ -9,7 +9,7 @@
 //! queue (`fips::discovery::platform`), which the node drains each tick.
 //!
 //! Kotlin passes the peer's link-local address already formatted with a
-//! *numeric* scope (`"[fe80::x%3]:4870"`, ifindex resolved from
+//! *numeric* scope (`"[fe80::x%3]:4871"`, ifindex resolved from
 //! `LinkProperties`) — interface-name scopes do not parse (see
 //! docs/design/wifi-aware-interop.md § "Dialing a link-local peer").
 //!

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -1,7 +1,7 @@
 //! The Myco content layer: the embedded relay + Blossom stores wired to the
 //! `nsite-deck` gateway engine, plus the Library and per-site sync status the FFI
 //! surfaces. This is the in-process glue (`myco-core` is the only crate that names
-//! a concrete relay/Blossom). The localhost `:4869` / `:24242` sockets and the
+//! a concrete relay/Blossom). The localhost `:4870` / `:24243` sockets and the
 //! `:80` external door are **not** bound in P2 — the in-app WebView reaches the
 //! gateway in-process via `gateway_get` (the `gatewayGet` JNI). Peer sync over
 //! those sockets is P3.
@@ -863,7 +863,7 @@ impl Content {
     /// **Every** Circle member's npub, regardless of whether they're a *direct*
     /// mesh neighbour right now. Chat fan-out targets this: a Circle peer you've
     /// walked away from is still reachable multi-hop over the mesh, and messages
-    /// must keep flowing to them — the routed `ws://[fd00::peer]:4869` dial reaches
+    /// must keep flowing to them — the routed `ws://[fd00::peer]:4870` dial reaches
     /// them, and a truly-offline member's connect just fails fast and is dropped.
     /// (Contrast [`connected_circle_npubs`](Self::connected_circle_npubs), the
     /// direct-neighbour subset used where an offline dial's timeout must be
@@ -1062,7 +1062,7 @@ impl Content {
                 return;
             }
         };
-        let url = format!("ws://[{}]:4869", peer.address().to_ipv6());
+        let url = format!("ws://[{}]:4870", peer.address().to_ipv6());
         for attempt in 0..PAIR_DIAL_ATTEMPTS {
             if attempt > 0 {
                 tokio::time::sleep(PAIR_DIAL_RETRY_DELAY).await;
@@ -1122,7 +1122,7 @@ impl Content {
         let Ok(peer) = fips::PeerIdentity::from_npub(npub) else {
             return;
         };
-        let url = format!("ws://[{}]:4869", peer.address().to_ipv6());
+        let url = format!("ws://[{}]:4870", peer.address().to_ipv6());
         let mut stored = 0u32;
         for filters in subs {
             let events = self
@@ -1150,7 +1150,7 @@ impl Content {
         let circle: HashSet<String> = self.circle_npubs().into_iter().collect();
         for npub in &circle {
             if let Ok(peer) = fips::PeerIdentity::from_npub(npub) {
-                let url = format!("ws://[{}]:4869", peer.address().to_ipv6());
+                let url = format!("ws://[{}]:4870", peer.address().to_ipv6());
                 self.peer_relays.ensure(npub, &url);
             }
         }
@@ -1176,7 +1176,7 @@ impl Content {
         let Ok(peer) = fips::PeerIdentity::from_npub(npub) else {
             return;
         };
-        let url = format!("ws://[{}]:4869", peer.address().to_ipv6());
+        let url = format!("ws://[{}]:4870", peer.address().to_ipv6());
         self.peer_relays.send(npub, &url, frame);
     }
 
@@ -1220,7 +1220,7 @@ impl Content {
                 if exclude == Some(ip) {
                     return None;
                 }
-                let url = format!("ws://[{}]:4869", ip);
+                let url = format!("ws://[{}]:4870", ip);
                 let filters = filters.clone();
                 Some(async move {
                     pool.request(&npub, &url, filters, std::time::Duration::from_secs(8))
@@ -1239,7 +1239,7 @@ impl Content {
     // --- discovery ("nsites around me") ---
 
     /// Discover nsites on connected Circle peers' relays: query each reachable
-    /// member's mesh relay (`ws://[fd00::peer]:4869`) for manifest events in
+    /// member's mesh relay (`ws://[fd00::peer]:4870`) for manifest events in
     /// parallel, then rebuild the discovered list. Spawn-not-block; the UI polls
     /// `discovered`. Opening a result pulls from that peer (its npub is the holder).
     pub async fn discover_from_circle(self: Arc<Self>) {
@@ -1249,7 +1249,7 @@ impl Content {
             let Ok(peer) = fips::PeerIdentity::from_npub(&npub) else {
                 return Vec::new();
             };
-            let relay_url = format!("ws://[{}]:4869", peer.address().to_ipv6());
+            let relay_url = format!("ws://[{}]:4870", peer.address().to_ipv6());
             // Manifest kinds only; `req-ttl: 1` reaches our peers' peers (2 hops),
             // matching the old `discover_manifests` helper.
             let filter = serde_json::json!({
@@ -1350,7 +1350,7 @@ impl Content {
             .into_iter()
             .filter_map(|npub| {
                 let peer = fips::PeerIdentity::from_npub(&npub).ok()?;
-                Some((npub, format!("ws://[{}]:4869", peer.address().to_ipv6())))
+                Some((npub, format!("ws://[{}]:4870", peer.address().to_ipv6())))
             })
             .collect();
         let online: Vec<String> = if self.is_offline_only() {
@@ -1644,8 +1644,8 @@ impl Content {
         if let Some(IpAddr::V6(ip)) = inbound.sender {
             sources.push(Arc::new(
                 crate::ip_source::IpPeerSource::new(
-                    vec![format!("ws://[{ip}]:4869")],
-                    vec![format!("http://[{ip}]:24242")],
+                    vec![format!("ws://[{ip}]:4870")],
+                    vec![format!("http://[{ip}]:24243")],
                 )
                 .ignoring_manifest_servers(),
             ));

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -2,7 +2,7 @@
 //! mesh, implementing the **push** plane of `docs/design/event-gossip.md`.
 //!
 //! **P2 — multi-hop flood.** An event is pushed to the whole Circle's relays
-//! (`ws://[fd00::peer]:4869`) — every member, not just direct neighbours, so a
+//! (`ws://[fd00::peer]:4870`) — every member, not just direct neighbours, so a
 //! peer reachable only multi-hop over the mesh still receives it — carrying a
 //! decrementing `event-ttl`:
 //!

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -54,7 +54,7 @@ pub struct IpPeerSource {
     timeout: Duration,
     /// When true, blob fetches ignore the manifest's `["server", …]` hints and
     /// use only `blossom_servers` — so a **mesh** source never reaches out to
-    /// public Blossom over the internet (it stays on the peer's `[fd00::]:24242`).
+    /// public Blossom over the internet (it stays on the peer's `[fd00::]:24243`).
     ignore_manifest_servers: bool,
     /// For a **mesh** source: the shared peer-relay pool + the holder's npub, so a
     /// manifest REQ reuses the one persistent WS connection to the peer instead of
@@ -111,7 +111,7 @@ impl IpPeerSource {
 /// A [`PeerSource`] that pulls from a specific **holder's** embedded relay +
 /// Blossom over the FIPS mesh, addressed by the holder's npub: the ULA
 /// `fd00:: = fd + node_addr[0..15]` (`PeerIdentity::from_npub`), reached at
-/// `ws://[fd00::holder]:4869` / `http://[fd00::holder]:24242`. Requires the
+/// `ws://[fd00::holder]:4870` / `http://[fd00::holder]:24243`. Requires the
 /// app-owned TUN to be up so the IPv6 socket routes over the mesh. A longer
 /// timeout than the IP source absorbs BLE latency + first-contact session setup.
 pub fn mesh_source_for(
@@ -122,8 +122,8 @@ pub fn mesh_source_for(
         .map_err(|e| anyhow::anyhow!("invalid holder npub {holder_npub}: {e}"))?;
     let ip = peer.address().to_ipv6();
     Ok(IpPeerSource::new(
-        vec![format!("ws://[{ip}]:4869")],
-        vec![format!("http://[{ip}]:24242")],
+        vec![format!("ws://[{ip}]:4870")],
+        vec![format!("http://[{ip}]:24243")],
     )
     .with_timeout(Duration::from_secs(20))
     .ignoring_manifest_servers()
@@ -131,7 +131,7 @@ pub fn mesh_source_for(
 }
 
 /// Dev-menu **speedtest** against a mesh peer: PUT a fresh `bytes`-sized payload to
-/// the peer's Blossom (`http://[fd00::peer]:24242/upload`), then GET it back, timing
+/// the peer's Blossom (`http://[fd00::peer]:24243/upload`), then GET it back, timing
 /// each leg. Returns `(up_mbps, down_mbps)` — upload (this device → peer) and
 /// download (peer → this device) throughput in megabits per second. The whole call
 /// is bounded by `timeout`. The peer's Blossom gates non-loopback sources by Circle
@@ -154,7 +154,7 @@ pub async fn speedtest_peer(
     let peer = fips::PeerIdentity::from_npub(npub)
         .map_err(|e| anyhow::anyhow!("invalid peer npub {npub}: {e}"))?;
     let host = format!("{npub}.fips");
-    let socket = std::net::SocketAddr::new(std::net::IpAddr::V6(peer.address().to_ipv6()), 24242);
+    let socket = std::net::SocketAddr::new(std::net::IpAddr::V6(peer.address().to_ipv6()), 24243);
     let client = reqwest::Client::builder()
         .resolve(&host, socket)
         // A short connect timeout so an unroutable/unreachable peer fails fast
@@ -163,7 +163,7 @@ pub async fn speedtest_peer(
         .connect_timeout(Duration::from_secs(15))
         .timeout(timeout)
         .build()?;
-    speedtest_blossom(&client, &format!("http://{host}:24242"), bytes).await
+    speedtest_blossom(&client, &format!("http://{host}:24243"), bytes).await
 }
 
 /// The Blossom round-trip itself, against an already-built `client` + `base` URL —

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -19,7 +19,7 @@ use crate::state::{
 /// discovery problem. UDP is fips's native transport and the LAN-discovery
 /// path (which this reuses) is already UDP + scoped link-local IPv6.
 /// See docs/design/wifi-aware-interop.md.
-const WIFI_AWARE_PORT: u16 = 4870;
+const WIFI_AWARE_PORT: u16 = 4871;
 
 /// The app runtime behind the FFI. Owns the device identity, a multi-thread
 /// Tokio runtime, and the embedded fips node. A `Mutex<AppRuntime>` is what the
@@ -109,7 +109,7 @@ impl AppRuntime {
         seed_default_sites(&content, &rt, Path::new(data_dir));
 
         // Serve the relay + Blossom over the mesh so paired peers can pull this
-        // device's nsites at ws://<npub>.fips:4869 / http://<npub>.fips:24242.
+        // device's nsites at ws://<npub>.fips:4870 / http://<npub>.fips:24243.
         // Bound IPV6_V6ONLY (the mesh is IPv6-only) so `[::]:port` doesn't collide
         // with another app squatting on `127.0.0.1:port`; a port already in use
         // surfaces as a warning. Android-only (the host has no TUN). ports.md.
@@ -139,9 +139,9 @@ impl AppRuntime {
                 Some(gate),
             );
 
-            // Mesh socket: IPV6_V6ONLY `[::]:4869` so it doesn't collide with the
-            // loopback bind and is reachable by peers at `ws://<npub>.fips:4869`.
-            match myco_relay::server::bind("[::]:4869".parse::<SocketAddr>().unwrap()) {
+            // Mesh socket: IPV6_V6ONLY `[::]:4870` so it doesn't collide with the
+            // loopback bind and is reachable by peers at `ws://<npub>.fips:4870`.
+            match myco_relay::server::bind("[::]:4870".parse::<SocketAddr>().unwrap()) {
                 Ok(listener) => {
                     let hub = hub.clone();
                     rt.spawn(async move {
@@ -152,13 +152,13 @@ impl AppRuntime {
                 }
                 Err(e) => {
                     mesh_warning =
-                        format!("relay port 4869 unavailable (another app using it?): {e}");
+                        format!("relay port 4870 unavailable (another app using it?): {e}");
                 }
             }
-            // Loopback socket: the in-app nsite WebView talks to `ws://localhost:4869`
-            // / `ws://127.0.0.1:4869`; the mesh socket is v6only, so serve loopback
+            // Loopback socket: the in-app nsite WebView talks to `ws://localhost:4870`
+            // / `ws://127.0.0.1:4870`; the mesh socket is v6only, so serve loopback
             // explicitly. Connections here are classified as `Origin::Local`.
-            match myco_relay::server::bind("127.0.0.1:4869".parse::<SocketAddr>().unwrap()) {
+            match myco_relay::server::bind("127.0.0.1:4870".parse::<SocketAddr>().unwrap()) {
                 Ok(listener) => {
                     let hub = hub.clone();
                     rt.spawn(async move {
@@ -168,21 +168,21 @@ impl AppRuntime {
                     });
                 }
                 Err(e) => {
-                    // Critical: the in-app nsites connect to ws://localhost:4869, so
+                    // Critical: the in-app nsites connect to ws://localhost:4870, so
                     // if another app holds it they'll silently talk to the WRONG
                     // relay (you'd see messages that aren't yours). Flag it loudly;
-                    // the UI watches for "port 4869" to pop a warning.
+                    // the UI watches for "port 4870" to pop a warning.
                     if !mesh_warning.is_empty() {
                         mesh_warning.push_str("; ");
                     }
                     mesh_warning.push_str(&format!(
-                        "Another app is using port 4869 — Myco's relay couldn't start, \
+                        "Another app is using port 4870 — Myco's relay couldn't start, \
                          so apps will talk to the wrong relay. Close the other app and \
                          restart Myco. ({e})"
                     ));
                 }
             }
-            match myco_blossom::server::bind("[::]:24242".parse::<SocketAddr>().unwrap()) {
+            match myco_blossom::server::bind("[::]:24243".parse::<SocketAddr>().unwrap()) {
                 Ok(listener) => {
                     // Same paired-only gate for blobs: a mesh source must be a
                     // current Circle member (loopback bypasses). Pairing never
@@ -202,7 +202,7 @@ impl AppRuntime {
                     if !mesh_warning.is_empty() {
                         mesh_warning.push_str("; ");
                     }
-                    mesh_warning.push_str(&format!("blossom port 24242 unavailable: {e}"));
+                    mesh_warning.push_str(&format!("blossom port 24243 unavailable: {e}"));
                 }
             }
 
@@ -272,7 +272,7 @@ impl AppRuntime {
                     ..Default::default()
                 });
         }
-        // The Wi-Fi Aware bulk lane: a UDP transport bound `[::]:4870`. UDP is
+        // The Wi-Fi Aware bulk lane: a UDP transport bound `[::]:4871`. UDP is
         // symmetric (no listener/dialer), fips-native, and reuses the proven
         // scoped-link-local path. Peers are supplied only by the platform peer
         // queue (`fips::discovery::platform`) — UDP is not advertised on Nostr

--- a/myco-relay/src/lib.rs
+++ b/myco-relay/src/lib.rs
@@ -1,5 +1,5 @@
 //! `myco-relay` — a generic embedded **Nostr relay**: a NIP-01 event store
-//! implementing `nsite-deck`'s [`RelayBackend`] seam, plus a `ws://…:4869` socket
+//! implementing `nsite-deck`'s [`RelayBackend`] seam, plus a `ws://…:4870` socket
 //! ([`server`]). See `docs/design/nsite-layer.md` §2.1 and
 //! `docs/design/event-gossip.md`.
 //!

--- a/myco-relay/src/server.rs
+++ b/myco-relay/src/server.rs
@@ -1,6 +1,6 @@
 //! A NIP-01 WebSocket relay over [`RelayStore`]. Serves the node's events to the
-//! in-app WebView at `ws://localhost:4869` and to mesh peers at
-//! `ws://[fd00::self]:4869`.
+//! in-app WebView at `ws://localhost:4870` and to mesh peers at
+//! `ws://[fd00::self]:4870`.
 //!
 //! Unlike the original manifest-only socket, this one keeps **live subscriptions**
 //! (a `REQ` stays open; newly-stored events that match are pushed as they arrive),
@@ -111,8 +111,8 @@ const MAX_REQ_TTL: u8 = 2;
 /// Shared per-relay state: the store, a broadcast bus that fans newly-stored
 /// events to all live subscriptions on this device, and the optional mesh gossiper.
 ///
-/// One hub can back **several listeners** (e.g. the mesh `[::]:4869` socket and a
-/// loopback `127.0.0.1:4869` socket for the WebView) via [`serve_on_hub`], so the
+/// One hub can back **several listeners** (e.g. the mesh `[::]:4870` socket and a
+/// loopback `127.0.0.1:4870` socket for the WebView) via [`serve_on_hub`], so the
 /// live bus, store, and gossiper are shared across them — a peer's event pushed on
 /// the mesh socket reaches a WebView subscription on the loopback socket.
 pub struct RelayHub {

--- a/nsite-deck/src/host.rs
+++ b/nsite-deck/src/host.rs
@@ -118,7 +118,7 @@ fn strip_suffix(host: &str) -> Option<&str> {
     }
     // The in-app WebView serves nsites under `<label>.localhost` (not `.nsite`):
     // Chromium classifies `*.localhost` as loopback + a secure context, so the
-    // page can open `ws://localhost:4869` to the embedded relay without tripping
+    // page can open `ws://localhost:4870` to the embedded relay without tripping
     // Private/Local Network Access (see docs/design/nsite-layer.md host suffix).
     if let Some(idx) = lower.rfind(".localhost") {
         if idx + ".localhost".len() == lower.len() {


### PR DESCRIPTION
## What

Bumps the embedded services' localhost ports by one:

| Service | Old | New |
| --- | --- | --- |
| Embedded Nostr relay | 4869 | **4870** |
| Embedded Blossom | 24242 | **24243** |

Swept across code (Rust + Android/Kotlin + `network_security_config.xml`), all docs, and the SVG diagrams. CHANGELOG updated; `docs/reference/ports.md` gained a note explaining the offset.

## Why

To stop Myco squatting on the ports a developer's own localhost relay / Blossom may already run on. Temporary measure until the ports are made configurable.

## Note on the mesh

The localhost bind and the mesh bind use the **same** port number by design — a peer dials `<npub>.fips:4870` and it lands on the peer's `127.0.0.1:4870`. So both had to move together; peer sync over FIPS is unaffected.

## Companion PRs

The two client nsites that default to `ws://localhost:4869` need the matching bump:
- `Origami74/myco-bitchat`
- `Origami74/myco-ics`