### PR TITLE
feat(android): Wi-Fi AP lane — discover LAN fips nodes over mDNS, peer over UDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A **Wi-Fi AP lane** (developer preview): when the phone joins a Wi-Fi network
+  that carries a FIPS node — such as a router broadcasting the open `!FIPS`
+  access SSID — Myco discovers the node via its mDNS advert (`_fips._udp`) and
+  connects to it over UDP automatically. Requires LAN discovery/rendezvous to
+  be enabled on the router's fips node. The Developer screen gains a
+  **Wi-Fi AP** panel (Wi-Fi/SSID state, mDNS browse state, discovered nodes),
+  and the Wi-Fi Aware panel now lists live data paths. See
+  [docs/design/ap-lane.md](docs/design/ap-lane.md).
+
 ## [0.2.0] - 2026-07-14
 
 ### Added

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions
 import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import app.myco.ap.ApRadio
 import app.myco.aware.AwareRadio
 import app.myco.aware.AwareService
 import app.myco.ble.BleService
@@ -93,6 +94,12 @@ class MainActivity : ComponentActivity() {
         core.dispatch(NativeActions.setOfflineOnly(prefs.getBoolean(PREF_OFFLINE_ONLY, false)))
         // (Device name is asserted in onResume, which also covers identity not yet
         // being ready at this point.)
+
+        // The `!FIPS` AP lane: watch Wi-Fi and browse the LAN for fips-node
+        // mDNS adverts, feeding them to the node (Dev panel shows results).
+        // Passive and permissionless; process-wide, so idempotent across
+        // Activity recreation.
+        ApRadio.ensureStarted(this)
 
         // BLE on by default, and remembered thereafter.
         if (prefs.getBoolean(PREF_BLE, true)) {

--- a/android/app/src/main/java/app/myco/ap/ApRadio.kt
+++ b/android/app/src/main/java/app/myco/ap/ApRadio.kt
@@ -1,0 +1,372 @@
+package app.myco.ap
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.net.wifi.WifiInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import androidx.annotation.RequiresApi
+import app.myco.core.MycoCore
+import app.myco.core.NativeCore
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * The `!FIPS` access-point lane. When the phone associates with a FIPS AP's
+ * open `!FIPS` SSID (or any LAN carrying a fips node), this connects the app's
+ * node to the AP's fips node over the ordinary UDP transport:
+ *
+ *  1. watch infrastructure Wi-Fi via a [ConnectivityManager.NetworkCallback]
+ *     (passive, permissionless);
+ *  2. while any Wi-Fi is up, browse mDNS for `_fips._udp` — the advert fips
+ *     LAN discovery publishes (`reference/fips` `src/discovery/lan`), whose
+ *     TXT carries the node's `npub`;
+ *  3. on resolve, push `(npub, addr)` into the core's platform peer queue
+ *     ([NativeCore.awarePeerFound], transport `"udp"`) — the same seam the
+ *     Wi-Fi Aware radio uses. The node dials the UDP transport bound `:4871`
+ *     and Noise IK authenticates; the pushed npub is only a routing hint.
+ *
+ * The browse is deliberately **not** gated on the literal `!FIPS` SSID: on
+ * API 33+ the SSID is redacted unless the app holds location permission, so a
+ * name gate would kill the lane on modern devices — and browsing another LAN
+ * is harmless (nothing advertises there). The SSID is still read best-effort
+ * for the Dev panel.
+ *
+ * Address preference on resolve: link-local IPv6 first (never captured by the
+ * mesh TUN, always on-link), then a global/non-ULA IPv6, then IPv4 as a
+ * v4-mapped IPv6 (`[::ffff:a.b.c.d]` — the core's UDP socket is a dual-stack
+ * `[::]` bind and its transport selection is family-aware, so a plain V4
+ * address would find no compatible socket). `fd00::/8` addresses are skipped:
+ * the VpnService routes that prefix into the mesh TUN, so dialing one would
+ * blackhole the handshake.
+ */
+class ApRadio private constructor(private val context: Context) {
+    private val connectivity =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val nsd = context.getSystemService(Context.NSD_SERVICE) as NsdManager
+
+    /** All mutable state below is confined to this thread. */
+    private val thread = HandlerThread("myco-ap").apply { start() }
+    private val handler = Handler(thread.looper)
+
+    /** Live infrastructure Wi-Fi networks (usually 0 or 1). */
+    private val wifiNets = HashSet<Network>()
+
+    /** mDNS instance name → npub, learned at resolve time (a lost event
+     *  carries only the instance name). */
+    private val npubByService = HashMap<String, String>()
+
+    /** npub → last pushed addr. */
+    private val pushed = HashMap<String, String>()
+
+    private val resolveQueue = ArrayDeque<NsdServiceInfo>()
+    private var resolving = false
+    private var browsing = false
+    private var browseListener: NsdManager.DiscoveryListener? = null
+    private var ssid: String? = null
+
+    /** Own npub, to skip a self-advert (defensive — the app never publishes
+     *  mDNS, only browses). Resolved lazily; the core is up by first resolve. */
+    private val ownNpub: String by lazy {
+        runCatching { MycoCore.client(context).state().ownNpub }.getOrDefault("")
+    }
+
+    private inner class WifiCallback : ConnectivityManager.NetworkCallback {
+        constructor() : super()
+
+        @RequiresApi(Build.VERSION_CODES.S)
+        constructor(flags: Int) : super(flags)
+
+        override fun onAvailable(network: Network) {
+            if (wifiNets.add(network) && wifiNets.size == 1) startBrowse()
+            publishWifi()
+        }
+
+        override fun onCapabilitiesChanged(network: Network, caps: NetworkCapabilities) {
+            currentSsid(caps)?.let { ssid = it }
+            publishWifi()
+        }
+
+        override fun onLost(network: Network) {
+            if (wifiNets.remove(network) && wifiNets.isEmpty()) {
+                ssid = null
+                stopBrowse()
+            }
+            publishWifi()
+        }
+    }
+
+    private fun start() {
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .build()
+        // FLAG_INCLUDE_LOCATION_INFO (31+) asks for an unredacted SSID in the
+        // callback's WifiInfo; still redacted without location permission —
+        // that's fine, the SSID is display-only.
+        val callback = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            WifiCallback(ConnectivityManager.NetworkCallback.FLAG_INCLUDE_LOCATION_INFO)
+        } else {
+            WifiCallback()
+        }
+        connectivity.registerNetworkCallback(request, callback, handler)
+        Log.i(TAG, "AP lane armed (browsing $SERVICE_TYPE while Wi-Fi is up)")
+    }
+
+    // --- mDNS browse ---
+
+    private fun startBrowse() {
+        if (browseListener != null) return
+        // A DiscoveryListener is single-use: a fresh one per browse session.
+        val listener = object : NsdManager.DiscoveryListener {
+            override fun onDiscoveryStarted(serviceType: String) {
+                handler.post {
+                    browsing = true
+                    publishWifi()
+                    handler.postDelayed(repush, REPUSH_MS)
+                    Log.i(TAG, "mDNS browse started")
+                }
+            }
+
+            override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+                handler.post {
+                    Log.w(TAG, "mDNS browse failed to start: $errorCode")
+                    browseListener = null
+                    browsing = false
+                    publishWifi()
+                }
+            }
+
+            override fun onServiceFound(info: NsdServiceInfo) {
+                handler.post {
+                    resolveQueue.add(info)
+                    pumpResolve()
+                }
+            }
+
+            override fun onServiceLost(info: NsdServiceInfo) {
+                handler.post { serviceLost(info.serviceName) }
+            }
+
+            override fun onDiscoveryStopped(serviceType: String) {
+                handler.post { browsing = false; publishWifi() }
+            }
+
+            override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+                handler.post { browsing = false; publishWifi() }
+            }
+        }
+        browseListener = listener
+        nsd.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, listener)
+    }
+
+    private fun stopBrowse() {
+        browseListener?.let { runCatching { nsd.stopServiceDiscovery(it) } }
+        browseListener = null
+        browsing = false
+        handler.removeCallbacks(repush)
+        resolveQueue.clear()
+        // The LAN is gone with the link: tell the core so it closes the pooled
+        // UDP sessions instead of re-using dead sockets.
+        for (npub in pushed.keys) NativeCore.awarePeerLost(npub)
+        pushed.clear()
+        npubByService.clear()
+        publishNodes()
+        publishWifi()
+    }
+
+    /** Periodic re-push of every resolved node while the browse is live: NSD
+     *  fires onServiceFound only once per appearance, so a dropped UDP session
+     *  would otherwise never get a fresh dial hint. The core's alternate-path
+     *  gates make a redundant push a no-op for a healthy peer. */
+    private val repush = object : Runnable {
+        override fun run() {
+            if (browseListener == null) return
+            for ((npub, addr) in pushed) NativeCore.awarePeerFound(npub, addr)
+            handler.postDelayed(this, REPUSH_MS)
+        }
+    }
+
+    // --- resolve (NsdManager allows one in-flight resolve at a time) ---
+
+    private fun pumpResolve() {
+        if (resolving) return
+        val next = resolveQueue.removeFirstOrNull() ?: return
+        resolving = true
+        @Suppress("DEPRECATION") // registerServiceInfoCallback is 34+; minSdk 29
+        nsd.resolveService(next, object : NsdManager.ResolveListener {
+            override fun onServiceResolved(info: NsdServiceInfo) {
+                handler.post {
+                    resolving = false
+                    resolved(info)
+                    pumpResolve()
+                }
+            }
+
+            override fun onResolveFailed(info: NsdServiceInfo, errorCode: Int) {
+                handler.post {
+                    resolving = false
+                    if (errorCode == NsdManager.FAILURE_ALREADY_ACTIVE) {
+                        // Another app's resolve is in flight; retry shortly.
+                        resolveQueue.add(info)
+                        handler.postDelayed({ pumpResolve() }, 1_000)
+                    } else {
+                        Log.w(TAG, "resolve failed for ${info.serviceName}: $errorCode")
+                        pumpResolve()
+                    }
+                }
+            }
+        })
+    }
+
+    private fun resolved(info: NsdServiceInfo) {
+        val npub = info.attributes[TXT_NPUB]?.toString(Charsets.UTF_8)
+            ?.takeIf { it.startsWith("npub1") }
+            ?: run { Log.w(TAG, "advert ${info.serviceName} has no npub TXT"); return }
+        if (npub == ownNpub) return
+        val addr = pickAddr(info) ?: run {
+            Log.w(TAG, "no dialable address for ${short(npub)} (${info.serviceName})")
+            return
+        }
+        npubByService[info.serviceName] = npub
+        if (pushed[npub] != addr) {
+            Log.i(TAG, "fips node ${short(npub)} at $addr — pushing to core")
+            NativeCore.awarePeerFound(npub, addr)
+            pushed[npub] = addr
+        }
+        publishNodes()
+    }
+
+    private fun serviceLost(serviceName: String) {
+        val npub = npubByService.remove(serviceName) ?: return
+        if (pushed.remove(npub) != null) {
+            Log.i(TAG, "fips node ${short(npub)} gone from LAN")
+            NativeCore.awarePeerLost(npub)
+        }
+        publishNodes()
+    }
+
+    /**
+     * Pick the address to dial, per the preference order in the class doc.
+     * Formats match what the core's address parser accepts: numeric-scope
+     * link-local (`[fe80::x%3]:4871`), plain `[v6]:port`, v4-mapped v6.
+     */
+    private fun pickAddr(info: NsdServiceInfo): String? {
+        val hosts: List<InetAddress> =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                info.hostAddresses
+            } else {
+                @Suppress("DEPRECATION")
+                listOfNotNull(info.host)
+            }
+        val port = info.port.takeIf { it > 0 } ?: return null
+        val v6 = hosts.filterIsInstance<Inet6Address>()
+        v6.firstOrNull { it.isLinkLocalAddress && it.scopeId != 0 }
+            ?.let { return "[${bare(it)}%${it.scopeId}]:$port" }
+        // fd00::/8 is routed into the mesh TUN — dialing it would blackhole.
+        v6.firstOrNull { !it.isLinkLocalAddress && it.address[0] != 0xfd.toByte() }
+            ?.let { return "[${bare(it)}]:$port" }
+        hosts.filterIsInstance<Inet4Address>().firstOrNull()
+            ?.let { return "[::ffff:${it.hostAddress}]:$port" }
+        return null
+    }
+
+    private fun bare(a: InetAddress): String = a.hostAddress?.substringBefore('%') ?: ""
+
+    // --- state for the Dev panel ---
+
+    private fun publishWifi() {
+        _wifi.value = WifiApView(
+            connected = wifiNets.isNotEmpty(),
+            ssid = currentSsid() ?: ssid,
+            browsing = browsing,
+        )
+    }
+
+    private fun publishNodes() {
+        _nodes.value = npubByService.values.distinct().map { npub ->
+            LanFipsNode(npub = npub, addr = pushed[npub] ?: "", pushed = pushed.containsKey(npub))
+        }
+    }
+
+    /** Best-effort SSID: from the callback's [WifiInfo] on 31+ (unredacted only
+     *  with location permission), from the deprecated [WifiManager] path below. */
+    private fun currentSsid(caps: NetworkCapabilities? = null): String? {
+        val raw = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (caps?.transportInfo as? WifiInfo)?.ssid
+        } else {
+            @Suppress("DEPRECATION")
+            runCatching {
+                (context.getSystemService(Context.WIFI_SERVICE) as? WifiManager)
+                    ?.connectionInfo?.ssid
+            }.getOrNull()
+        }
+        return raw?.removeSurrounding("\"")
+            ?.takeIf { it.isNotEmpty() && it != WifiManager.UNKNOWN_SSID }
+    }
+
+    private fun short(npub: String): String =
+        if (npub.length > 12) npub.substring(0, 12) + "…" else npub
+
+    companion object {
+        private const val TAG = "MycoApRadio"
+
+        /** fips LAN discovery's DNS-SD service type (Android form, no `.local.`). */
+        private const val SERVICE_TYPE = "_fips._udp"
+
+        /** TXT key carrying the advertising node's npub. */
+        private const val TXT_NPUB = "npub"
+
+        private const val REPUSH_MS = 60_000L
+
+        private val _wifi = MutableStateFlow(WifiApView())
+        private val _nodes = MutableStateFlow<List<LanFipsNode>>(emptyList())
+
+        /** Wi-Fi + browse status, for the Dev screen. */
+        val wifi: StateFlow<WifiApView> = _wifi.asStateFlow()
+
+        /** fips nodes discovered on the current LAN, for the Dev screen. */
+        val nodes: StateFlow<List<LanFipsNode>> = _nodes.asStateFlow()
+
+        @Volatile
+        private var instance: ApRadio? = null
+
+        /** Start the process-wide watcher (idempotent; survives Activity
+         *  recreation — it holds only the application context). */
+        fun ensureStarted(context: Context) {
+            if (instance != null) return
+            synchronized(this) {
+                if (instance == null) {
+                    instance = ApRadio(context.applicationContext).also { it.start() }
+                }
+            }
+        }
+    }
+}
+
+/** Wi-Fi + mDNS-browse status for the Dev panel. `ssid` is best-effort (null
+ *  when redacted — API 33+ without location permission). */
+data class WifiApView(
+    val connected: Boolean = false,
+    val ssid: String? = null,
+    val browsing: Boolean = false,
+)
+
+/** One fips node seen on the current LAN. `pushed` = handed to the core's
+ *  platform peer queue (the node dials it over UDP). */
+data class LanFipsNode(
+    val npub: String,
+    val addr: String,
+    val pushed: Boolean,
+)

