### PR TITLE
chore: v0.2.0 release prep — changelog bump and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-14
+
 ### Added
 
 - An experimental **Wi-Fi Aware** transfer lane that runs alongside the Bluetooth

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,113 +1,117 @@
-# Myco v0.1.0
+# Myco v0.2.0
 
-**Released**: 2026-06-30
+**Released**: 2026-07-14
 
-v0.1.0 makes the Bluetooth mesh **reliable**. The L2CAP reader and writer had a
-fundamental framing mismatch with the embedded core that caused data corruption
-on almost every BLE link — fragmented socket reads were shipped up as truncated
-packets and coalesced reads were silently dropped. That's now fixed: the radio is
-a transparent byte pipe, and the core recovers packet boundaries itself using the
-same length-prefixed framer the IP transport uses. If a chunk ever does go
-missing the link resets cleanly instead of silently corrupting the rest of the
-session.
+v0.2.0 is about **reach and reliability**: chat and content now flow across your
+whole Circle — including peers several hops away over the mesh — and survive the
+link drops, reconnects, and Bluetooth flaps that used to silently stall them. On
+top of that it ships an **experimental Wi-Fi Aware bulk lane** for fast transfers
+between capable phones, and a redesigned Discover tab.
 
-On top of the reliability fix, v0.1.0 ships NFC sharing, a storage settings
-page, peer speedtest diagnostics, and a cleaned-up settings layout. It upgrades
-from v0.0.3 in-place with no data loss.
+> **Update every device together.** v0.2.0 moves the embedded relay and Blossom
+> ports (see below), so a v0.2.0 phone and a v0.1.0 phone **won't exchange chat
+> or content over the mesh**. Pairing and discovery still work across versions —
+> but sync won't — so update all the devices in a Circle.
 
-It interoperates with v0.0.3 devices on the mesh; older peers aren't aware of
-the NFC sharing path or the speedtest, but the mesh still routes and pairs over
-QR as before.
+It upgrades from v0.1.0 in place with no data loss; your identity (nsec), Circle,
+and installed apps are preserved.
 
 ## At a glance
 
-- **BLE reliability fix** — the headline change; mesh links no longer corrupt
-  data or thrash when the socket read doesn't align to a packet boundary.
-- NFC app sharing — bump phones to hand off a `myco://share` link; the recipient
-  pairs and pulls the app from you over the mesh.
-- Storage settings — usage gauge, delete-cache, and delete-all-data.
-- Peer speedtest — round-trip a payload through a paired peer and read up/down
-  throughput in the Dev tab.
-- Settings reorganised into focused pages; mesh controls and raw identity fields
-  behind a developer page.
-- Circle *Nearby* is always shown, sorted by name — no reshuffling as signal
-  fluctuates.
-- App locked to portrait everywhere.
+- **Whole-Circle, multi-hop chat** — messages reach every Circle member wherever
+  they are on the mesh, not just direct neighbours.
+- **Resilient relay links** — each device keeps a persistent, two-way relay
+  connection to every Circle member, detects a dead link, and re-establishes it
+  within seconds of a flap — both directions — pulling back anything missed.
+- **BLE scanning recovers itself** — discovery no longer gets stuck at zero peers
+  after a burst of connects/disconnects.
+- **Wi-Fi Aware bulk lane (experimental)** — a second, much faster transport
+  raised beside BLE when both phones support it. Off by default.
+- **Redesigned Discover** — an app-icon grid with a **Suggested** row of starter
+  apps; tapping one opens it just like opening a shared app.
+- **Bigger uploads** — the in-app Blossom store now accepts up to 64 MiB.
+- **Relay/Blossom ports moved** to 4870 / 24243 (see Behavior changes).
 
 ## What's new
 
-### BLE reliability fix
+### Wi-Fi Aware bulk lane (experimental)
 
-The Kotlin L2CAP radio was applying its own 2-byte length-prefix framing on top
-of `BluetoothSocket` — a byte *stream* with no packet boundaries — and
-reconstructing packets in the reader with a `readFully()` that assumed each
-socket `read()` returned exactly one whole mesh packet. It didn't: a fragmented
-read produced a runt packet; a coalesced read was truncated to the first expected
-length. Either way data was corrupted and the link would eventually thrash or
-stall.
+BLE is reliable but slow — a real handset L2CAP link tops out around ~22 KB/s,
+which makes a large nsite a long transfer. v0.2.0 adds an **experimental Wi-Fi
+Aware (NAN) lane**: when two nearby phones both have the hardware, they form a
+pairwise Wi-Fi data path and larger transfers ride it at Wi-Fi speed, while
+pairing and discovery stay on the always-on BLE mesh. It runs as fips's native
+UDP transport over the Aware interface — no new wire format — and is **off by
+default**; enable it under the Wi-Fi Aware section in Settings. Aware-less phones
+simply stay on BLE. A dev-menu **adaptive speedtest** measures the lane
+end-to-end (up/down throughput to a paired peer), with sub-1-Mbps results shown
+in kbps.
 
