### PR TITLE
Background battery fixes + relay-connection resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Background battery drain cut substantially: BLE discovery now duty-cycles
+  down (low-power scan with batched delivery) while the app is not visible,
+  the per-link GATT connection priority drops to balanced after 30s without
+  bulk traffic, and the once-a-second state poll no longer runs backgrounded
+  (and no longer walks the blob cache directory on every read).
+- Circle relay links no longer die permanently after a mesh session gets
+  stuck mid-rekey: peer relay dials now time out at 10s and back off per
+  peer (8s up to 3min) after consecutive failures, letting the node reclaim
+  the stale session and rebuild a fresh one on the next dial.
+- Turning the Bluetooth toggle off no longer stops the embedded mesh node
+  out from under the Wi-Fi Aware lane — the node's lifecycle now follows
+  the mesh "Enable" switch; radio toggles only gate their radios.
+- Developer panel peer/advert rows keep a stable alphabetical order instead
+  of reshuffling every refresh.
+
 ### Added
 
 - A **Wi-Fi AP lane** (developer preview): when the phone joins a Wi-Fi network

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -132,6 +132,8 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+    // ProcessLifecycleOwner: app-visibility signal driving background BLE duty cycle.
+    implementation("androidx.lifecycle:lifecycle-process:2.8.7")
     // Bottom-nav shell (Apps · Circle · Discover · Settings · Dev). minSdk-29 safe.
     implementation("androidx.navigation:navigation-compose:2.8.4")
     // QR generation for share-an-nsite (encodes the nsite id + pairing info)…

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -115,7 +115,11 @@ class MainActivity : ComponentActivity() {
         // The mesh adapter (app-owned TUN) is ON by default — it's how this device
         // reaches the mesh, so it's effectively required. Bring it up at launch,
         // prompting for the one-time VPN consent the first time it's needed.
+        // The fips node's lifecycle follows this master "Enable" switch (the
+        // radio toggles only gate their radios), so start it here too — the
+        // dispatch is idempotent with the radio services' own startNode calls.
         if (prefs.getBoolean(PREF_MESH, true)) {
+            core.dispatch(NativeActions.startNode())
             val consent = VpnService.prepare(this)
             if (consent == null) startMeshNow() else vpnConsentLauncher.launch(consent)
         }
@@ -147,12 +151,15 @@ class MainActivity : ComponentActivity() {
     private fun setMeshEnabled(enabled: Boolean) {
         prefs.edit().putBoolean(PREF_MESH, enabled).apply()
         if (enabled) {
+            // Node follows the master switch (radio toggles only gate radios).
+            core.dispatch(NativeActions.startNode())
             // Android requires user consent before any app can run a VPN.
             val consent = VpnService.prepare(this)
             android.util.Log.i("MycoVpn", "setMeshEnabled(true): consent needed=${consent != null}")
             if (consent != null) vpnConsentLauncher.launch(consent) else startMeshNow()
         } else {
             MycoVpnService.stop(this)
+            core.dispatch(NativeActions.stopNode())
         }
     }
 
@@ -470,7 +477,8 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private companion object {
+    // Non-private: the radio services read PREF_MESH to gate node startup.
+    companion object {
         const val PREF_BLE = "ble_enabled"
         const val PREF_AWARE = "wifi_aware_enabled"
         const val PREF_MESH = "mesh_enabled"

--- a/android/app/src/main/java/app/myco/aware/AwareService.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareService.kt
@@ -59,10 +59,14 @@ class AwareService : Service() {
             return
         }
 
-        // Enable the lane (adds the UDP transport, restarting a running node),
-        // then ensure the node is up so the lane works even without BLE.
+        // Enable the lane. Node lifecycle follows the mesh "Enable" master
+        // switch; when it's on, ensure the node is up so the lane works even
+        // without BLE (idempotent — the UDP transport is always in the node's
+        // config on Android, so no restart is needed to pick the lane up).
         client.dispatch(NativeActions.setWifiAwareEnabled(true))
-        client.dispatch(NativeActions.startNode())
+        val meshOn = getSharedPreferences("myco_prefs", MODE_PRIVATE)
+            .getBoolean(app.myco.MainActivity.PREF_MESH, true)
+        if (meshOn) client.dispatch(NativeActions.startNode())
 
         if (!AwareRadio.isSupported(this)) {
             Log.w(TAG, "Wi-Fi Aware not supported on this device")
@@ -83,7 +87,8 @@ class AwareService : Service() {
     private fun stopAware() {
         runCatching {
             val client = MycoCore.client(this)
-            // Drop the UDP transport; leave the node running for other users.
+            // Drop the lane flag only — node lifecycle belongs to the mesh
+            // "Enable" master switch.
             client.dispatch(NativeActions.setWifiAwareEnabled(false))
         }
         radio?.shutdown()

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -59,7 +59,23 @@ class BleRadio(context: Context) {
     private val channels = ConcurrentHashMap<Long, BluetoothSocket>()
     // A parallel GATT per channel, used only to request a low connection interval
     // (L2CAP CoC exposes no priority API). Bumps mesh throughput ~2-4x.
-    private val gatts = ConcurrentHashMap<Long, BluetoothGatt>()
+    private val gatts = ConcurrentHashMap<Long, GattPrio>()
+
+    /**
+     * Per-channel GATT + connection-priority state. HIGH priority pins the LE
+     * connection interval at ~11-15ms, which is great for throughput but costs
+     * real battery if held for the life of the link — so it is granted on
+     * connect (the noise handshake is many small round-trips) and on bulk
+     * traffic, then demoted to BALANCED after [IDLE_DEMOTE_MS] without a
+     * bulk-sized packet. Heartbeats/pings ride the BALANCED interval fine.
+     */
+    private class GattPrio {
+        @Volatile var gatt: BluetoothGatt? = null // set right after connectGatt returns
+        @Volatile var connected = false
+        @Volatile var high = false
+        @Volatile var lastBulkMs = 0L
+        @Volatile var demotePending = false
+    }
 
     @Volatile
     private var stopped = false
@@ -80,6 +96,25 @@ class BleRadio(context: Context) {
     // SCAN_FAILED_SCANNING_TOO_FREQUENTLY) used to be logged and abandoned, which
     // permanently killed peer discovery until the mesh was toggled. We re-arm it.
     private var scanRetries = 0
+
+    // Background mode (set from the service via ProcessLifecycleOwner): while the
+    // app is not visible, discovery drops from LOW_LATENCY (~100% RX duty) to
+    // LOW_POWER (~10% duty, 512ms/5120ms) with batched delivery — the single
+    // biggest background battery saving. Established connections are unaffected;
+    // only how fast we *find* new peers degrades (seconds, not minutes).
+    @Volatile
+    private var backgroundMode = false
+
+    /** Flip fore/background discovery intensity; restarts the scan if one is live. */
+    fun setBackgroundMode(bg: Boolean) {
+        if (backgroundMode == bg) return
+        backgroundMode = bg
+        Log.i(TAG, "background mode: $bg")
+        // Re-arm the scan with the new duty cycle. Mode flips are user-driven
+        // (screen off / app switch), far below the ~5 startScan/30s throttle;
+        // if we do trip it, scheduleScanRetry re-arms with the 30s floor.
+        if (scanCallback != null) startScanning()
+    }
 
     fun bindBridge(handle: Long) {
         bridgeHandle = handle
@@ -208,30 +243,29 @@ class BleRadio(context: Context) {
         scanner = sc
         val filters = listOf(ScanFilter.Builder().setServiceUuid(FIPS_PARCEL_UUID).build())
         val settings = ScanSettings.Builder()
-            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+            .apply {
+                if (backgroundMode) {
+                    setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+                    // Batch results in the controller and deliver every few seconds
+                    // so the host CPU stays asleep between batches. Only when the
+                    // chipset can actually offload — otherwise a report delay just
+                    // adds latency without saving a wakeup.
+                    if (adapter?.isOffloadedScanBatchingSupported == true) {
+                        setReportDelay(BACKGROUND_BATCH_MS)
+                    }
+                } else {
+                    setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                }
+            }
             .build()
         val cb = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
-                scanRetries = 0 // a result proves scanning is live; reset backoff
-                val addr = "$ADAPTER/${result.device.address}"
-                // PSM rides in the primary advert under the compact 16-bit UUID;
-                // fall back to the legacy 128-bit-keyed service-data for any peer
-                // still on the old scan-response layout.
-                val sd = result.scanRecord?.getServiceData(PSM_SD_PARCEL_UUID)
-                    ?: result.scanRecord?.getServiceData(FIPS_PARCEL_UUID)
-                val psm = if (sd != null && sd.size >= 2) {
-                    (sd[0].toInt() and 0xFF) or ((sd[1].toInt() and 0xFF) shl 8) // 16-bit LE
-                } else 0
-                // Only report a peer once its real PSM is known (it rides the
-                // scan-response service data). A psm=0 sighting is the primary
-                // advert without the scan response yet — reporting it makes the
-                // core fall back to the legacy default PSM (0x0085) and dial the
-                // wrong L2CAP port, which the peer rejects every time.
-                if (psm > 0) {
-                    NativeCore.bleDeliverScan(bridgeHandle, addr, psm, result.rssi)
-                } else {
-                    Log.d(TAG, "scan $addr: PSM not in advert yet (awaiting scan response)")
-                }
+                handleScanResult(result)
+            }
+
+            // Batched delivery path (background mode with setReportDelay > 0).
+            override fun onBatchScanResults(results: List<ScanResult>) {
+                results.forEach { handleScanResult(it) }
             }
 
             override fun onScanFailed(errorCode: Int) {
@@ -242,10 +276,33 @@ class BleRadio(context: Context) {
         scanCallback = cb
         try {
             sc.startScan(filters, settings, cb)
-            Log.i(TAG, "scanning for FIPS peers")
+            Log.i(TAG, "scanning for FIPS peers (${if (backgroundMode) "low-power" else "low-latency"})")
         } catch (e: Exception) {
             Log.e(TAG, "startScanning failed", e)
             scheduleScanRetry(-1)
+        }
+    }
+
+    private fun handleScanResult(result: ScanResult) {
+        scanRetries = 0 // a result proves scanning is live; reset backoff
+        val addr = "$ADAPTER/${result.device.address}"
+        // PSM rides in the primary advert under the compact 16-bit UUID;
+        // fall back to the legacy 128-bit-keyed service-data for any peer
+        // still on the old scan-response layout.
+        val sd = result.scanRecord?.getServiceData(PSM_SD_PARCEL_UUID)
+            ?: result.scanRecord?.getServiceData(FIPS_PARCEL_UUID)
+        val psm = if (sd != null && sd.size >= 2) {
+            (sd[0].toInt() and 0xFF) or ((sd[1].toInt() and 0xFF) shl 8) // 16-bit LE
+        } else 0
+        // Only report a peer once its real PSM is known (it rides the
+        // scan-response service data). A psm=0 sighting is the primary
+        // advert without the scan response yet — reporting it makes the
+        // core fall back to the legacy default PSM (0x0085) and dial the
+        // wrong L2CAP port, which the peer rejects every time.
+        if (psm > 0) {
+            NativeCore.bleDeliverScan(bridgeHandle, addr, psm, result.rssi)
+        } else {
+            Log.d(TAG, "scan $addr: PSM not in advert yet (awaiting scan response)")
         }
     }
 
@@ -330,6 +387,7 @@ class BleRadio(context: Context) {
     private fun boostPriority(chId: Long, device: BluetoothDevice) {
         runCatching {
             Log.i(TAG, "boostPriority: GATT to ${device.address} (low interval + 2M PHY)")
+            val prio = GattPrio()
             // TRANSPORT_LE is mandatory here: the 3-arg connectGatt defaults to
             // TRANSPORT_AUTO, which on a dual-mode peer can bring up a classic
             // BR/EDR link. BR/EDR between two phones makes Android auto-negotiate
@@ -338,10 +396,13 @@ class BleRadio(context: Context) {
             val gatt = device.connectGatt(appContext, false, object : BluetoothGattCallback() {
                 override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) {
                     if (newState == BluetoothProfile.STATE_CONNECTED) {
-                        val ok = runCatching {
-                            g.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
-                        }.getOrDefault(false)
-                        // 2M PHY ~doubles the raw rate over 1M.
+                        prio.connected = true
+                        // HIGH from the start: the noise handshake right after
+                        // connect is many small round-trips and wants the low
+                        // interval. Demoted to BALANCED once the link idles.
+                        boostNow(prio, g)
+                        // 2M PHY ~doubles the raw rate over 1M (and halves radio
+                        // on-time per byte — keep it regardless of priority).
                         runCatching {
                             g.setPreferredPhy(
                                 BluetoothDevice.PHY_LE_2M_MASK,
@@ -349,7 +410,7 @@ class BleRadio(context: Context) {
                                 BluetoothDevice.PHY_OPTION_NO_PREFERRED,
                             )
                         }
-                        Log.i(TAG, "GATT up: requestConnectionPriority(HIGH)=$ok, requested 2M PHY")
+                        Log.i(TAG, "GATT up: requested HIGH priority + 2M PHY")
                     }
                 }
 
@@ -357,12 +418,73 @@ class BleRadio(context: Context) {
                     Log.i(TAG, "PHY now tx=$txPhy rx=$rxPhy (2=2M) status=$status")
                 }
             }, BluetoothDevice.TRANSPORT_LE)
-            if (gatt != null) gatts[chId] = gatt
+            if (gatt != null) {
+                prio.gatt = gatt
+                gatts[chId] = prio
+            }
         }.onFailure { Log.w(TAG, "boostPriority failed: ${it.message}") }
     }
 
+    /** Grant HIGH priority and arm the idle-demotion check. */
+    private fun boostNow(prio: GattPrio, gatt: BluetoothGatt) {
+        prio.lastBulkMs = android.os.SystemClock.elapsedRealtime()
+        synchronized(prio) {
+            if (!prio.high) {
+                prio.high = true
+                runCatching { gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH) }
+            }
+            if (!prio.demotePending) {
+                prio.demotePending = true
+                scheduleDemoteCheck(prio, gatt, IDLE_DEMOTE_MS)
+            }
+        }
+    }
+
+    /** After [delayMs], demote to BALANCED if no bulk packet moved in the window;
+     *  otherwise re-check when the current window would expire. */
+    private fun scheduleDemoteCheck(prio: GattPrio, gatt: BluetoothGatt, delayMs: Long) {
+        runCatching {
+            retryExec.schedule({
+                val idle = android.os.SystemClock.elapsedRealtime() - prio.lastBulkMs
+                synchronized(prio) {
+                    when {
+                        !prio.connected || stopped -> prio.demotePending = false
+                        idle >= IDLE_DEMOTE_MS -> {
+                            prio.demotePending = false
+                            prio.high = false
+                            runCatching {
+                                gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)
+                            }
+                            Log.i(TAG, "GATT idle ${idle}ms: demoted to BALANCED priority")
+                        }
+                        else -> scheduleDemoteCheck(prio, gatt, IDLE_DEMOTE_MS - idle)
+                    }
+                }
+            }, delayMs, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    /**
+     * Called by the reader/writer loops with each packet's size. Bulk-sized
+     * packets (sync/site transfers, ~MTU-sized) re-grant HIGH priority and keep
+     * it while the burst lasts; control chatter (link heartbeats, WS pings, TCP
+     * ACKs — all well under [BULK_BOOST_BYTES]) never re-boosts, so an
+     * otherwise-idle link stays on the cheap BALANCED interval.
+     */
+    private fun noteBulk(chId: Long, n: Int) {
+        if (n < BULK_BOOST_BYTES) return
+        val prio = gatts[chId] ?: return
+        prio.lastBulkMs = android.os.SystemClock.elapsedRealtime()
+        if (prio.connected && !prio.high) {
+            prio.gatt?.let { boostNow(prio, it) }
+        }
+    }
+
     private fun dropGatt(chId: Long) {
-        gatts.remove(chId)?.let { runCatching { it.disconnect(); it.close() } }
+        gatts.remove(chId)?.let { prio ->
+            prio.connected = false
+            prio.gatt?.let { runCatching { it.disconnect(); it.close() } }
+        }
     }
 
     private fun readerLoop(chId: Long, sock: BluetoothSocket) {
@@ -378,6 +500,7 @@ class BleRadio(context: Context) {
                 val n = ins.read(buf)
                 if (n < 0) break // EOF → channel closed (handled in finally)
                 if (n == 0) continue
+                noteBulk(chId, n) // bulk inbound re-grants the low connection interval
                 if (!NativeCore.bleChannelDeliverRecv(bridgeHandle, chId, buf, n)) {
                     // deliver_recv == false: the core's bounded inbound queue is
                     // saturated, or the channel is gone. Under FMP reframing a single
@@ -410,6 +533,7 @@ class BleRadio(context: Context) {
                     n < 0 -> break // channel closed
                     n == 0 -> continue // timeout, poll again
                     else -> {
+                        noteBulk(chId, n) // bulk outbound re-grants the low interval
                         // OutputStream.write on a blocking socket writes all n bytes
                         // (looping internally) or throws — no manual partial-write loop.
                         outs.write(buf, 0, n)
@@ -454,6 +578,18 @@ class BleRadio(context: Context) {
         // read() fits one SDU and next_send never truncates an outbound packet.
         private const val MAX_PACKET = 8192
         private const val SEND_TIMEOUT_MS = 1000
+
+        /** Background scan: batched delivery window (controller-offloaded). */
+        private const val BACKGROUND_BATCH_MS = 5000L
+
+        /** A packet at least this big is "bulk" (site/sync transfer, ~MTU-sized
+         *  1357B frames) and re-grants HIGH connection priority. Control chatter —
+         *  1B link heartbeats, WS pings and TCP ACKs (~250B on the wire with
+         *  FSP+IPv6 overhead) — stays under it and rides BALANCED. */
+        private const val BULK_BOOST_BYTES = 512
+
+        /** Demote HIGH → BALANCED after this long without a bulk packet. */
+        private const val IDLE_DEMOTE_MS = 5000L
 
         /** Cap on the MTU reported to the core: one full IPv6 packet per L2CAP SDU.
          *  The TUN sends ≤1280-byte IPv6 packets; with FSP's ~77-byte overhead that

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -588,8 +588,12 @@ class BleRadio(context: Context) {
          *  FSP+IPv6 overhead) — stays under it and rides BALANCED. */
         private const val BULK_BOOST_BYTES = 512
 
-        /** Demote HIGH → BALANCED after this long without a bulk packet. */
-        private const val IDLE_DEMOTE_MS = 5000L
+        /** Demote HIGH → BALANCED after this long without a bulk packet. 30s, not
+         *  lower: relay sync traffic arrives in bursts ~10-20s apart, and a 5s
+         *  window made every burst renegotiate connection parameters (boost ↔
+         *  demote flip-flop every ~15s in the field logs) — churn that risks link
+         *  stability on some chipsets for marginal battery gain. */
+        private const val IDLE_DEMOTE_MS = 30_000L
 
         /** Cap on the MTU reported to the core: one full IPv6 packet per L2CAP SDU.
          *  The TUN sends ≤1280-byte IPv6 packets; with FSP's ~77-byte overhead that

--- a/android/app/src/main/java/app/myco/ble/BleService.kt
+++ b/android/app/src/main/java/app/myco/ble/BleService.kt
@@ -11,6 +11,9 @@ import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import app.myco.R
 import app.myco.core.MycoCore
 import app.myco.core.NativeActions
@@ -30,6 +33,21 @@ import app.myco.core.NativeCore
 class BleService : Service() {
     private var radio: BleRadio? = null
     private var bridgeHandle: Long = 0
+
+    // App-visibility observer: while no activity is visible (home button, screen
+    // off), drop BLE discovery from LOW_LATENCY to a duty-cycled LOW_POWER scan —
+    // the dominant background battery cost. ProcessLifecycleOwner's onStop fires
+    // for both cases; onStart restores full intensity. Established connections
+    // are untouched either way.
+    private val visibilityObserver = object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
+            radio?.setBackgroundMode(false)
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            radio?.setBackgroundMode(true)
+        }
+    }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -65,10 +83,14 @@ class BleService : Service() {
         // begins driving the radio (listen → advertise → scan).
         client.dispatch(NativeActions.setBleEnabled(true))
         client.dispatch(NativeActions.startNode())
+        // Registration replays the current state (onStart fires immediately if the
+        // app is already visible), so the radio starts in the right mode.
+        ProcessLifecycleOwner.get().lifecycle.addObserver(visibilityObserver)
         Log.i(TAG, "BLE service started")
     }
 
     private fun stopBle() {
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(visibilityObserver)
         // Order matters: stop the node loop FIRST so it drops the BLE transport
         // (and its streams). That makes the radio's writer threads see their
         // channels close and exit, and stops the node from calling the radio.

--- a/android/app/src/main/java/app/myco/ble/BleService.kt
+++ b/android/app/src/main/java/app/myco/ble/BleService.kt
@@ -82,7 +82,16 @@ class BleService : Service() {
         // Inject-then-start: the node's BLE transport picks up the bridge and
         // begins driving the radio (listen → advertise → scan).
         client.dispatch(NativeActions.setBleEnabled(true))
-        client.dispatch(NativeActions.startNode())
+        // Node lifecycle follows the mesh "Enable" master switch, not this
+        // toggle. When it's on, (re)start the node: a byte-bridge is only bound
+        // at node start, so a node that was already running must bounce to pick
+        // up the fresh bridge injected above.
+        val meshOn = getSharedPreferences("myco_prefs", MODE_PRIVATE)
+            .getBoolean(app.myco.MainActivity.PREF_MESH, true)
+        if (meshOn) {
+            if (client.state().nodeRunning) client.dispatch(NativeActions.stopNode())
+            client.dispatch(NativeActions.startNode())
+        }
         // Registration replays the current state (onStart fires immediately if the
         // app is already visible), so the radio starts in the right mode.
         ProcessLifecycleOwner.get().lifecycle.addObserver(visibilityObserver)
@@ -91,13 +100,13 @@ class BleService : Service() {
 
     private fun stopBle() {
         ProcessLifecycleOwner.get().lifecycle.removeObserver(visibilityObserver)
-        // Order matters: stop the node loop FIRST so it drops the BLE transport
-        // (and its streams). That makes the radio's writer threads see their
-        // channels close and exit, and stops the node from calling the radio.
+        // Node lifecycle belongs to the mesh "Enable" master switch — never stop
+        // the node here. Clearing the BLE flag tells the node's BLE backend to
+        // stop driving the radio; shutting the radio down closes its channels,
+        // which the core observes as channel closures.
         runCatching {
             val client = MycoCore.client(this)
             client.dispatch(NativeActions.setBleEnabled(false))
-            client.dispatch(NativeActions.stopNode())
         }
         radio?.shutdown()
         radio = null

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -68,6 +68,7 @@ import app.myco.ui.screens.SettingsScreen
 import app.myco.ui.theme.EmeraldSoft
 import app.myco.ui.theme.Slate
 import app.myco.ui.theme.StatusConnected
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -115,13 +116,19 @@ fun MycoApp(
     // Circle members we already knew about — anything new means a fresh pairing.
     val knownCircle = remember { mutableStateOf(state.circle.map { it.npub }.toSet()) }
     val context = LocalContext.current
-    // Re-poll the native state each second off the main thread (it crosses JNI and
-    // walks the blob dir for cache counts). Pure read — does not bump `rev`.
+    // Re-poll the native state each second off the main thread (it crosses JNI
+    // into the Rust core). Pure read — does not bump `rev`. Gated on STARTED:
+    // with the app backgrounded the UI can't show the result anyway, and the
+    // 1Hz JNI wakeup was a measurable battery cost. repeatOnLifecycle cancels
+    // the loop on onStop and restarts it (immediate first poll) on onStart.
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     androidx.compose.runtime.LaunchedEffect(Unit) {
-        while (true) {
-            delay(1000)
-            state = withContext(Dispatchers.IO) { client.state() }
-            bleExhausted = BleHealth.advertiserExhausted
+        lifecycleOwner.repeatOnLifecycle(androidx.lifecycle.Lifecycle.State.STARTED) {
+            while (true) {
+                state = withContext(Dispatchers.IO) { client.state() }
+                bleExhausted = BleHealth.advertiserExhausted
+                delay(1000)
+            }
         }
     }
 

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -102,18 +102,22 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
                         apNodes.forEach { ApNodeRow(it) }
                     }
                 }
+                // Stable alphabetical order — the state arrays arrive in snapshot
+                // order, which reshuffles between polls and makes the rows flap.
+                val peersSorted = state.blePeers.sortedBy { it.npub.ifEmpty { it.nodeAddrHex } }
+                val advertsSorted = state.bleAdverts.sortedBy { it.addr }
                 DevCard("PEERS (${state.blePeers.size})") {
                     if (state.blePeers.isEmpty()) {
                         EmptyLine("none connected")
                     } else {
-                        state.blePeers.forEach { PeerRow(it) }
+                        peersSorted.forEach { PeerRow(it) }
                     }
                 }
                 DevCard("RADIO ADVERTS (${state.bleAdverts.size})") {
                     if (state.bleAdverts.isEmpty()) {
                         EmptyLine("none")
                     } else {
-                        state.bleAdverts.forEach { AdvertRow(it) }
+                        advertsSorted.forEach { AdvertRow(it) }
                     }
                 }
                 DevCard("CACHE") {

--- a/docs/design/wifi-aware-interop.md
+++ b/docs/design/wifi-aware-interop.md
@@ -373,6 +373,14 @@ Manifest deltas, mirroring the BLE set:
   background lifecycle; the foreground service is field practice, not
   documented mandate — same as BLE.)
 
+Node-lifecycle coordination between the two radio services: the embedded
+fips node's lifecycle follows the mesh **Enable** master switch
+(`PREF_MESH`), not either radio toggle. Each service's toggle only gates
+its own radio and lane flag; `BleService` additionally bounces the node
+once on enable when it is already running, because a byte-bridge is only
+bound at node start. Neither service stops the node — only Enable-off
+does.
+
 Power is the reason the lane is a lane: an active NDP costs materially more
 than BLE idle, so Aware should be **released when idle** (tear down the
 network request after a sync quiesces; the discovery sessions are cheap and

--- a/myco-blossom/src/lib.rs
+++ b/myco-blossom/src/lib.rs
@@ -16,6 +16,7 @@
 //! [`BlobStore`]: nsite_deck::seams::BlobStore
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use async_trait::async_trait;
 use nsite_deck::seams::BlobStore;
@@ -26,6 +27,17 @@ pub mod server;
 /// A content-addressed blob store rooted at a directory.
 pub struct FsBlobStore {
     root: PathBuf,
+    /// Cached `(count, bytes)` so the app's once-a-second state poll doesn't walk
+    /// the blob dir (plus a `stat` per blob) on every read. Computed lazily on
+    /// first read, invalidated on any mutation (`put`/`retain_blobs`/`wipe`) —
+    /// the only ways blobs enter or leave while the store is open.
+    stats: Mutex<Option<BlobStats>>,
+}
+
+#[derive(Clone, Copy)]
+struct BlobStats {
+    count: usize,
+    bytes: u64,
 }
 
 impl FsBlobStore {
@@ -33,18 +45,53 @@ impl FsBlobStore {
     pub fn open(root: impl AsRef<Path>) -> anyhow::Result<Self> {
         let root = root.as_ref().to_path_buf();
         std::fs::create_dir_all(&root)?;
-        Ok(Self { root })
+        Ok(Self {
+            root,
+            stats: Mutex::new(None),
+        })
     }
 
     fn blob_path(&self, sha256_hex: &str) -> PathBuf {
         self.root.join(sha256_hex)
     }
 
-    /// Number of stored blobs (for diagnostics / cache status).
+    /// Number of stored blobs (for diagnostics / cache status). Cached.
     pub fn count(&self) -> usize {
+        self.stats().count
+    }
+
+    /// Total bytes on disk (for the LRU cap accounting; eviction itself is P5).
+    /// Cached.
+    pub fn total_bytes(&self) -> u64 {
+        self.stats().bytes
+    }
+
+    fn stats(&self) -> BlobStats {
+        let mut cached = self.stats.lock().unwrap();
+        if let Some(s) = *cached {
+            return s;
+        }
+        let s = self.scan_stats();
+        *cached = Some(s);
+        s
+    }
+
+    fn invalidate_stats(&self) {
+        *self.stats.lock().unwrap() = None;
+    }
+
+    /// One walk over the blob dir computing count + bytes together.
+    fn scan_stats(&self) -> BlobStats {
         std::fs::read_dir(&self.root)
-            .map(|rd| rd.filter_map(Result::ok).filter(is_blob_name).count())
-            .unwrap_or(0)
+            .map(|rd| {
+                let mut s = BlobStats { count: 0, bytes: 0 };
+                for entry in rd.filter_map(Result::ok).filter(is_blob_name) {
+                    s.count += 1;
+                    s.bytes += entry.metadata().map(|m| m.len()).unwrap_or(0);
+                }
+                s
+            })
+            .unwrap_or(BlobStats { count: 0, bytes: 0 })
     }
 
     /// Delete every blob whose hash is **not** in `keep`. Used by the selective
@@ -62,19 +109,7 @@ impl FsBlobStore {
                 }
             }
         }
-    }
-
-    /// Total bytes on disk (for the LRU cap accounting; eviction itself is P5).
-    pub fn total_bytes(&self) -> u64 {
-        std::fs::read_dir(&self.root)
-            .map(|rd| {
-                rd.filter_map(Result::ok)
-                    .filter(is_blob_name)
-                    .filter_map(|e| e.metadata().ok())
-                    .map(|m| m.len())
-                    .sum()
-            })
-            .unwrap_or(0)
+        self.invalidate_stats();
     }
 }
 
@@ -120,6 +155,7 @@ impl BlobStore for FsBlobStore {
             .join(format!(".tmp-{}-{}", std::process::id(), &hash));
         std::fs::write(&tmp, bytes)?;
         std::fs::rename(&tmp, &dest)?;
+        self.invalidate_stats();
         Ok(hash)
     }
 
@@ -127,6 +163,7 @@ impl BlobStore for FsBlobStore {
         for entry in std::fs::read_dir(&self.root)?.filter_map(Result::ok) {
             let _ = std::fs::remove_file(entry.path());
         }
+        self.invalidate_stats();
         Ok(())
     }
 }

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -843,7 +843,15 @@ impl Content {
     /// Record which mesh peers are connected right now (called by the runtime from
     /// the node's peer snapshot), so `open_site` only tries reachable Circle members.
     pub fn set_connected_peers(&self, npubs: Vec<String>) {
-        *self.connected_peers.lock().unwrap() = npubs;
+        let mut cur = self.connected_peers.lock().unwrap();
+        // A peer newly present in the mesh view is a reconnect edge: forget its
+        // dial backoff so the next keepwarm tick dials it immediately.
+        for npub in &npubs {
+            if !cur.contains(npub) {
+                self.peer_relays.reset_backoff(npub);
+            }
+        }
+        *cur = npubs;
     }
 
     /// Circle members that are **direct** mesh neighbours right now — the pull

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -242,17 +242,16 @@ async fn run(
 ) {
     // Bounded connect: a hang here (SYN black hole into a wedged session) must
     // fail fast, both to arm the backoff and to stop touching the stale session.
-    let ws = match tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(&url))
-        .await
-    {
-        Ok(Ok((ws, _))) => ws,
-        _ => {
-            // Connect failed or timed out → back off this peer; the channel drops
-            // with this task and a post-backoff command respawns it.
-            record_dial_failure(&dial_backoff, &npub);
-            return;
-        }
-    };
+    let ws =
+        match tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(&url)).await {
+            Ok(Ok((ws, _))) => ws,
+            _ => {
+                // Connect failed or timed out → back off this peer; the channel drops
+                // with this task and a post-backoff command respawns it.
+                record_dial_failure(&dial_backoff, &npub);
+                return;
+            }
+        };
     // Live now — clear any backoff and mark reachable so the keepwarm loop sees
     // the (re)connect edge.
     dial_backoff.lock().unwrap().remove(&npub);
@@ -436,7 +435,10 @@ mod tests {
             let map = pool.dial_backoff.lock().unwrap();
             let b = map.get("peerB").unwrap();
             let delay = b.next_allowed - std::time::Instant::now();
-            assert!(delay <= BACKOFF_BASE, "first failure waits one base interval");
+            assert!(
+                delay <= BACKOFF_BASE,
+                "first failure waits one base interval"
+            );
         }
         for _ in 0..10 {
             record_dial_failure(&pool.dial_backoff, "peerB");
@@ -447,7 +449,10 @@ mod tests {
             let delay = b.next_allowed - std::time::Instant::now();
             assert!(delay <= BACKOFF_CAP, "backoff never exceeds the cap");
             // Must exceed the node's 90s idle purge so a wedged session starves.
-            assert!(delay > Duration::from_secs(90), "capped backoff outlasts idle purge");
+            assert!(
+                delay > Duration::from_secs(90),
+                "capped backoff outlasts idle purge"
+            );
         }
         pool.reset_backoff("peerB");
         assert!(pool.dial_backoff.lock().unwrap().is_empty());

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -42,6 +42,43 @@ use tokio_tungstenite::tungstenite::Message;
 /// over BLE. The runtime's keepwarm loop respawns the dropped task promptly.
 const PING_INTERVAL: Duration = Duration::from_secs(10);
 
+/// Cap on the WS connect itself. Without this, a TCP connect into a wedged FSP
+/// session hangs on SYN retransmits for the OS horizon (~2min) — and every
+/// retransmit rides the session, refreshing its activity clock so the node's
+/// 90s idle purge can never reclaim it.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Dial backoff: after consecutive connect failures to a peer, hold off dialing
+/// 8s → 16 → 32 → 64 → 128 → capped 180s. Two jobs: stop burning radio on an
+/// unreachable Circle member every keepwarm tick, and **starve a wedged FSP
+/// session** — once our dials pause for longer than the node's 90s idle purge,
+/// the stale session (e.g. one stuck mid-rekey) is reclaimed and the next dial
+/// establishes a fresh one. Cleared on connect success or a mesh reconnect edge
+/// ([`PeerRelayPool::reset_backoff`]).
+const BACKOFF_BASE: Duration = Duration::from_secs(8);
+const BACKOFF_CAP: Duration = Duration::from_secs(180);
+
+/// Per-peer dial-failure state (see [`BACKOFF_BASE`]).
+struct DialBackoff {
+    failures: u32,
+    next_allowed: std::time::Instant,
+}
+
+type BackoffMap = Arc<Mutex<HashMap<String, DialBackoff>>>;
+
+fn record_dial_failure(map: &BackoffMap, npub: &str) {
+    let mut map = map.lock().unwrap();
+    let entry = map.entry(npub.to_string()).or_insert(DialBackoff {
+        failures: 0,
+        next_allowed: std::time::Instant::now(),
+    });
+    entry.failures = entry.failures.saturating_add(1);
+    let delay = BACKOFF_BASE
+        .saturating_mul(1u32 << (entry.failures - 1).min(5))
+        .min(BACKOFF_CAP);
+    entry.next_allowed = std::time::Instant::now() + delay;
+}
+
 /// A command sent to a peer's connection actor over its channel.
 enum Command {
     /// Fire-and-forget: write a pre-built `["EVENT", …]` frame (the push plane).
@@ -73,6 +110,11 @@ pub struct PeerRelayPool {
     /// edge that drives a resubscribe. Distinct from `peers` (which has an entry
     /// during the connecting window too).
     connected: Arc<Mutex<HashSet<String>>>,
+    /// Per-peer dial backoff after consecutive connect failures (see
+    /// [`BACKOFF_BASE`]). While a peer is backing off, `spawn_or_get` refuses to
+    /// spawn its actor — sends drop (push is best-effort) and requests return
+    /// empty, exactly as they already do for a dead peer.
+    dial_backoff: BackoffMap,
 }
 
 impl PeerRelayPool {
@@ -85,6 +127,13 @@ impl PeerRelayPool {
         self.connected.lock().unwrap().clone()
     }
 
+    /// Forget a peer's dial backoff — called on its mesh reconnect edge (the
+    /// node just saw the peer come back), so the next keepwarm tick dials
+    /// immediately instead of waiting out a stale backoff window.
+    pub fn reset_backoff(&self, npub: &str) {
+        self.dial_backoff.lock().unwrap().remove(npub);
+    }
+
     /// Ensure `npub` has a running actor (which lazily connects) at `url`, without
     /// sending anything. The runtime's keepwarm loop calls this for every Circle
     /// member so a dropped connection is respawned promptly — not lazily on the next
@@ -95,19 +144,24 @@ impl PeerRelayPool {
     }
 
     /// Get a live command channel for `npub`'s connection at `url`, spawning the
-    /// actor (which lazily connects) if there isn't a running one. Caller holds the
-    /// map lock.
+    /// actor (which lazily connects) if there isn't a running one. Returns `None`
+    /// while the peer is in dial backoff. Caller holds the map lock.
     fn spawn_or_get(
         &self,
         peers: &mut HashMap<String, mpsc::UnboundedSender<Command>>,
         npub: &str,
         url: &str,
-    ) -> mpsc::UnboundedSender<Command> {
+    ) -> Option<mpsc::UnboundedSender<Command>> {
         if let Some(tx) = peers.get(npub) {
             if !tx.is_closed() {
-                return tx.clone();
+                return Some(tx.clone());
             }
             peers.remove(npub);
+        }
+        if let Some(b) = self.dial_backoff.lock().unwrap().get(npub) {
+            if std::time::Instant::now() < b.next_allowed {
+                return None;
+            }
         }
         let (tx, rx) = mpsc::unbounded_channel::<Command>();
         peers.insert(npub.to_string(), tx.clone());
@@ -116,8 +170,9 @@ impl PeerRelayPool {
             npub.to_string(),
             rx,
             self.connected.clone(),
+            self.dial_backoff.clone(),
         ));
-        tx
+        Some(tx)
     }
 
     /// Queue a pre-built relay frame (`["EVENT", {…}]`) to a peer's relay over the
@@ -126,7 +181,11 @@ impl PeerRelayPool {
     /// buffered in the channel and flushed on connect.
     pub fn send(&self, npub: &str, url: &str, frame: String) {
         let mut peers = self.peers.lock().unwrap();
-        let tx = self.spawn_or_get(&mut peers, npub, url);
+        // In dial backoff → drop the frame (push is best-effort; the pull plane
+        // recovers backlog once the peer reconnects).
+        let Some(tx) = self.spawn_or_get(&mut peers, npub, url) else {
+            return;
+        };
         // Lost the race with a task that just exited: drop the entry so the next
         // publish respawns. Rare, and the push plane is best-effort (the pull plane
         // recovers backlog on reconnect).
@@ -149,7 +208,10 @@ impl PeerRelayPool {
         let (reply_tx, reply_rx) = oneshot::channel();
         {
             let mut peers = self.peers.lock().unwrap();
-            let tx = self.spawn_or_get(&mut peers, npub, url);
+            // In dial backoff → empty batch, same contract as a dead peer.
+            let Some(tx) = self.spawn_or_get(&mut peers, npub, url) else {
+                return Vec::new();
+            };
             if tx
                 .send(Command::Request {
                     filters,
@@ -176,11 +238,24 @@ async fn run(
     npub: String,
     mut cmd_rx: mpsc::UnboundedReceiver<Command>,
     connected: Arc<Mutex<HashSet<String>>>,
+    dial_backoff: BackoffMap,
 ) {
-    let Ok((ws, _)) = tokio_tungstenite::connect_async(&url).await else {
-        return; // connect failed → channel drops with this task → next command respawns
+    // Bounded connect: a hang here (SYN black hole into a wedged session) must
+    // fail fast, both to arm the backoff and to stop touching the stale session.
+    let ws = match tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(&url))
+        .await
+    {
+        Ok(Ok((ws, _))) => ws,
+        _ => {
+            // Connect failed or timed out → back off this peer; the channel drops
+            // with this task and a post-backoff command respawns it.
+            record_dial_failure(&dial_backoff, &npub);
+            return;
+        }
     };
-    // Live now — mark reachable so the keepwarm loop sees the (re)connect edge.
+    // Live now — clear any backoff and mark reachable so the keepwarm loop sees
+    // the (re)connect edge.
+    dial_backoff.lock().unwrap().remove(&npub);
     connected.lock().unwrap().insert(npub.clone());
     let (mut sink, mut stream) = ws.split();
     let mut pending: HashMap<String, Pending> = HashMap::new();
@@ -349,6 +424,33 @@ mod tests {
             .await;
         assert_eq!(got.len(), 1, "request reads the event back");
         assert_eq!(got[0].id, ev.id);
+    }
+
+    /// Consecutive dial failures escalate the backoff toward the cap; a reset
+    /// (connect success / mesh reconnect edge) clears it entirely.
+    #[test]
+    fn dial_backoff_escalates_and_resets() {
+        let pool = PeerRelayPool::new();
+        record_dial_failure(&pool.dial_backoff, "peerB");
+        {
+            let map = pool.dial_backoff.lock().unwrap();
+            let b = map.get("peerB").unwrap();
+            let delay = b.next_allowed - std::time::Instant::now();
+            assert!(delay <= BACKOFF_BASE, "first failure waits one base interval");
+        }
+        for _ in 0..10 {
+            record_dial_failure(&pool.dial_backoff, "peerB");
+        }
+        {
+            let map = pool.dial_backoff.lock().unwrap();
+            let b = map.get("peerB").unwrap();
+            let delay = b.next_allowed - std::time::Instant::now();
+            assert!(delay <= BACKOFF_CAP, "backoff never exceeds the cap");
+            // Must exceed the node's 90s idle purge so a wedged session starves.
+            assert!(delay > Duration::from_secs(90), "capped backoff outlasts idle purge");
+        }
+        pool.reset_backoff("peerB");
+        assert!(pool.dial_backoff.lock().unwrap().is_empty());
     }
 
     /// A request to an unreachable peer returns empty within the timeout (no hang).

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -57,6 +57,11 @@ pub struct AppRuntime {
     /// Latest dev-menu peer speedtest result; written by the spawned run task and
     /// read back into `state()`. Shared so the async task can update it in place.
     speedtest: Arc<std::sync::Mutex<crate::state::SpeedtestView>>,
+    /// Read-handle slot shared with the keepwarm loop (populated on StartNode,
+    /// cleared on StopNode). The keepwarm tick feeds mesh connectivity to the
+    /// content layer from here, so peer-driven relay sync keeps working while
+    /// the app is backgrounded and the UI's `state()` poll is paused.
+    shared_read: Arc<std::sync::Mutex<Option<ControlReadHandle>>>,
 }
 
 impl AppRuntime {
@@ -107,6 +112,10 @@ impl AppRuntime {
         // fresh device shows it in Apps without pasting a link. A one-shot marker
         // file makes this idempotent and lets a user who removes it stay removed.
         seed_default_sites(&content, &rt, Path::new(data_dir));
+
+        // Read-handle slot for the keepwarm loop; populated once the node starts.
+        let shared_read: Arc<std::sync::Mutex<Option<ControlReadHandle>>> =
+            Arc::new(std::sync::Mutex::new(None));
 
         // Serve the relay + Blossom over the mesh so paired peers can pull this
         // device's nsites at ws://<npub>.fips:4870 / http://<npub>.fips:24243.
@@ -211,13 +220,38 @@ impl AppRuntime {
             // and resubscribe on each peer's reconnect edge. This is what restores a
             // Circle relay link *mutually and fast* after a mid-chain node flaps —
             // independent of chat traffic and of where the peer sits in the mesh.
+            //
+            // The tick also feeds the node's connected-peer view into the content
+            // layer and drives not-ready-site retries. state() does the same at
+            // 1Hz for foreground snappiness, but its poll pauses when the app is
+            // backgrounded — this loop is what keeps peer-driven relay sync alive
+            // then.
             {
                 let content = content.clone();
+                let shared_read = shared_read.clone();
                 rt.spawn(async move {
                     let mut tick = tokio::time::interval(std::time::Duration::from_secs(8));
                     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
                     loop {
                         tick.tick().await;
+                        let handle = shared_read.lock().unwrap().clone();
+                        if let Some(h) = handle {
+                            let connected: Vec<String> = h
+                                .peer_views()
+                                .into_iter()
+                                .filter(|p| p.connected && !p.npub.is_empty())
+                                .map(|p| p.npub)
+                                .collect();
+                            content.set_connected_peers(connected);
+                            if !content.connected_circle_npubs().is_empty() {
+                                for addr in content.retriable_library_addrs() {
+                                    let content = content.clone();
+                                    tokio::spawn(
+                                        async move { content.open_site(addr, None).await },
+                                    );
+                                }
+                            }
+                        }
                         content.keepwarm_tick();
                     }
                 });
@@ -240,6 +274,7 @@ impl AppRuntime {
             loop_task: None,
             content: Some(content),
             speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
+            shared_read,
         })
     }
 
@@ -311,6 +346,7 @@ impl AppRuntime {
             loop_task: None,
             content: None,
             speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
+            shared_read: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -644,6 +680,7 @@ impl AppRuntime {
                 tracing::warn!("fips rx loop ended: {e}");
             }
         });
+        *self.shared_read.lock().unwrap() = Some(handle.clone());
         self.read_handle = Some(handle);
         self.loop_task = Some(task);
         self.node_running = true;
@@ -655,6 +692,7 @@ impl AppRuntime {
         if let Some(task) = self.loop_task.take() {
             task.abort();
         }
+        *self.shared_read.lock().unwrap() = None;
         self.read_handle = None;
         self.node_running = false;
         self.node_status = "stopped".to_string();


### PR DESCRIPTION
## What

Cuts the app's background battery drain (top-3 offenders from a full audit) and fixes two field-reported relay failures found while testing the battery build.

### Battery (audit top 3)

1. **BLE scan duty cycle** — `SCAN_MODE_LOW_LATENCY` (~100% RX duty) ran 24/7. A `ProcessLifecycleOwner` observer drops discovery to duty-cycled `SCAN_MODE_LOW_POWER` with controller-offloaded batching while no activity is visible; full intensity restores on return. Established connections unaffected.
2. **GATT connection priority** — `CONNECTION_PRIORITY_HIGH` (~15ms interval) was held for the life of every link. Now granted on connect and by bulk-sized packets (≥512B), demoted to `BALANCED` after 30s idle; heartbeats/pings ride the cheap interval. 2M PHY kept.
3. **1Hz state poll** — the UI poll (JNI crossing + two blob-dir walks + a stat per blob, every second, even backgrounded) is gated on `repeatOnLifecycle(STARTED)`, and `FsBlobStore` caches (count, bytes) with invalidation on mutation.

Estimated combined saving: roughly 60–90 mA → 10–20 mA background draw (device-dependent).

### Relay resilience (found during device testing)

- **Keepwarm decoupled from the UI poll** — `state()` was the only feeder of the content layer's connected-peer view, so gating the poll starved relay sync in background. The 8s keepwarm loop now reads the node's lock-free `ControlReadHandle` itself.
- **Dial backoff starves wedged FSP sessions** — a lost rekey msg1/msg2 can wedge a session one-sided (rekey never abandons; the dual-rekey tie-break then drops the peer's fresh SessionSetup forever — log-confirmed 44 drops / 5 min). The session layer is out of scope for this repo, so recovery is app-side: WS connects bounded at 10s, per-peer dial backoff 8s→180s after consecutive failures. Once dials pause past the node's 90s idle purge, the stale session is reclaimed and the next dial builds a fresh one. Backoff clears on connect success or mesh reconnect edge.
- **Node lifecycle follows the mesh "Enable" switch** — the BLE toggle previously stopped the shared node, killing Wi-Fi-Aware-only peering until app restart. Radio toggles now only gate radios.
- Dev panel: stable alphabetical peer/advert ordering (rows flapped with snapshot order).

## Testing

- `cargo test -p myco-core` (23) and `-p myco-blossom` (3) green; `assembleDebug` clean.
- 3 physical devices (Pixel 7 Pro, Galaxy A52s, +1), 7-minute soak: 7 clean FSP rekey cutovers, zero dual-rekey drops / unknown-session errors, Pixel↔A52 session healthy throughout (prior build wedged at the first ~120s rekey).
- Battery deltas are estimates; validate with `dumpsys batterystats` / Battery Historian over a longer soak.