--- a/android/app/src/main/java/app/myco/aware/AwareRadio.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareRadio.kt
@@ -25,6 +25,9 @@ import android.util.Log
 import app.myco.core.NativeCore
 import java.net.Inet6Address
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * The Wi-Fi Aware (NAN) bulk-lane radio. Control-plane only: it discovers
@@ -146,6 +149,7 @@ class AwareRadio(
         for ((_, cb) in ndpCallbacks) runCatching { connectivity.unregisterNetworkCallback(cb) }
         ndpCallbacks.clear()
         peerNpubs.clear()
+        _links.value = emptyList()
         runCatching { publishSession?.close() }
         runCatching { subscribeSession?.close() }
         runCatching { session?.close() }
@@ -253,6 +257,7 @@ class AwareRadio(
                 val info = caps.transportInfo as? WifiAwareNetworkInfo ?: return
                 val addr = formatPeerAddr(info.peerIpv6Addr) ?: return
                 Log.i(TAG, "Aware NDP up to ${short(peerNpub)} at $addr")
+                setLink(peerNpub, addr, up = true)
                 NativeCore.awarePeerFound(peerNpub, addr)
             }
 
@@ -273,6 +278,7 @@ class AwareRadio(
             }
         }
         ndpCallbacks[peerNpub] = callback