-The fix removes the per-packet framing from Kotlin entirely. The radio is now a
-**transparent, in-order byte pipe**: the reader forwards whatever `read()` returns
-directly to the core via `deliver_recv`, and the writer writes whatever the core
-hands it verbatim. The embedded core's `BleStreamRead` framer — the same
-`FMP` length-prefixed framer used on the IP transport — recovers packet
-boundaries from the raw stream. If `deliver_recv` ever refuses a chunk (inbound
-queue full or channel gone), the reader now treats that as fatal and resets the
-link, rather than dropping the chunk silently and desyncing the framer for the
-rest of the connection.
+Wi-Fi Aware is experimental: hardware coverage is uneven, throughput is
+unmeasured across the device matrix, and the BLE↔Aware cutover policy is still
+being tuned. Treat it as a preview.
 
-### NFC app sharing
+### Redesigned Discover
 
-The "Share this app" surface is now a bottom sheet: a larger QR code, a
-prominent "tap phones together" prompt, and an auto-close once the recipient
-pairs. On the receiving side, *Add an app* is a bottom sheet with a live camera
-scanner, a paste-a-link button, and a tap-a-phone option — and tapping opens the
-share sheet in emulation mode so a bump hands off the `myco://share` code over
-NFC the same way pairing does.
+Discover is now an app-drawer icon grid (favicon or lettered tile), matching the
+Apps screen. A curated **Suggested** row sits above the mesh-discovered results:
+**bitchat** (also the bundled first-run default, so a user who wiped it can get
+it back) and **ICS**, an Incident Command System app for disaster response.
+Tapping any tile — Suggested or discovered — opens the app exactly like opening a
+shared one: it starts syncing and shows its live page, pulling from a Circle peer
+that has it or, for the public suggestions, from public relays/Blossom.
 
-### Storage settings
+## Reliability: the mesh now holds
 
-A new **Storage** page in Settings shows a local storage gauge (relay + Blossom)
-and two delete actions: *Delete cache* reclaims space while keeping pinned apps
-working offline, and *Delete all data, including apps* wipes the relay and
-Blossom entirely. Your identity (nsec) and Circle survive both.
+The bulk of v0.2.0 is a wave of mesh-comms fixes so chat and content keep flowing
+as people move around and links come and go.
 
-### Peer speedtest
-
-The Dev diagnostics tab now has a **speedtest** that round-trips a fixed payload
-through a connected, paired peer's mesh Blossom and reports up and down
-throughput. Results under 1 Mbps display in kbps so a slow BLE link reads as
-e.g. "220 kbps" rather than "0.2 Mbps."
-
-### Settings reorganisation
-
-Settings is now a list of focused pages. Everyday controls — device name,
-storage, and the mesh (with Bluetooth as a sub-toggle) — stay on the first
-screen. The mesh-only switch and raw identity fields (npub, node\_addr, `.fips`
-address, mesh ULA) move behind a **Developer** page, so everyday users don't
-land on a screen full of hex strings.
+- **Chat reaches your whole Circle.** Messages used to fan out only to Circle
+  members you were *directly* connected to; once two paired people drifted several
+  hops apart, their messages stopped even though the mesh could still route
+  between them. Chat now fans out to the whole Circle, so a paired peer keeps
+  receiving your messages wherever they sit on the mesh.
+- **Relay links restore fast and both ways.** When a device in the middle of a
+  chain dropped and reconnected, the relay links between Circle members came back
+  slowly and often one-way, stalling messages for up to a minute. Each device now
+  proactively keeps a live relay connection to every Circle member, re-establishes
+  it within seconds of a flap in **both** directions, and on reconnect recreates
+  its open subscriptions against the returned peer to pull back anything missed.
+- **No more silent stalls after a Bluetooth flap.** The reused write-only relay
+  connection could go stale — a half-open socket the app never noticed — and
+  quietly swallow every message while the mesh still looked healthy. Each peer now
+  holds a single persistent, two-way connection that detects a dead link (read
+  side + keepalive) and reconnects; manifest fetches share that one socket.
+- **BLE discovery recovers on its own.** After a burst of connects/disconnects,
+  Android's scan throttle (~5 starts per 30s) could leave discovery stuck at zero
+  peers until you toggled the mesh off and on. The scanner now re-arms itself on a
+  backoff, waits out the throttle window, and recovers on its own.
 
 ## Behavior changes worth flagging
 
