### PR TITLE
feat(android): Discover as an icon grid with a Suggested apps row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in Settings.
 - A peer speedtest in the Developer menu that measures upload and download
   throughput to a paired peer over the mesh, for diagnosing slow transfers.
+- The Discover tab now shows apps as an icon grid, with a **Suggested** row of
+  starter apps (bitchat and ICS, an Incident Command System app for disaster
+  response) above the nsites your Circle is hosting. Tapping any app opens it
+  just like opening a shared one — it starts syncing and shows its live page.
 
 ### Changed
 

--- a/android/app/src/main/java/app/myco/ui/screens/DiscoverScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DiscoverScreen.kt
@@ -1,40 +1,62 @@
 package app.myco.ui.screens
 
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import app.myco.NsiteIcons
 import app.myco.core.AppCoreClient
 import app.myco.core.AppState
-import app.myco.core.DiscoveredNsite
 import app.myco.core.NativeActions
 import app.myco.ui.ScreenHeader
 import app.myco.ui.theme.Slate
+import app.myco.ui.theme.tileColorFor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
- * **Discover** — "nsites around me": tap Discover to query connected Circle peers'
- * relays for the nsites they host. Opening a result pulls it from that peer.
+ * **Discover** — an app-drawer of nsites to add: a curated **Suggested** row
+ * (the bundled bitchat + community apps) and **Around you** — nsites your
+ * connected Circle peers are hosting, queried over the mesh. Tiles mirror the
+ * Apps grid (favicon or lettered fallback); tapping an nsite opens it exactly
+ * like opening a shared app — it starts syncing and shows its live page, pulling
+ * from a Circle holder (Around you) or public relays/Blossom (Suggested).
  */
 @Composable
 fun DiscoverScreen(
@@ -44,35 +66,62 @@ fun DiscoverScreen(
 ) {
     // Auto-run discovery when the screen first appears, so results show without a
     // manual tap (the button stays available as Refresh).
-    androidx.compose.runtime.LaunchedEffect(Unit) {
+    LaunchedEffect(Unit) {
         client.dispatch(NativeActions.searchNsites())
     }
-    LazyColumn(
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(4),
         modifier = Modifier.fillMaxSize(),
         contentPadding = androidx.compose.foundation.layout.PaddingValues(20.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
     ) {
-        item {
-            ScreenHeader("Discover", state, subtitle = "nsites your Circle is hosting, over the mesh.")
-            Spacer(Modifier.height(8.dp))
-            OutlinedButton(onClick = { client.dispatch(NativeActions.searchNsites()) }) {
-                Icon(Icons.Filled.Refresh, contentDescription = null)
-                Spacer(Modifier.size(8.dp))
-                Text(if (state.discovered.isEmpty()) "Discover" else "Refresh")
+        item(span = { GridItemSpan(maxLineSpan) }) {
+            Column {
+                ScreenHeader("Discover", state, subtitle = "apps to add — suggested, and nsites your Circle is hosting.")
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(onClick = { client.dispatch(NativeActions.searchNsites()) }) {
+                    Icon(Icons.Filled.Refresh, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text(if (state.discovered.isEmpty()) "Discover" else "Refresh")
+                }
             }
         }
+
+        item(span = { GridItemSpan(maxLineSpan) }) { SectionLabel("Suggested") }
+        items(SUGGESTED_APPS, key = { it.host }) { app ->
+            DiscoverTile(
+                client = client,
+                iconHost = app.host,
+                colorKey = app.host,
+                title = app.title,
+            ) {
+                // Same as opening a shared app (minus pairing): kick off the sync
+                // and open its live page. No holder — a public nsite pulls from the
+                // Circle if a peer has it, else public relays/Blossom.
+                client.dispatch(NativeActions.openNsite(app.host))
+                onLaunchNsite(app.host, app.title)
+            }
+        }
+
+        item(span = { GridItemSpan(maxLineSpan) }) { SectionLabel("Around you") }
         if (state.discovered.isEmpty()) {
-            item {
+            item(span = { GridItemSpan(maxLineSpan) }) {
                 Text(
                     "Nothing found yet. Make sure a Circle peer is connected, then tap Discover.",
                     color = Slate,
                     style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(top = 12.dp),
+                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
         } else {
             items(state.discovered, key = { it.host + it.holderNpub }) { d ->
-                DiscoveredCard(d) {
+                DiscoverTile(
+                    client = client,
+                    iconHost = d.host,
+                    colorKey = d.host,
+                    title = d.title.ifEmpty { d.host.take(8) },
+                ) {
                     client.dispatch(NativeActions.openNsite(d.host, d.holderNpub))
                     onLaunchNsite(d.host, d.title)
                 }
@@ -82,44 +131,87 @@ fun DiscoverScreen(
 }
 
 @Composable
-private fun DiscoveredCard(d: DiscoveredNsite, onOpen: () -> Unit) {
-    Surface(
-        shape = RoundedCornerShape(18.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    d.title.ifEmpty { d.host.take(12) },
-                    fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    "from ${d.holderName.ifEmpty { "a peer" }}",
-                    color = Slate,
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                if (d.updatedAt > 0L) {
-                    // Surface the version timestamp so two same-named apps from
-                    // different authors (npubs) are distinguishable.
-                    Text(
-                        "latest version: ${formatVersion(d.updatedAt)}",
-                        color = Slate,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
+private fun SectionLabel(text: String) {
+    Text(
+        text,
+        fontWeight = FontWeight.Bold,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(top = 4.dp),
+    )
+}
+
+/**
+ * A Discover grid tile, styled like an Apps-drawer icon: the nsite's favicon when
+ * one can be fetched locally (installed / already-pulled sites), otherwise a
+ * lettered tile tinted by [colorKey].
+ */
+@Composable
+private fun DiscoverTile(
+    client: AppCoreClient,
+    iconHost: String,
+    colorKey: String,
+    title: String,
+    onClick: () -> Unit,
+) {
+    var icon by remember(iconHost) { mutableStateOf<Bitmap?>(null) }
+    LaunchedEffect(iconHost) {
+        if (icon == null) {
+            icon = withContext(Dispatchers.IO) {
+                runCatching { NsiteIcons.fetch(client, "$iconHost.localhost") }.getOrNull()
             }
-            Button(onClick = onOpen) { Text("Open") }
         }
+    }
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.clickable(onClick = onClick),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(18.dp))
+                .background(if (icon == null) tileColorFor(colorKey) else MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            val bmp = icon
+            if (bmp != null) {
+                Image(bmp.asImageBitmap(), contentDescription = null, modifier = Modifier.fillMaxSize())
+            } else {
+                Text(
+                    initialOf(title),
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.titleLarge,
+                )
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(
+            title,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.labelMedium,
+            textAlign = TextAlign.Center,
+        )
     }
 }
 
-/** Format a unix-seconds manifest timestamp as a local `yyyy-MM-dd HH:mm`. */
-private fun formatVersion(epochSecs: Long): String =
-    java.time.format.DateTimeFormatter
-        .ofPattern("yyyy-MM-dd HH:mm")
-        .format(java.time.Instant.ofEpochSecond(epochSecs).atZone(java.time.ZoneId.systemDefault()))
+private fun initialOf(label: String): String =
+    label.firstOrNull { it.isLetterOrDigit() }?.uppercase() ?: "?"
+
+/**
+ * A curated app suggestion. [host] is the nsite gateway label (the `nsite.lol`
+ * subdomain, i.e. a `<base36-pubkey><d-tag>` named site) — the same string a
+ * discovered nsite carries in `host`, so opening one runs the identical path.
+ */
+private data class SuggestedApp(val title: String, val host: String)
+
+/**
+ * Curated starter apps shown in Discover. `bitchat` is also the bundled first-run
+ * default (`DEFAULT_SITES` in `myco-core`); listing it here lets a user who wiped
+ * it get it back.
+ */
+private val SUGGESTED_APPS = listOf(
+    SuggestedApp("bitchat", "4ofb5evx6765n3syphyhlocydo8q7fyipswzgpkx59u7p1yiivbitchat"),
+    SuggestedApp("ICS", "4ofb5evx6765n3syphyhlocydo8q7fyipswzgpkx59u7p1yiivics"),
+)


### PR DESCRIPTION
## What this adds

Reworks the **Discover** tab into an app-drawer icon grid (matching the Apps screen — favicon tile with a lettered fallback) and adds a curated **Suggested** row above the mesh-discovered results.

- **Suggested** — starter apps a fresh install can grab: **bitchat** (also the bundled first-run default in `DEFAULT_SITES`, so a user who wiped it can get it back) and **ICS** — an Incident Command System app for disaster response.
- **Around you** — the existing mesh discovery, now rendered as icon tiles.

## Why the two behave identically

The suggestions are **named nsites** (`<base36-pubkey><d-tag>`), so the gateway label *is* the `nsite.lol` subdomain. That means a Suggested tile carries the same `host` string a discovered nsite does, and tapping either runs the same path: `open_nsite(host)` + launch. Opening an app now works just like opening a **shared** app (QR/NFC), minus the pairing step — it starts syncing and shows its live page, pulling from a Circle holder (Around you) or public relays/Blossom (Suggested, no holder).

## Testing

- `./gradlew :app:assembleDebug` builds; installed on a Pixel 7 Pro.
- On-device: Discover shows the icon grid; the Suggested `bitchat` tile renders its real favicon (it's seeded), the ICS tile shows a lettered fallback until pulled; tapping either opens the app and it syncs in.

## Notes / follow-ups

- No Rust changes — pure Android/Compose, plus a CHANGELOG entry.
- Suggested curation is hardcoded in `DiscoverScreen.kt` (`SUGGESTED_APPS`); a real curation source can replace the constant later.