+        setLink(peerNpub, addr = null, up = false)
         // Timed request: on failure to provision within NDP_TIMEOUT_MS the
         // framework calls onUnavailable and releases it, so a stuck negotiation
         // never leaks a data-path slot (the root cause of "works fresh, dies
@@ -285,6 +291,7 @@ class AwareRadio(
         ndpCallbacks.remove(peerNpub)?.let {
             runCatching { connectivity.unregisterNetworkCallback(it) }
         }
+        removeLink(peerNpub)
     }
 
     /** Best-effort snapshot of free Aware data-path/session slots (API 31+),
@@ -321,6 +328,21 @@ class AwareRadio(
     companion object {
         private const val TAG = "MycoAwareRadio"
 
+        private val _links = MutableStateFlow<List<AwareLink>>(emptyList())
+
+        /** Live NDP links (requested + up), for the Dev screen. There is one
+         *  radio per process (owned by [AwareService]), so a companion flow is
+         *  safe; [closeSessions]/[stop] clear it. */
+        val links: StateFlow<List<AwareLink>> = _links.asStateFlow()
+
+        private fun setLink(npub: String, addr: String?, up: Boolean) {
+            _links.value = _links.value.filter { it.npub != npub } + AwareLink(npub, addr, up)
+        }
+
+        private fun removeLink(npub: String) {
+            _links.value = _links.value.filter { it.npub != npub }
+        }
+
         /**
          * Whether this device has Wi-Fi Aware hardware at all — a static
          * capability the UI can read to gray out the toggle and show
@@ -353,3 +375,11 @@ class AwareRadio(
         private const val NDP_TIMEOUT_MS = 20_000
     }
 }
+
+/** One Wi-Fi Aware NDP as the radio sees it: requested (no addr yet) or up
+ *  (peer's scoped link-local + port). For the Dev screen. */
+data class AwareLink(
+    val npub: String,
+    val addr: String?,
+    val up: Boolean,
+)

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -15,11 +15,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import app.myco.ap.ApRadio
+import app.myco.ap.LanFipsNode
+import app.myco.aware.AwareLink
 import app.myco.aware.AwareRadio
 import app.myco.core.AppCoreClient
 import app.myco.core.AppState