-- **BLE links will reset on framer desync.** Under the old code a corrupted link
-  would stall silently; now it resets and reconnects. You may see reconnect
-  events in the Dev tab where before you saw a stalled link.
-- **NFC sharing auto-closes the sheet.** Once the recipient pairs, the "Share
-  this app" bottom sheet closes itself — the same pattern as the pairing flow.
+- **Relay/Blossom ports moved.** The embedded Nostr relay is now on **4870** and
+  Blossom on **24243** (up one from 4869 / 24242), so Myco stops squatting on the
+  ports a developer's own localhost relay or Blossom may use. Because the mesh and
+  localhost binds share a port number, both moved together. **Consequence:** a
+  v0.2.0 device and a v0.1.0 device won't sync chat or content over the mesh —
+  update all devices together. (Temporary until the ports become configurable.)
+- **Wi-Fi Aware is off until you enable it.** No behavior change unless you turn
+  the lane on in Settings.
 
 ## Notable bug fixes
 
-- **Bluetooth data corruption** — fragmented or coalesced L2CAP reads no longer
-  produce runt or truncated packets; see above.
-- **Portrait lock** — the app no longer flips to landscape on a slight tilt.
+- **Chat stalled across the mesh** — one-way and lost messages after a mid-chain
+  peer flapped; see Reliability above.
+- **Discovery stuck at zero peers** — BLE scan-throttle recovery.
+- **Silent event-propagation stall** — stale half-open peer-relay socket.
 
 ## Getting it
 
-- **Android**: install the v0.1.0 APK from the
-  [release page](https://github.com/Origami74/myco/releases/tag/v0.1.0),
+- **Android**: install the v0.2.0 APK from the
+  [release page](https://github.com/Origami74/myco/releases/tag/v0.2.0),
   or via [zapstore](https://zapstore.dev/apps/app.myco).
 - **From source**: `cd android && ./gradlew assembleDebug` from a checkout of
-  the v0.1.0 tag. See [CONTRIBUTING.md](CONTRIBUTING.md) for build prerequisites.
+  the v0.2.0 tag. See [CONTRIBUTING.md](CONTRIBUTING.md) for build prerequisites.
 
 The full per-release change history lives in [CHANGELOG.md](CHANGELOG.md).
 Issues and discussion at [github.com/Origami74/myco](https://github.com/Origami74/myco).


### PR DESCRIPTION
Release prep for **v0.2.0**: bump `CHANGELOG.md` (`[Unreleased]` → `[0.2.0] - 2026-07-14`, fresh empty `[Unreleased]`) and rewrite `RELEASE-NOTES.md` for the release. No code changes.

## What's in v0.2.0

Rolls up the four mesh-reliability fixes (#6–#9), the Wi-Fi Aware bulk lane + adaptive speedtest (#10), the port bump (#11), and the Discover redesign (#12).

- **Reliability wave** — whole-Circle multi-hop chat, fast bidirectional relay-link recovery on flap, no more silent stalls after a BLE drop, self-recovering BLE scan.
- **Wi-Fi Aware bulk lane (experimental, off by default)** — a fast second transport beside BLE.
- **Discover redesign** — icon grid + Suggested row.
- **64 MiB uploads**; **relay/Blossom ports moved to 4870 / 24243** (Aware on 4871).

## ⚠️ Interop break to call out

The port move means a **v0.2.0 device won't sync chat or content over the mesh with a v0.1.0 device** (pairing/discovery still work). The release notes lead with "update every device together." Worth confirming this is acceptable for the release.

## Release mechanics (after merge)

- Version is tag-driven (`MYCO_VERSION_NAME` from the tag) — no gradle bump needed.
- `release.yml` clones fips from `feat/platform-peer-queue` (landed in #10), so the Aware code builds.
- Cutting the release = push a `v0.2.0` tag → the Release workflow builds + publishes the APK. **I have not tagged** — that's the trigger, left for you to pull.