@@ -45,6 +50,9 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
     val context = LocalContext.current
     val awareSupported = AwareRadio.isSupported(context)
     val awareAvailable = AwareRadio.isAvailable(context)
+    val awareLinks by AwareRadio.links.collectAsState()
+    val apWifi by ApRadio.wifi.collectAsState()
+    val apNodes by ApRadio.nodes.collectAsState()
     Column(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -75,6 +83,24 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
                     )
                     KeyValDot("lane", if (state.wifiAwareEnabled) "enabled" else "off", state.wifiAwareEnabled)
                     KeyVal("udp port", if (state.wifiAwarePort > 0) state.wifiAwarePort.toString() else "—")
+                    if (awareLinks.isEmpty()) {
+                        EmptyLine("no data paths")
+                    } else {
+                        awareLinks.forEach { AwareLinkRow(it) }
+                    }
+                }
+                DevCard("WI-FI AP (!FIPS)") {
+                    KeyValDot(
+                        "wi-fi",
+                        apWifi.ssid ?: if (apWifi.connected) "connected" else "off",
+                        apWifi.connected,
+                    )
+                    KeyValDot("mdns browse", if (apWifi.browsing) "active" else "idle", apWifi.browsing)
+                    if (apNodes.isEmpty()) {
+                        EmptyLine("no fips node on this lan")
+                    } else {
+                        apNodes.forEach { ApNodeRow(it) }
+                    }
                 }
                 DevCard("PEERS (${state.blePeers.size})") {
                     if (state.blePeers.isEmpty()) {
@@ -213,6 +239,36 @@ private fun PeerRow(peer: BlePeer) {
         )
         Text(
             "${short(peer.nodeAddrHex)}  ${peer.npub.ifEmpty { "(handshake pending)" }.let { if (it.length > 18) it.take(14) + "…" else it }}",
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+        )
+    }
+}
+
+@Composable
+private fun AwareLinkRow(l: AwareLink) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) {
+        Text(
+            if (l.up) "● ndp up" else "○ ndp requested",
+            color = if (l.up) StatusConnected else Slate,
+            style = MaterialTheme.typography.labelMedium,
+        )
+        Text(
+            "${short(l.npub)}  ${l.addr ?: ""}",
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+        )
+    }
+}
+
+@Composable
+private fun ApNodeRow(n: LanFipsNode) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) {
+        Text(
+            if (n.pushed) "● pushed to node" else "○ resolved",
+            color = if (n.pushed) StatusConnected else Slate,
+            style = MaterialTheme.typography.labelMedium,
+        )
+        Text(
+            "${short(n.npub)}  ${n.addr}",
             style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
         )
     }

--- a/docs/design/ap-lane.md
+++ b/docs/design/ap-lane.md
@@ -1,0 +1,74 @@
+# The Wi-Fi AP Lane (`!FIPS` access SSID)
+
+FIPS routers can broadcast an open access SSID — `!FIPS` — that phones
+join to reach the mesh through the router (see the fips repo's
+`docs/how-to/set-up-open-access-ssid.md`). This lane connects Myco's
+embedded node to the router's fips node over the ordinary UDP
+transport whenever the phone is on such a network.
+
+## Mechanism
+
+The lane is Kotlin-side control plane only (`app.myco.ap.ApRadio`), a
+sibling of the Wi-Fi Aware radio and reusing its core seam:
+
+1. A passive `ConnectivityManager.NetworkCallback` on `TRANSPORT_WIFI`
+   watches for infrastructure Wi-Fi. Permissionless.
+2. While any Wi-Fi is up, an `NsdManager` browse runs for
+   `_fips._udp` — the DNS-SD advert fips LAN discovery publishes. The
+   TXT record carries the node's `npub`; the SRV carries the port the
+   node's UDP transport is bound to (routers default to `2121`).
+3. Each resolve pushes `(npub, "[addr]:port")` into the core's
+   platform peer queue (`NativeCore.awarePeerFound`, transport
+   `"udp"`) — identical to the Wi-Fi Aware path. The node dials from
+   its own UDP socket and Noise IK authenticates; the pushed npub is
+   only a routing hint, exactly as with mDNS adverts elsewhere in
+   fips.
+4. On service loss or Wi-Fi loss, `awarePeerLost` closes the pooled
+   UDP session so a dead socket is never re-used.
+
+There is no identity-less "dial an address" path in fips: Noise IK's
+msg1 is encrypted to the responder's static key, so the router's npub
+must arrive before the first packet. Over IP, the mDNS advert is that
+delivery channel (the raw-Ethernet transport's beacons serve the same
+role at L2, but an unprivileged Android app cannot receive raw
+frames). **The router must therefore have fips LAN
+discovery/rendezvous enabled** so it answers `_fips._udp` queries; the
+access-SSID firewall zone already admits mDNS (UDP 5353).
+
+## Why the browse is not gated on the literal `!FIPS` SSID
+
+API 33+ redacts the SSID unless the app holds location permission, so
+a name gate would disable the lane on modern devices. Browsing other
+LANs is harmless (nothing answers) and useful: a desktop fips node
+with LAN discovery enabled on a home network exercises the identical
+path. The SSID is still read best-effort and shown on the Dev screen.
+
+## Address selection
+
+The access SSID intentionally provides no internet, so Android keeps
+**cellular as the default network** — and Myco's own VpnService routes
+`fd00::/8` into the mesh TUN. Both would swallow a naive dial. The
+resolver output is therefore ranked:
+
+1. **Link-local IPv6 with a numeric scope** (`[fe80::x%3]:2121`) — the
+   scope pins the egress interface, bypassing both traps; same proven
+   form the Wi-Fi Aware lane dials.
+2. Global/ULA IPv6, **skipping `fd00::/8`** (TUN capture).
+3. IPv4, rewritten as v4-mapped IPv6 (`[::ffff:a.b.c.d]:port`) — the
+   node's UDP socket is a dual-stack `[::]` bind and fips's transport
+   selection is family-strict, so a bare V4 address would match no
+   socket. May still lose to cellular default-routing; last resort.
+
+## Re-push cadence
+
+NSD fires `onServiceFound` once per service appearance, so a dropped
+UDP session would never get a fresh dial hint. While the browse is
+live, every resolved node is re-pushed each 60 s; the core's
+alternate-path gates make redundant pushes no-ops for healthy peers.
+
+## Observability
+
+The Dev screen's **WI-FI AP (!FIPS)** panel shows Wi-Fi/SSID state,
+browse state, and each discovered node (npub, address, pushed). The
+**WI-FI AWARE** panel lists live NDP links from the same change.
+`adb logcat -s MycoApRadio` traces the lane.


### PR DESCRIPTION
When the phone joins a Wi-Fi network carrying a fips node — e.g. a router
broadcasting the open `!FIPS` access SSID — Myco now connects its embedded
node to it over the ordinary UDP transport.

**Mechanism** (`app.myco.ap.ApRadio`, design notes in `docs/design/ap-lane.md`):
passive `TRANSPORT_WIFI` NetworkCallback; while any Wi-Fi is up, an NSD browse
for `_fips._udp` (the advert fips LAN discovery publishes) resolves npub + port
and pushes them into the core's platform peer queue — the same seam the Wi-Fi
Aware radio uses. Noise IK authenticates; the pushed npub is only a routing hint.

**Notable choices**
- Browse is not gated on the literal `!FIPS` SSID: API 33+ redacts SSIDs without
  location permission, so a name gate would kill the lane on modern devices.
  SSID is still shown best-effort in the Dev panel.
- Address ranking dodges two routing traps: scoped link-local IPv6 first (immune
  to the cellular default route on the internet-less access SSID), `fd00::/8`
  skipped (mesh TUN captures it), IPv4 rewritten v4-mapped for the dual-stack
  `[::]` socket.
- Dev screen: new **WI-FI AP (!FIPS)** panel (Wi-Fi/SSID, browse state,
  discovered nodes); Wi-Fi Aware panel now lists live NDP links (tech debt —
  previously invisible).

**Router-side requirement:** fips LAN discovery/rendezvous enabled so the router
answers `_fips._udp` (the access-SSID firewall zone already admits mDNS).

**Testing:** no unit tests — the behavior is Android-framework-bound
(NsdManager/ConnectivityManager) with no new core logic. Manually verified on a
Samsung (Android 14) against an OpenWrt `!FIPS` AP with fips UDP on 2121:
node discovered via mDNS, pushed, Noise IK completed, router visible in PEERS.
`./gradlew assembleDebug` green; Rust untouched.
