### PR TITLE
Mesh names (`<npub>.fips`) system-wide, exit-node mode, and Wi-Fi AP lane fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ node_modules/
 /myco-ics/
 
 .env
+# Standalone mesh exit-node daemon (developed in-tree, not shipped)
+/fips-exitnode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-29
+
+### Added
+
+- **`<npub>.fips` addresses now resolve for every app on the device**, not just
+  inside Myco. The mesh tunnel advertises an in-mesh resolver that answers
+  `<npub>.fips` from the public key alone — no network, no lookup — so any
+  browser or app can open `http://<npub>.fips/` and reach that node over the
+  mesh. Previously only Myco's own gateway could address mesh content by name.
+- An **exit-node mode** (developer preview): point Myco at an HTTP proxy running
+  on a mesh node and every proxy-aware app's web traffic egresses through it, so
+  a phone with no internet of its own can browse the web over the mesh. The exit
+  is named by npub (`<npub>.fips:8080`), so it does not have to be a direct peer
+  — FIPS forwards multi-hop. Set it under Settings → Developer → Exit node; see
+  [docs/how-to/exit-node-demo.md](docs/how-to/exit-node-demo.md). `.fips` names
+  bypass the proxy and stay on the mesh.
+
+### Fixed
+
+- The **Wi-Fi AP lane now connects reliably** on a phone that also has mobile
+  data. A local-only AP never passes internet validation, so the OS steered the
+  mesh socket to the validated network and the peer's replies were discarded
+  before reaching us — the node received every handshake while the phone saw
+  nothing. The socket is now bound to the Wi-Fi network explicitly.
+- The AP lane also **dials the right address**. A fips node advertises one
+  address per interface and only the one facing us answers; Myco took the first
+  and could sit retrying an unreachable one. It now keeps every advertised
+  address and rotates through them until the peer connects.
+
+### Known issues
+
+- Peering over the AP lane can stall after the phone's Wi-Fi reconnects, until
+  the node's old peer entry expires (roughly a minute). Phones that rotate their
+  Wi-Fi MAC per connection — GrapheneOS by default — hit this most often, since
+  the phone's mesh-facing address changes each time. Tracked upstream at
+  [fips#130](https://github.com/jmcorgan/fips/issues/130).
+- Exit-node mode only covers proxy-aware apps (browsers). Other apps, and
+  QUIC/UDP traffic, continue to use the phone's normal connection.
+
 ## [0.3.0] - 2026-07-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fips"
-version = "0.4.0-dev"
+version = "0.5.0-dev"
 dependencies = [
  "arc-swap",
  "bech32",
@@ -2146,6 +2146,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "simple-dns",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tracing",

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,108 +1,104 @@
-# Myco v0.3.0
+# Myco v0.4.0
 
-**Released**: 2026-07-25
+**Released**: 2026-07-29
 
-v0.3.0 is about **staying up and staying honest**: the mesh survives the crashes,
-stalls, and silent failures that used to bite in the field, and the app now tells
-you plainly when a transport is enabled but can't actually run. It also brings the
-mesh on/off control and live reachability into the top status pill, and adds an
-experimental **Wi-Fi AP lane** for connecting to LAN fips nodes over Wi-Fi.
+v0.4.0 is about **reaching the mesh by name**. A node's npub is now an address any
+app on the phone can use: type `http://<npub>.fips/` into an ordinary browser and
+it loads, over Bluetooth or Wi-Fi, with no internet involved. Building on that,
+an experimental **exit-node mode** lets a phone with no connection of its own
+browse the public web through a mesh node that egresses for it.
 
-It upgrades from v0.2.0 in place with no data loss; your identity (nsec), Circle,
-and installed apps are preserved. Unlike v0.2.0, this release changes no ports or
-wire formats — a v0.3.0 phone and a v0.2.0 phone still sync over the mesh — but
-update every device in a Circle to get the reliability fixes on both ends.
+It also fixes the Wi-Fi AP lane, which could fail to connect on any phone that
+also had mobile data — the node saw every handshake arrive while the phone saw
+nothing come back.
+
+It upgrades from v0.3.0 in place with no data loss; your identity (nsec), Circle,
+and installed apps are preserved. No ports or wire formats changed, so a v0.4.0
+phone and a v0.3.0 phone still sync over the mesh.
 
 ## At a glance
 
-- **No more GrapheneOS / secondary-user crash** — a Wi-Fi Aware permission refusal
-  no longer kills the whole app; the lane shuts down gracefully and warns instead.
-- **Transport warnings** — Settings shows a red dot and a tappable warning when
-  mesh, Bluetooth, or Wi-Fi Aware is switched on but can't run (VPN slot taken,
-  Bluetooth off, Wi-Fi off).
-- **Mesh control in the status pill** — a mesh on/off slider, a live
-  `reachable/total` Circle count, and the current peer count, all top-right.
-- **Battery drain cut** — background BLE duty-cycles down, GATT priority relaxes
-  when idle, and the once-a-second poll stops when the app isn't visible.
-- **Relay links self-heal after a stuck rekey** — a wedged mesh session no longer
-  kills a Circle link permanently; dials time out and back off, then rebuild.
-- **Wi-Fi AP lane (developer preview)** — auto-discover and connect to fips nodes
-  on a joined Wi-Fi network over mDNS + UDP. Off unless the network carries a node.
+- **`<npub>.fips` works everywhere on the device** — any browser or app can open
+  a mesh node by name, not just Myco's own gateway.
+- **Exit-node mode (developer preview)** — browse the public internet through a
+  mesh peer, addressed by its npub. For a phone with no internet at all.
+- **Wi-Fi AP lane actually connects** — no longer defeated by having mobile data
+  on at the same time, and no longer stuck dialling an unreachable address.
 
 ## What's new
 
-### The app stops lying about transports
+### Mesh nodes have names now
 
-When a transport was enabled but physically couldn't run, Myco used to look fine
-while quietly doing nothing. v0.3.0 surfaces it: a **red dot on the Settings tab**
-and a tappable warning row for each broken transport — mesh enabled without the
-VPN slot (another VPN app took it), Bluetooth transport on while the phone's
-Bluetooth is off, or Wi-Fi Aware on while Wi-Fi is off. Each warning jumps to the
-fix. Declining the VPN consent dialog now turns the mesh preference **off** instead
-of pretending the mesh is up.
+Every node's npub doubles as a hostname: `<npub>.fips`. Myco's tunnel advertises
+an in-mesh resolver, and answers those names by deriving the address from the
+public key — pure computation, no lookup, no upstream server, works fully offline.
+Because the answer comes from the tunnel rather than from Myco, **every app on the
+phone** gets it. Open `http://<npub>.fips/` in your browser and you are talking to
+that node over the mesh.
 
-### Mesh control in the status pill
+Names that are not `.fips` are passed to your normal resolvers untouched, so this
+does not take over DNS on the device.
 
-The top-right status pill grows a **mesh on/off slider** and now shows, at a
-glance, how many Circle members are reachable right now (`reachable/total`)
-alongside the live peer count — so you can see and toggle mesh state without
-diving into Settings.
+### Exit-node mode (developer preview)
 
-### Wi-Fi AP lane (developer preview)
+A phone with no internet — only a Bluetooth or Wi-Fi link to the mesh — can now
+browse the web, by routing through an HTTP proxy on a mesh node that does have a
+connection. Set the exit under **Settings → Developer → Exit node**, addressed by
+npub:
 
-When the phone joins a Wi-Fi network that carries a FIPS node — such as a router
-broadcasting the open `!FIPS` access SSID — Myco discovers the node via its mDNS
-advert (`_fips._udp`) and connects to it over UDP automatically. It requires LAN
-discovery/rendezvous enabled on the router's fips node. The Developer screen gains
-a **Wi-Fi AP** panel (Wi-Fi/SSID state, mDNS browse state, discovered nodes), and
-the Wi-Fi Aware panel now lists live data paths. See
-[docs/design/ap-lane.md](docs/design/ap-lane.md). Developer preview — treat it as
-experimental.
+```
+<npub>.fips:8080
+```
 
-## Reliability: the mesh holds under stress
+The exit does the DNS and the egress, so the phone never needs to resolve a public
+name or hold a route to one. It also need not be a direct peer — FIPS forwards
+multi-hop to it. `.fips` addresses bypass the exit and stay on the mesh.
 
-- **No crash on GrapheneOS / secondary users.** The system can refuse Wi-Fi Aware
-  calls for lack of the nearby-devices permission *even after* the app's own check
-  passed; the resulting `SecurityException` on the Aware callback thread used to
-  kill the whole app. The lane now shuts down gracefully and surfaces a warning.
-- **Mesh starts even right after granting VPN access.** Enabling the mesh
-  immediately after granting VPN (e.g. reclaiming the slot from another app) no
-  longer silently fails when the mesh address isn't ready yet — the VPN start
-  retries until the node has published its address.
-- **Relay links self-heal after a stuck rekey.** A mesh session wedged mid-rekey
-  used to kill a Circle relay link permanently. Peer relay dials now time out at
-  10s and back off per peer (8s up to 3min) after consecutive failures, reclaim the
-  stale session, and rebuild a fresh one on the next dial.
-- **Bluetooth toggle no longer knocks out Wi-Fi Aware.** Turning the Bluetooth
-  toggle off used to stop the embedded mesh node out from under the Aware lane. The
-  node's lifecycle now follows the mesh **Enable** switch; radio toggles only gate
-  their own radios.
+This covers **proxy-aware apps** — browsers. Other apps and QUIC/UDP traffic keep
+using the phone's normal connection. The runbook, including how to run the exit
+daemon, is in [docs/how-to/exit-node-demo.md](docs/how-to/exit-node-demo.md).
 
-## Battery
+## Reliability: the Wi-Fi AP lane connects
 
-Background drain is cut substantially: BLE discovery duty-cycles down (low-power
-scan with batched delivery) while the app isn't visible, the per-link GATT
-connection priority drops to balanced after 30s without bulk traffic, and the
-once-a-second state poll no longer runs backgrounded (and no longer walks the blob
-cache directory on every read).
+Two separate faults, either of which was enough to stop it:
 
-## Notable bug fixes
+The mesh socket **was not bound to the Wi-Fi network**. A local-only access point
+never passes the system's internet-validation check, so with mobile data also up
+the OS steered the socket to the validated network and quietly discarded the AP's
+replies. The symptom was maddening from either end: the node's counters showed
+every handshake arriving, while the phone re-sent them forever. The socket is now
+pinned to the network the peer is actually on.
 
-- **App crash on GrapheneOS / non-admin users** — Wi-Fi Aware `SecurityException`;
-  see Reliability above.
-- **Mesh silently down after VPN grant** — start now retries until the address is
-  ready; declining consent turns the preference off.
-- **Permanent relay stall after a stuck rekey** — dials now time out and back off.
-- **Developer panel reshuffle** — peer/advert rows keep a stable alphabetical
-  order instead of reordering on every refresh.
+Myco also **dialled the wrong address**. A fips node advertises one address per
+interface, and only the interface facing you answers — nothing in the advert says
+which that is. Myco took the first and could sit retrying an unreachable one
+indefinitely. It now keeps every advertised address and works through them until
+the peer connects, then stays on the one that worked.
+
+## Known issues
+
+- **Peering can stall after a Wi-Fi reconnect** until the node's previous peer
+  entry expires, about a minute. Phones that rotate their Wi-Fi MAC on every
+  connection — GrapheneOS does by default — hit this most, because the phone's
+  mesh-facing address changes each time and the node keeps answering the old one.
+  Turning the mesh off, waiting for the peer to disappear on the node, and turning
+  it back on clears it. Tracked upstream as
+  [fips#130](https://github.com/jmcorgan/fips/issues/130).
+- **Exit mode is browsers-only.** `setHttpProxy` is the only system-wide proxy
+  hook available to a VPN app, so non-proxy-aware apps and UDP/QUIC traffic are
+  unaffected by it. Capturing everything needs a userspace network stack, which
+  is the next step.
+- On macOS, an exit node's proxy will not accept mesh connections until the
+  binary is allowed through the Application Firewall — inbound TCP is dropped
+  silently while ICMP still works, which makes it look like a routing problem.
 
 ## Getting it
 
-- **Android**: install the v0.3.0 APK from the
-  [release page](https://github.com/Origami74/myco/releases/tag/v0.3.0),
+- **Android**: install the v0.4.0 APK from the
+  [release page](https://github.com/Origami74/myco/releases/tag/v0.4.0),
   or via [zapstore](https://zapstore.dev/apps/app.myco).
 - **From source**: `cd android && ./gradlew assembleDebug` from a checkout of
-  the v0.3.0 tag. See [CONTRIBUTING.md](CONTRIBUTING.md) for build prerequisites.
+  the v0.4.0 tag. See [CONTRIBUTING.md](CONTRIBUTING.md) for build prerequisites.
 
 The full per-release change history lives in [CHANGELOG.md](CHANGELOG.md).
 Issues and discussion at [github.com/Origami74/myco](https://github.com/Origami74/myco).

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <!-- Read the underlying network's addresses, to decide whether the mesh
+         tunnel needs to claim an IPv6 default route (see MycoVpnService). -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!-- Foreground service hosting the BLE radio -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -151,6 +151,8 @@ class MainActivity : ComponentActivity() {
                     onOfflineOnlyToggle = { enabled -> setOfflineOnly(enabled) },
                     initialDeveloperMode = prefs.getBoolean(PREF_DEV, BuildConfig.DEBUG),
                     onDeveloperModeToggle = { enabled -> prefs.edit().putBoolean(PREF_DEV, enabled).apply() },
+                    initialExitProxy = prefs.getString(PREF_EXIT_PROXY, "").orEmpty(),
+                    onExitProxyChange = { spec -> setExitProxy(spec) },
                 )
             }
         }
@@ -175,6 +177,19 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    /**
+     * Set (or clear) the mesh **exit proxy** — a `[fd00::exit]:port` HTTP proxy on
+     * a mesh node. Persisted, then applied by re-establishing the VPN so the new
+     * proxy takes effect (the service re-configures in place when the config
+     * changes). Empty string turns exit mode off (back to mesh-only routing).
+     */
+    private fun setExitProxy(spec: String) {
+        prefs.edit().putString(PREF_EXIT_PROXY, spec.trim()).apply()
+        // Only re-establish if the mesh is currently up; otherwise the new value is
+        // picked up the next time the mesh starts.
+        if (prefs.getBoolean(PREF_MESH, true)) startMeshNow()
+    }
+
     /** Toggle mesh-only (no IP fallback); persisted + applied to the core. */
     private fun setOfflineOnly(enabled: Boolean) {
         prefs.edit().putBoolean(PREF_OFFLINE_ONLY, enabled).apply()
@@ -186,7 +201,7 @@ class MainActivity : ComponentActivity() {
         val ula = state.fipsIpv6
         android.util.Log.i("MycoVpn", "startMeshNow: ula=$ula mtu=${state.fipsMtu} attempt=$attempt")
         if (ula.isNotEmpty()) {
-            MycoVpnService.start(this, ula, state.fipsMtu)
+            MycoVpnService.start(this, ula, state.fipsMtu, prefs.getString(PREF_EXIT_PROXY, "").orEmpty())
         } else if (attempt < MESH_START_RETRIES) {
             // The node is still coming up (common right after the VPN consent
             // dialog — e.g. when Myco just reclaimed the slot from another VPN
@@ -506,5 +521,6 @@ class MainActivity : ComponentActivity() {
         const val PREF_MESH = "mesh_enabled"
         const val PREF_OFFLINE_ONLY = "offline_only"
         const val PREF_DEV = "developer_mode"
+        const val PREF_EXIT_PROXY = "exit_proxy"
     }
 }

--- a/android/app/src/main/java/app/myco/ap/ApRadio.kt
+++ b/android/app/src/main/java/app/myco/ap/ApRadio.kt
@@ -12,10 +12,12 @@ import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
+import android.os.ParcelFileDescriptor
 import android.util.Log
 import androidx.annotation.RequiresApi
 import app.myco.core.MycoCore
 import app.myco.core.NativeCore
+import java.io.FileDescriptor
 import java.net.Inet4Address
 import java.net.Inet6Address
 import java.net.InetAddress
@@ -51,6 +53,14 @@ import kotlinx.coroutines.flow.asStateFlow
  * address would find no compatible socket). `fd00::/8` addresses are skipped:
  * the VpnService routes that prefix into the mesh TUN, so dialing one would
  * blackhole the handshake.
+ *
+ * The `!FIPS` AP never passes internet validation (it's local-only), so on a
+ * phone with active mobile data the OS can route the handshake's replies to
+ * a competing validated default network instead of back over this Wi-Fi —
+ * the send succeeds locally but nothing ever comes back. [`bindUdpSocket`]
+ * pins the core's UDP transport socket (fd surfaced via
+ * [NativeCore.nextUdpTransportFd]) to this specific [Network] with
+ * `Network.bindSocket` so replies aren't lost that way.
  */
 class ApRadio private constructor(private val context: Context) {
     private val connectivity =
@@ -71,11 +81,25 @@ class ApRadio private constructor(private val context: Context) {
     /** npub → last pushed addr. */
     private val pushed = HashMap<String, String>()
 
+    /** npub → every dialable address the advert carried, in preference order,
+     *  and which one we are currently trying. A fips node advertises one
+     *  address per interface, and only the interface facing us is actually
+     *  on-link — the others fail neighbour discovery — so the right one can
+     *  only be found by trying them ([rotate]). */
+    private val candidates = HashMap<String, List<String>>()
+    private val candidateIdx = HashMap<String, Int>()
+
     private val resolveQueue = ArrayDeque<NsdServiceInfo>()
     private var resolving = false
     private var browsing = false
     private var browseListener: NsdManager.DiscoveryListener? = null
     private var ssid: String? = null
+
+    /** The core's UDP transport socket fd, once learned (see [bindUdpSocket]).
+     *  Confined to [handler]; re-learned each time the node (re)starts.
+     *  [udpPfd] owns the dup and is kept alive so [udpFd] stays valid. */
+    private var udpPfd: ParcelFileDescriptor? = null
+    private var udpFd: FileDescriptor? = null
 
     /** Own npub, to skip a self-advert (defensive — the app never publishes
      *  mDNS, only browses). Resolved lazily; the core is up by first resolve. */
@@ -91,6 +115,7 @@ class ApRadio private constructor(private val context: Context) {
 
         override fun onAvailable(network: Network) {
             if (wifiNets.add(network) && wifiNets.size == 1) startBrowse()
+            bindUdpSocket(network)
             publishWifi()
         }
 
@@ -122,6 +147,44 @@ class ApRadio private constructor(private val context: Context) {
         }
         connectivity.registerNetworkCallback(request, callback, handler)
         Log.i(TAG, "AP lane armed (browsing $SERVICE_TYPE while Wi-Fi is up)")
+
+        // Learn the core's UDP transport fd as soon as the node opens it (only
+        // once mesh is toggled on — see runtime.rs's start_node). A dedicated
+        // thread since the native call blocks; loops forever so a later
+        // mesh off→on cycle (a fresh transport, fresh fd) is picked up too.
+        Thread({
+            while (true) {
+                val fd = NativeCore.nextUdpTransportFd(FD_POLL_TIMEOUT_MS)
+                if (fd >= 0) handler.post { onUdpFd(fd) }
+            }
+        }, "myco-ap-udpfd").apply { isDaemon = true; start() }
+    }
+
+    /** A fresh UDP transport fd arrived (node just started, or restarted).
+     *  `fromFd` dups it, so fips keeps full ownership of the original — the
+     *  dup refers to the same socket, and `bindSocket`'s mark applies to the
+     *  socket, not the fd. The [ParcelFileDescriptor] is held (not closed) for
+     *  as long as we may need to re-bind on a network change. */
+    private fun onUdpFd(fd: Int) {
+        val pfd = runCatching { ParcelFileDescriptor.fromFd(fd) }.getOrElse {
+            Log.w(TAG, "could not dup UDP transport fd $fd", it)
+            return
+        }
+        udpPfd?.let { old -> runCatching { old.close() } }
+        udpPfd = pfd
+        udpFd = pfd.fileDescriptor
+        wifiNets.firstOrNull()?.let { bindUdpSocket(it) }
+    }
+
+    /** Pin the core's UDP transport socket to `network` via `Network.bindSocket`
+     *  — see the class doc's "why" — so replies to a peer on this ap-lane
+     *  network aren't lost to a competing validated default network. A no-op
+     *  until [onUdpFd] has learned the fd (mesh not started yet). */
+    private fun bindUdpSocket(network: Network) {
+        val fd = udpFd ?: return // node not started yet; onUdpFd binds when it is
+        runCatching { network.bindSocket(fd) }
+            .onSuccess { Log.i(TAG, "bound core UDP socket to $network") }
+            .onFailure { Log.w(TAG, "bindSocket to Wi-Fi network failed", it) }
     }
 
     // --- mDNS browse ---
@@ -181,19 +244,28 @@ class ApRadio private constructor(private val context: Context) {
         // UDP sessions instead of re-using dead sockets.
         for (npub in pushed.keys) NativeCore.awarePeerLost(npub)
         pushed.clear()
+        candidates.clear()
+        candidateIdx.clear()
         npubByService.clear()
         publishNodes()
         publishWifi()
     }
 
-    /** Periodic re-push of every resolved node while the browse is live: NSD
-     *  fires onServiceFound only once per appearance, so a dropped UDP session
-     *  would otherwise never get a fresh dial hint. The core's alternate-path
-     *  gates make a redundant push a no-op for a healthy peer. */
+    /** Periodic tick while the browse is live. For a connected peer it re-pushes
+     *  the working address: NSD fires onServiceFound only once per appearance,
+     *  so a dropped UDP session would otherwise never get a fresh dial hint (the
+     *  core's alternate-path gates make a redundant push a no-op for a healthy
+     *  peer). For an unconnected one it advances to the next candidate address. */
     private val repush = object : Runnable {
         override fun run() {
             if (browseListener == null) return
-            for ((npub, addr) in pushed) NativeCore.awarePeerFound(npub, addr)
+            for (npub in candidates.keys.toList()) {
+                if (connected(npub)) {
+                    pushed[npub]?.let { NativeCore.awarePeerFound(npub, it) }
+                } else {
+                    rotate(npub)
+                }
+            }
             handler.postDelayed(this, REPUSH_MS)
         }
     }
@@ -235,21 +307,47 @@ class ApRadio private constructor(private val context: Context) {
             ?.takeIf { it.startsWith("npub1") }
             ?: run { Log.w(TAG, "advert ${info.serviceName} has no npub TXT"); return }
         if (npub == ownNpub) return
-        val addr = pickAddr(info) ?: run {
+        val addrs = pickAddrs(info)
+        if (addrs.isEmpty()) {
             Log.w(TAG, "no dialable address for ${short(npub)} (${info.serviceName})")
             return
         }
         npubByService[info.serviceName] = npub
-        if (pushed[npub] != addr) {
-            Log.i(TAG, "fips node ${short(npub)} at $addr — pushing to core")
-            NativeCore.awarePeerFound(npub, addr)
-            pushed[npub] = addr
-        }
+        candidates[npub] = addrs
+        candidateIdx.putIfAbsent(npub, 0)
+        push(npub)
         publishNodes()
+    }
+
+    /** Push this peer's current candidate address to the core. */
+    private fun push(npub: String) {
+        val addrs = candidates[npub] ?: return
+        val addr = addrs[(candidateIdx[npub] ?: 0) % addrs.size]
+        if (pushed[npub] == addr) return
+        Log.i(TAG, "fips node ${short(npub)} at $addr — pushing to core")
+        NativeCore.awarePeerFound(npub, addr)
+        pushed[npub] = addr
+    }
+
+    /** True once the core reports an authenticated session with `npub`. */
+    private fun connected(npub: String): Boolean = runCatching {
+        MycoCore.client(context).state().blePeers.any { it.npub == npub && it.connected }
+    }.getOrDefault(false)
+
+    /** Advance an unconnected peer to its next candidate address. Only the
+     *  interface facing us answers neighbour discovery, and the advert doesn't
+     *  say which that is, so this cycles until one handshakes. */
+    private fun rotate(npub: String) {
+        val addrs = candidates[npub] ?: return
+        if (addrs.size < 2) return
+        candidateIdx[npub] = ((candidateIdx[npub] ?: 0) + 1) % addrs.size
+        push(npub)
     }
 
     private fun serviceLost(serviceName: String) {
         val npub = npubByService.remove(serviceName) ?: return
+        candidates.remove(npub)
+        candidateIdx.remove(npub)
         if (pushed.remove(npub) != null) {
             Log.i(TAG, "fips node ${short(npub)} gone from LAN")
             NativeCore.awarePeerLost(npub)
@@ -258,11 +356,12 @@ class ApRadio private constructor(private val context: Context) {
     }
 
     /**
-     * Pick the address to dial, per the preference order in the class doc.
-     * Formats match what the core's address parser accepts: numeric-scope
-     * link-local (`[fe80::x%3]:4871`), plain `[v6]:port`, v4-mapped v6.
+     * Every dialable address the advert carries, in the preference order given
+     * in the class doc. Formats match what the core's address parser accepts:
+     * numeric-scope link-local (`[fe80::x%3]:4871`), plain `[v6]:port`,
+     * v4-mapped v6.
      */
-    private fun pickAddr(info: NsdServiceInfo): String? {
+    private fun pickAddrs(info: NsdServiceInfo): List<String> {
         val hosts: List<InetAddress> =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                 info.hostAddresses
@@ -270,16 +369,17 @@ class ApRadio private constructor(private val context: Context) {
                 @Suppress("DEPRECATION")
                 listOfNotNull(info.host)
             }
-        val port = info.port.takeIf { it > 0 } ?: return null
+        val port = info.port.takeIf { it > 0 } ?: return emptyList()
         val v6 = hosts.filterIsInstance<Inet6Address>()
-        v6.firstOrNull { it.isLinkLocalAddress && it.scopeId != 0 }
-            ?.let { return "[${bare(it)}%${it.scopeId}]:$port" }
-        // fd00::/8 is routed into the mesh TUN — dialing it would blackhole.
-        v6.firstOrNull { !it.isLinkLocalAddress && it.address[0] != 0xfd.toByte() }
-            ?.let { return "[${bare(it)}]:$port" }
-        hosts.filterIsInstance<Inet4Address>().firstOrNull()
-            ?.let { return "[::ffff:${it.hostAddress}]:$port" }
-        return null
+        return buildList {
+            v6.filter { it.isLinkLocalAddress && it.scopeId != 0 }
+                .forEach { add("[${bare(it)}%${it.scopeId}]:$port") }
+            // fd00::/8 is routed into the mesh TUN — dialing it would blackhole.
+            v6.filter { !it.isLinkLocalAddress && it.address[0] != 0xfd.toByte() }
+                .forEach { add("[${bare(it)}]:$port") }
+            hosts.filterIsInstance<Inet4Address>()
+                .forEach { add("[::ffff:${it.hostAddress}]:$port") }
+        }
     }
 
     private fun bare(a: InetAddress): String = a.hostAddress?.substringBefore('%') ?: ""
@@ -328,7 +428,14 @@ class ApRadio private constructor(private val context: Context) {
         /** TXT key carrying the advertising node's npub. */
         private const val TXT_NPUB = "npub"
 
-        private const val REPUSH_MS = 60_000L
+        /** Also the candidate-rotation interval, so an unconnected peer works
+         *  through its addresses in reasonable time (see [rotate]). */
+        private const val REPUSH_MS = 10_000L
+
+        /** Blocking wait per poll for the core's UDP transport fd. Short so a
+         *  mesh off→on cycle's fresh fd is picked up promptly, and so the
+         *  native side's install path never stalls long behind this call. */
+        private const val FD_POLL_TIMEOUT_MS = 1_000
 
         private val _wifi = MutableStateFlow(WifiApView())
         private val _nodes = MutableStateFlow<List<LanFipsNode>>(emptyList())

--- a/android/app/src/main/java/app/myco/core/NativeCore.kt
+++ b/android/app/src/main/java/app/myco/core/NativeCore.kt
@@ -62,6 +62,14 @@ internal object NativeCore {
     /** Aware data path to `npub` lost: close the pooled UDP session. */
     external fun awarePeerLost(npub: String)
 
+    /** Raw fd of the node's UDP transport socket, once it has opened. Blocks
+     *  up to `timeoutMs`; returns -1 on timeout. Sent once per node lifetime —
+     *  poll this once at startup, then bind it to whichever local-only
+     *  network (Wi-Fi Aware NDP, the `!FIPS` AP) is carrying a
+     *  platform-pushed peer via `Network.bindSocket`, so handshake replies
+     *  aren't lost to a competing validated default network (e.g. cellular). */
+    external fun nextUdpTransportFd(timeoutMs: Int): Int
+
     // --- TUN packet bridge (the app-owned TUN; the VpnService pumps these) ---
     /** Kotlin → Rust: route an IPv6 packet read from the TUN fd into the mesh. */
     external fun tunSendPacket(packet: ByteArray, len: Int): Boolean

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -105,6 +105,8 @@ fun MycoApp(
     onOfflineOnlyToggle: (Boolean) -> Unit,
     initialDeveloperMode: Boolean,
     onDeveloperModeToggle: (Boolean) -> Unit,
+    initialExitProxy: String = "",
+    onExitProxyChange: (String) -> Unit = {},
 ) {
     var state by remember { mutableStateOf(client.state()) }
     // Mesh toggle is hoisted here so it survives tab switches.
@@ -237,6 +239,8 @@ fun MycoApp(
                         developerMode = developerMode,
                         onDeveloperModeToggle = { on -> developerMode = on; onDeveloperModeToggle(on) },
                         bleExhausted = bleExhausted,
+                        initialExitProxy = initialExitProxy,
+                        onExitProxyChange = onExitProxyChange,
                     )
                 }
                 composable("dev") { DevScreen(state, client) }

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -45,6 +46,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -90,6 +92,8 @@ fun SettingsScreen(
     developerMode: Boolean,
     onDeveloperModeToggle: (Boolean) -> Unit,
     bleExhausted: Boolean = false,
+    initialExitProxy: String = "",
+    onExitProxyChange: (String) -> Unit = {},
 ) {
     var page by remember { mutableStateOf(SettingsPage.Root) }
 
@@ -118,6 +122,8 @@ fun SettingsScreen(
         SettingsPage.Developer -> DeveloperSettings(
             state = state,
             onOfflineOnlyToggle = onOfflineOnlyToggle,
+            initialExitProxy = initialExitProxy,
+            onExitProxyChange = onExitProxyChange,
             onBack = { page = SettingsPage.Root },
         )
     }
@@ -426,7 +432,13 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
 // ----------------------------------------------------------------------------
 
 @Composable
-private fun DeveloperSettings(state: AppState, onOfflineOnlyToggle: (Boolean) -> Unit, onBack: () -> Unit) {
+private fun DeveloperSettings(
+    state: AppState,
+    onOfflineOnlyToggle: (Boolean) -> Unit,
+    initialExitProxy: String,
+    onExitProxyChange: (String) -> Unit,
+    onBack: () -> Unit,
+) {
     SettingsColumn {
         SubHeader("Developer settings", onBack)
         Spacer(Modifier.height(4.dp))
@@ -440,6 +452,38 @@ private fun DeveloperSettings(state: AppState, onOfflineOnlyToggle: (Boolean) ->
                 checked = state.offlineOnly,
                 onToggle = onOfflineOnlyToggle,
             )
+        }
+
+        Spacer(Modifier.height(8.dp))
+        GroupLabel("EXIT NODE")
+        SectionCard {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    "Route web traffic through an HTTP proxy on a mesh exit node. " +
+                        "Enter the exit as <npub>.fips:8080 (or [fd00::…]:8080). Blank = off.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                // Init once — NOT keyed on initialExitProxy, which MainActivity
+                // re-reads from prefs on every recomposition; keying on it would
+                // wipe the user's typing mid-edit (and before Apply persists).
+                var field by rememberSaveable { mutableStateOf(initialExitProxy) }
+                OutlinedTextField(
+                    value = field,
+                    onValueChange = { field = it },
+                    singleLine = true,
+                    label = { Text("Exit proxy") },
+                    placeholder = { Text("<npub>.fips:8080") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = { onExitProxyChange(field.trim()) }) { Text("Apply") }
+                    TextButton(onClick = { field = ""; onExitProxyChange("") }) { Text("Turn off") }
+                }
+            }
         }
 
         Spacer(Modifier.height(8.dp))

--- a/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
+++ b/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.ProxyInfo
 import android.net.VpnService
 import android.os.ParcelFileDescriptor
 import android.util.Log
@@ -14,6 +15,10 @@ import app.myco.R
 import app.myco.core.NativeCore
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -32,12 +37,28 @@ import java.util.concurrent.atomic.AtomicBoolean
  * and reach mesh addresses directly. The native TUN pump answers those DNS
  * queries by pure computation (see `myco-core`'s `dns_intercept`); everything
  * else stays off this route, so normal internet is untouched.
+ *
+ * ### Exit mode
+ * Given an [EXTRA_EXIT_PROXY] address, the service also advertises an HTTP proxy
+ * to every app on the tunnel, so their web traffic egresses through a proxy
+ * running on a mesh **exit node** — letting a phone with no internet of its own
+ * browse the public web over the mesh. Android's [ProxyInfo] is unreliable with
+ * an IPv6 literal, so the proxy is advertised as `127.0.0.1:<port>` and a small
+ * loopback relay ([ExitRelay]) carries those connections to the exit's mesh
+ * address. Because the exit is named by npub, `<npub>.fips:8080` works and the
+ * exit need not peer this device directly — FIPS forwards multi-hop.
  */
 class MycoVpnService : VpnService() {
     private var tun: ParcelFileDescriptor? = null
     private val running = AtomicBoolean(false)
     @Volatile private var readerThread: Thread? = null
     @Volatile private var writerThread: Thread? = null
+    @Volatile private var relay: ExitRelay? = null
+
+    // Live config; a start intent carrying a different one re-establishes.
+    @Volatile private var curUla: String = ""
+    @Volatile private var curMtu: Int = 0
+    @Volatile private var curExit: String = ""
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_STOP) {
@@ -48,15 +69,22 @@ class MycoVpnService : VpnService() {
         startTun(
             intent?.getStringExtra(EXTRA_ULA).orEmpty(),
             intent?.getIntExtra(EXTRA_MTU, 0) ?: 0,
+            intent?.getStringExtra(EXTRA_EXIT_PROXY).orEmpty(),
         )
         return START_STICKY
     }
 
-    private fun startTun(ula: String, mtuHint: Int) {
-        if (running.get()) return
+    private fun startTun(ula: String, mtuHint: Int, exitProxy: String) {
         if (ula.isEmpty()) {
             stopSelf()
             return
+        }
+        // Already up on this exact config — nothing to do. A changed one (the
+        // user set or cleared the exit) tears down and re-establishes.
+        if (running.get()) {
+            if (ula == curUla && mtuHint == curMtu && exitProxy == curExit) return
+            Log.i(TAG, "reconfiguring TUN (exit='$exitProxy')")
+            teardown()
         }
         startForegroundCompat()
 
@@ -65,6 +93,23 @@ class MycoVpnService : VpnService() {
         // clamp (effective - 60) applied in the native bridge. Use the FIPS hint
         // only when it's already >= 1280 (a larger-MTU transport).
         val mtu = if (mtuHint in 1280..1500) mtuHint else 1280
+
+        // In exit mode, stand the loopback relay up first — we need its port to
+        // advertise the proxy below.
+        val exit = parseExit(exitProxy)
+        val relayPort: Int = if (exit != null) {
+            val r = try {
+                ExitRelay(exit.first, exit.second).also { it.start() }
+            } catch (t: Throwable) {
+                Log.e(TAG, "exit relay failed to start", t)
+                null
+            }
+            relay = r
+            r?.localPort ?: -1
+        } else {
+            -1
+        }
+
         val builder = Builder()
             .setSession("Myco mesh")
             .setMtu(mtu)
@@ -95,6 +140,15 @@ class MycoVpnService : VpnService() {
         } catch (e: Exception) {
             Log.w(TAG, "addDnsServer($DNS_SENTINEL) failed", e)
         }
+        if (relayPort > 0) {
+            // Point every app's web traffic at the loopback relay, which carries
+            // it to the exit's proxy over the mesh. Proxied requests go to
+            // 127.0.0.1 — loopback, reachable regardless of routes — so this
+            // needs no default route of its own, and Myco's own transports (the
+            // AP UDP lane, mDNS, BLE) stay on the real network.
+            builder.setHttpProxy(ProxyInfo.buildDirectProxy("127.0.0.1", relayPort))
+            Log.i(TAG, "exit mode: proxy 127.0.0.1:$relayPort -> mesh $exitProxy")
+        }
         val pfd = try {
             builder.establish()
         } catch (t: Throwable) {
@@ -103,6 +157,8 @@ class MycoVpnService : VpnService() {
         }
         if (pfd == null) {
             Log.e(TAG, "establish() returned null — VPN not consented or Builder rejected (ula=$ula)")
+            relay?.close()
+            relay = null
             android.widget.Toast.makeText(
                 this,
                 "Couldn't start the mesh adapter — another VPN may be active. " +
@@ -113,10 +169,17 @@ class MycoVpnService : VpnService() {
             return
         }
         tun = pfd
+        curUla = ula
+        curMtu = mtuHint
+        curExit = exitProxy
         running.set(true)
         readerThread = Thread({ readLoop(pfd) }, "myco-tun-read").apply { start() }
         writerThread = Thread({ writeLoop(pfd) }, "myco-tun-write").apply { start() }
-        Log.i(TAG, "mesh TUN up at $ula (route fd00::/8, dns $DNS_SENTINEL)")
+        Log.i(
+            TAG,
+            "mesh TUN up at $ula (route fd00::/8, dns $DNS_SENTINEL" +
+                "${if (relayPort > 0) ", exit on" else ""})",
+        )
     }
 
     /** TUN fd → mesh: read IPv6 packets and hand them to FIPS. */
@@ -150,16 +213,9 @@ class MycoVpnService : VpnService() {
         }
     }
 
-    private fun stopTun() {
-        if (!running.compareAndSet(true, false)) {
-            try {
-                tun?.close()
-            } catch (_: Exception) {
-            }
-            tun = null
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            return
-        }
+    /** Tear the tun + relay down without stopping the service (used on reconfig). */
+    private fun teardown() {
+        running.set(false)
         readerThread?.interrupt()
         writerThread?.interrupt()
         try {
@@ -167,8 +223,18 @@ class MycoVpnService : VpnService() {
         } catch (_: Exception) {
         }
         tun = null
+        relay?.close()
+        relay = null
+        curUla = ""
+        curMtu = 0
+        curExit = ""
+    }
+
+    private fun stopTun() {
+        val wasRunning = running.get()
+        teardown()
         stopForeground(STOP_FOREGROUND_REMOVE)
-        Log.i(TAG, "mesh TUN down")
+        if (wasRunning) Log.i(TAG, "mesh TUN down")
     }
 
     override fun onDestroy() {
@@ -200,9 +266,90 @@ class MycoVpnService : VpnService() {
             PendingIntent.FLAG_IMMUTABLE,
         )
 
+    /**
+     * A loopback TCP relay: accepts on `127.0.0.1:0` and forwards each connection
+     * verbatim to the exit node's HTTP proxy at `[host]:port` over the mesh. A
+     * dumb byte pipe — the browser speaks the proxy protocol (CONNECT/GET)
+     * end-to-end with the exit's proxy; we only carry the bytes, so the exit does
+     * the DNS and the egress and a phone with no internet still works.
+     *
+     * The upstream socket is deliberately NOT [protect]ed: it must ride this same
+     * VPN (route `fd00::/8`) into FIPS and out over the mesh. Replies come back
+     * on that socket, never into the listener, so there is no loop.
+     */
+    private inner class ExitRelay(private val host: String, private val port: Int) {
+        private val server = ServerSocket().apply {
+            reuseAddress = true
+            bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0))
+        }
+        val localPort: Int get() = server.localPort
+        private val alive = AtomicBoolean(true)
+        private var acceptThread: Thread? = null
+
+        fun start() {
+            acceptThread = Thread({ acceptLoop() }, "myco-exit-accept").apply { start() }
+        }
+
+        private fun acceptLoop() {
+            while (alive.get()) {
+                val client = try {
+                    server.accept()
+                } catch (_: Exception) {
+                    break
+                }
+                Thread({ handle(client) }, "myco-exit-conn").start()
+            }
+        }
+
+        private fun handle(client: Socket) {
+            val upstream = try {
+                Socket().apply {
+                    connect(InetSocketAddress(InetAddress.getByName(host), port), 10_000)
+                }
+            } catch (t: Throwable) {
+                Log.w(TAG, "exit upstream connect [$host]:$port failed", t)
+                try { client.close() } catch (_: Exception) {}
+                return
+            }
+            client.tcpNoDelay = true
+            upstream.tcpNoDelay = true
+            Thread({ pipe(client, upstream) }, "myco-exit-up").start()
+            Thread({ pipe(upstream, client) }, "myco-exit-down").start()
+        }
+
+        private fun pipe(from: Socket, to: Socket) {
+            val buf = ByteArray(8192)
+            try {
+                val ins = from.getInputStream()
+                val outs = to.getOutputStream()
+                while (true) {
+                    val n = ins.read(buf)
+                    if (n < 0) break
+                    outs.write(buf, 0, n)
+                    outs.flush()
+                }
+            } catch (_: Exception) {
+            } finally {
+                try { to.shutdownOutput() } catch (_: Exception) {}
+                try { from.shutdownInput() } catch (_: Exception) {}
+                if (from.isClosed || to.isClosed) {
+                    try { from.close() } catch (_: Exception) {}
+                    try { to.close() } catch (_: Exception) {}
+                }
+            }
+        }
+
+        fun close() {
+            alive.set(false)
+            try { server.close() } catch (_: Exception) {}
+            acceptThread?.interrupt()
+        }
+    }
+
     companion object {
         const val EXTRA_ULA = "app.myco.extra.ULA"
         const val EXTRA_MTU = "app.myco.extra.MTU"
+        const val EXTRA_EXIT_PROXY = "app.myco.extra.EXIT_PROXY"
         // In-mesh sentinel DNS resolver (matches myco-core's dns_intercept). Inside
         // the routed fd00::/8 range but never a node's own address, so query
         // packets reach the app-owned-TUN pump instead of being delivered locally.
@@ -212,11 +359,50 @@ class MycoVpnService : VpnService() {
         private const val NOTIF_ID = 42
         private const val TAG = "MycoVpn"
 
-        fun start(context: Context, ula: String, mtu: Int) {
+        /**
+         * Parse an exit-proxy spec into (host, port). Accepts `<npub>.fips:8080`,
+         * `[fd00::ab]:8080`, `fd00::ab 8080`, `host:8080`, or a bare host
+         * (default port 8080), and tolerates a pasted `http(s)://…/` URL.
+         * Returns null when [spec] is blank or unparseable.
+         */
+        fun parseExit(spec: String): Pair<String, Int>? {
+            var s = spec.trim()
+            s = s.removePrefix("https://").removePrefix("http://")
+            // Drop a path but never a port — only cut at '/' (IPv6 literals use
+            // brackets, so they carry no slashes).
+            val slash = s.indexOf('/')
+            if (slash >= 0) s = s.substring(0, slash)
+            s = s.trim()
+            if (s.isEmpty()) return null
+            return try {
+                when {
+                    s.startsWith("[") -> {
+                        val close = s.indexOf(']')
+                        val host = s.substring(1, close)
+                        val port = s.substring(close + 1).removePrefix(":").ifEmpty { "8080" }
+                        host to port.toInt()
+                    }
+                    ' ' in s -> {
+                        val (h, p) = s.split(Regex("\\s+"), limit = 2)
+                        h to p.toInt()
+                    }
+                    s.count { it == ':' } == 1 -> {
+                        val (h, p) = s.split(":", limit = 2)
+                        h to p.toInt()
+                    }
+                    else -> s to 8080 // bare host, or a bracket-less IPv6 literal
+                }
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        fun start(context: Context, ula: String, mtu: Int, exitProxy: String = "") {
             context.startService(
                 Intent(context, MycoVpnService::class.java)
                     .putExtra(EXTRA_ULA, ula)
-                    .putExtra(EXTRA_MTU, mtu),
+                    .putExtra(EXTRA_MTU, mtu)
+                    .putExtra(EXTRA_EXIT_PROXY, exitProxy),
             )
         }
 

--- a/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
+++ b/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
@@ -6,6 +6,8 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.ProxyInfo
 import android.net.VpnService
 import android.os.ParcelFileDescriptor
@@ -15,6 +17,7 @@ import app.myco.R
 import app.myco.core.NativeCore
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.net.Inet6Address
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.ServerSocket
@@ -59,6 +62,12 @@ class MycoVpnService : VpnService() {
     @Volatile private var curUla: String = ""
     @Volatile private var curMtu: Int = 0
     @Volatile private var curExit: String = ""
+    /** Whether the live tunnel claims `::/0` (see the route block in startTun). */
+    @Volatile private var curClaimIpv6: Boolean = false
+
+    /** Watches for IPv6 appearing/vanishing underneath, which changes whether
+     *  the tunnel should claim `::/0`. Registered while the TUN is up. */
+    private var netCallback: ConnectivityManager.NetworkCallback? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_STOP) {
@@ -79,11 +88,20 @@ class MycoVpnService : VpnService() {
             stopSelf()
             return
         }
+        // See the route block below; computed up front so a change in the
+        // underlying network's IPv6 also counts as a config change.
+        val claimIpv6 = !underlyingHasGlobalIpv6()
+
         // Already up on this exact config — nothing to do. A changed one (the
-        // user set or cleared the exit) tears down and re-establishes.
+        // user set or cleared the exit, or IPv6 appeared/vanished underneath)
+        // tears down and re-establishes.
         if (running.get()) {
-            if (ula == curUla && mtuHint == curMtu && exitProxy == curExit) return
-            Log.i(TAG, "reconfiguring TUN (exit='$exitProxy')")
+            if (ula == curUla && mtuHint == curMtu && exitProxy == curExit &&
+                claimIpv6 == curClaimIpv6
+            ) {
+                return
+            }
+            Log.i(TAG, "reconfiguring TUN (exit='$exitProxy', claimIpv6=$claimIpv6)")
             teardown()
         }
         startForegroundCompat()
@@ -119,15 +137,24 @@ class MycoVpnService : VpnService() {
             // VPN instead of being blacked out by an IPv6-only tunnel.
             .addAddress("10.255.255.254", 32)
             .addRoute("fd00::", 8) // the mesh ULA range — the only traffic we carry
-            // An IPv6 default route as well, purely so the OS reports this network
-            // as IPv6-capable. Chromium (and others) gate AAAA queries on an IPv6
-            // reachability probe, and a tunnel offering only a unique-local address
-            // fails it — so `<npub>.fips` was never even *asked* for as AAAA, and
-            // resolving it in a browser failed while `ping6` worked. Non-mesh
-            // packets that arrive because of this route are dropped in the pump
-            // (see myco-core's `tun_bridge`), never forwarded into the mesh.
-            .addRoute("::", 0)
             .setConfigureIntent(configIntent())
+
+        // Claim an IPv6 default route *only* when the network underneath has no
+        // global IPv6 of its own.
+        //
+        // Why claim it at all: browsers gate AAAA queries on an IPv6 reachability
+        // probe, and a tunnel offering only a unique-local address fails it — so
+        // `<npub>.fips` was never even *asked* for as AAAA and failed to resolve,
+        // while `ping6` (which forces AF_INET6) worked. Claiming `::/0` makes the
+        // tunnel read as IPv6-capable and the query gets made.
+        //
+        // Why only sometimes: packets arriving because of this route are dropped
+        // in the pump (myco-core's `tun_bridge`) rather than forwarded, so on a
+        // network that *does* have working IPv6 the route would blackhole it. The
+        // two cases are complementary — where real IPv6 exists the probe already
+        // succeeds via the underlying default route, so the claim isn't needed;
+        // where it doesn't, there is no IPv6 traffic to lose.
+        if (claimIpv6) builder.addRoute("::", 0)
         // Advertise the in-mesh sentinel resolver so every app on the VPN can
         // resolve `<npub>.fips` names system-wide. The native TUN pump answers
         // queries to this address (see dns_intercept); it never leaves the
@@ -139,6 +166,18 @@ class MycoVpnService : VpnService() {
             builder.addDnsServer(DNS_SENTINEL)
         } catch (e: Exception) {
             Log.w(TAG, "addDnsServer($DNS_SENTINEL) failed", e)
+        }
+        // …then the real resolvers, as fallbacks. The sentinel only owns
+        // `.fips` and answers everything else SERVFAIL (see dns_intercept), so
+        // without these the tunnel would deny all normal DNS on the device.
+        // Order matters: the sentinel must come first, or a `.fips` name would
+        // be sent to a real resolver and authoritatively denied.
+        for (server in underlyingDnsServers(claimIpv6)) {
+            try {
+                builder.addDnsServer(server)
+            } catch (e: Exception) {
+                Log.w(TAG, "addDnsServer($server) failed", e)
+            }
         }
         if (relayPort > 0) {
             // Point every app's web traffic at the loopback relay, which carries
@@ -179,14 +218,116 @@ class MycoVpnService : VpnService() {
         curUla = ula
         curMtu = mtuHint
         curExit = exitProxy
+        curClaimIpv6 = claimIpv6
         running.set(true)
+        watchUnderlyingNetworks()
         readerThread = Thread({ readLoop(pfd) }, "myco-tun-read").apply { start() }
         writerThread = Thread({ writeLoop(pfd) }, "myco-tun-write").apply { start() }
         Log.i(
             TAG,
             "mesh TUN up at $ula (route fd00::/8, dns $DNS_SENTINEL" +
+                "${if (claimIpv6) ", claiming ::/0" else ""}" +
                 "${if (relayPort > 0) ", exit on" else ""})",
         )
+    }
+
+    /**
+     * Re-run the `::/0` decision when the networks underneath change (Wi-Fi with
+     * real IPv6 comes or goes, cellular hands over). [startTun] is idempotent for
+     * an unchanged config, so this only re-establishes when the answer flips.
+     */
+    private fun watchUnderlyingNetworks() {
+        if (netCallback != null) return
+        val cm = getSystemService(ConnectivityManager::class.java) ?: return
+        val cb = object : ConnectivityManager.NetworkCallback() {
+            private fun recheck() {
+                if (!running.get()) return
+                startTun(curUla, curMtu, curExit)
+            }
+            override fun onAvailable(network: android.net.Network) = recheck()
+            override fun onLost(network: android.net.Network) = recheck()
+            override fun onLinkPropertiesChanged(
+                network: android.net.Network,
+                lp: android.net.LinkProperties,
+            ) = recheck()
+        }
+        netCallback = cb
+        runCatching { cm.registerDefaultNetworkCallback(cb) }
+            .onFailure { Log.w(TAG, "registerDefaultNetworkCallback failed", it); netCallback = null }
+    }
+
+    private fun unwatchUnderlyingNetworks() {
+        val cb = netCallback ?: return
+        netCallback = null
+        runCatching { getSystemService(ConnectivityManager::class.java)?.unregisterNetworkCallback(cb) }
+    }
+
+    /**
+     * The underlying networks' DNS servers, filtered to those our own routes do
+     * **not** capture — a resolver we swallow and drop is worse than none, since
+     * the OS would wait out a timeout on it.
+     *
+     * IPv4 is always safe (the tunnel carries no IPv4 route). IPv6 is only safe
+     * when we are not claiming `::/0`, and never for `fc00::/7`, which our
+     * `fd00::/8` mesh route covers.
+     */
+    private fun underlyingDnsServers(claimIpv6: Boolean): List<InetAddress> {
+        val cm = getSystemService(ConnectivityManager::class.java) ?: return emptyList()
+        return try {
+            cm.allNetworks.asSequence()
+                .filter { n ->
+                    val caps = cm.getNetworkCapabilities(n)
+                    caps != null &&
+                        !caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN) &&
+                        caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                }
+                .flatMap { n -> cm.getLinkProperties(n)?.dnsServers.orEmpty().asSequence() }
+                .filter { a ->
+                    when {
+                        a !is Inet6Address -> true // IPv4: never captured
+                        claimIpv6 -> false // ::/0 would swallow it
+                        a.isLinkLocalAddress -> false
+                        else -> (a.address[0].toInt() and 0xfe) != 0xfc // not fc00::/7
+                    }
+                }
+                .distinct()
+                .toList()
+        } catch (t: Throwable) {
+            Log.w(TAG, "could not read underlying DNS servers", t)
+            emptyList()
+        }
+    }
+
+    /**
+     * True if some non-VPN network the device is on carries a **global** IPv6
+     * address — i.e. real IPv6 connectivity we must not blackhole. Link-local
+     * (`fe80::/10`) and unique-local (`fc00::/7`, which includes the mesh's own
+     * `fd00::/8`) don't count: neither reaches the internet, and a tunnel that
+     * only offers a ULA is exactly the case a browser's probe rejects.
+     *
+     * Fails safe to `false` (claim the route) — that keeps `.fips` resolving,
+     * and it is only wrong on a network we couldn't read, where the blackhole
+     * costs at most IPv6 that we had no evidence existed.
+     */
+    private fun underlyingHasGlobalIpv6(): Boolean {
+        val cm = getSystemService(ConnectivityManager::class.java) ?: return false
+        return try {
+            cm.allNetworks.any { network ->
+                val caps = cm.getNetworkCapabilities(network) ?: return@any false
+                // Skip VPNs (including our own) — we want what's underneath.
+                if (caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) return@any false
+                if (!caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) return@any false
+                cm.getLinkProperties(network)?.linkAddresses.orEmpty().any { la ->
+                    val a = la.address
+                    a is Inet6Address && !a.isLinkLocalAddress && !a.isLoopbackAddress &&
+                        !a.isAnyLocalAddress && !a.isMulticastAddress &&
+                        (a.address[0].toInt() and 0xfe) != 0xfc // not fc00::/7
+                }
+            }
+        } catch (t: Throwable) {
+            Log.w(TAG, "could not inspect underlying networks for IPv6", t)
+            false
+        }
     }
 
     /** TUN fd → mesh: read IPv6 packets and hand them to FIPS. */
@@ -235,10 +376,14 @@ class MycoVpnService : VpnService() {
         curUla = ""
         curMtu = 0
         curExit = ""
+        curClaimIpv6 = false
     }
 
     private fun stopTun() {
         val wasRunning = running.get()
+        // Only here, not in teardown(): a reconfig tears down from inside the
+        // network callback, which must not unregister itself mid-dispatch.
+        unwatchUnderlyingNetworks()
         teardown()
         stopForeground(STOP_FOREGROUND_REMOVE)
         if (wasRunning) Log.i(TAG, "mesh TUN down")

--- a/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
+++ b/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
@@ -146,8 +146,15 @@ class MycoVpnService : VpnService() {
             // 127.0.0.1 — loopback, reachable regardless of routes — so this
             // needs no default route of its own, and Myco's own transports (the
             // AP UDP lane, mDNS, BLE) stay on the real network.
-            builder.setHttpProxy(ProxyInfo.buildDirectProxy("127.0.0.1", relayPort))
-            Log.i(TAG, "exit mode: proxy 127.0.0.1:$relayPort -> mesh $exitProxy")
+            // `.fips` names are mesh-local and already reachable directly (the
+            // sentinel resolver answers them and fd00::/8 is routed), so they
+            // must NOT go to the exit — it has no reason to resolve a mesh name
+            // and the request would die there. Excluding them keeps mesh
+            // browsing working while exit mode is on.
+            builder.setHttpProxy(
+                ProxyInfo.buildDirectProxy("127.0.0.1", relayPort, listOf("*.fips")),
+            )
+            Log.i(TAG, "exit mode: proxy 127.0.0.1:$relayPort -> mesh $exitProxy (except *.fips)")
         }
         val pfd = try {
             builder.establish()

--- a/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
+++ b/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
@@ -25,6 +25,13 @@ import java.util.concurrent.atomic.AtomicBoolean
  * The node installs the bridge channels when it starts (BLE on); this service just
  * moves bytes. With it up, a native socket to `[fd00::peer]:4870/:24243` routes
  * over the mesh, so the sync engine can pull a shared nsite from a peer's device.
+ *
+ * It also advertises the in-mesh sentinel resolver `fd00::53` as the VPN's DNS
+ * server and leaves every app on the tunnel (no [Builder.addAllowedApplication]
+ * restriction), so **any app** — not just Myco — can resolve `<npub>.fips` names
+ * and reach mesh addresses directly. The native TUN pump answers those DNS
+ * queries by pure computation (see `myco-core`'s `dns_intercept`); everything
+ * else stays off this route, so normal internet is untouched.
  */
 class MycoVpnService : VpnService() {
     private var tun: ParcelFileDescriptor? = null
@@ -66,15 +73,27 @@ class MycoVpnService : VpnService() {
             // "configured" so Myco's own IPv4 (the online fallback) bypasses the
             // VPN instead of being blacked out by an IPv6-only tunnel.
             .addAddress("10.255.255.254", 32)
-            .addRoute("fd00::", 8) // route ONLY the mesh ULA range
+            .addRoute("fd00::", 8) // the mesh ULA range — the only traffic we carry
+            // An IPv6 default route as well, purely so the OS reports this network
+            // as IPv6-capable. Chromium (and others) gate AAAA queries on an IPv6
+            // reachability probe, and a tunnel offering only a unique-local address
+            // fails it — so `<npub>.fips` was never even *asked* for as AAAA, and
+            // resolving it in a browser failed while `ping6` worked. Non-mesh
+            // packets that arrive because of this route are dropped in the pump
+            // (see myco-core's `tun_bridge`), never forwarded into the mesh.
+            .addRoute("::", 0)
             .setConfigureIntent(configIntent())
-        // Restrict the VPN to Myco itself: only our sync engine uses the mesh, so
-        // every OTHER app bypasses the tunnel entirely and keeps its normal
-        // internet untouched.
+        // Advertise the in-mesh sentinel resolver so every app on the VPN can
+        // resolve `<npub>.fips` names system-wide. The native TUN pump answers
+        // queries to this address (see dns_intercept); it never leaves the
+        // device. No addAllowedApplication restriction — leaving every app on
+        // the VPN is what lets e.g. a browser reach a resolved fd00:: address,
+        // not just Myco's own sync engine. Only the fd00::/8 route above is
+        // captured, so normal internet is unaffected for all apps.
         try {
-            builder.addAllowedApplication(packageName)
+            builder.addDnsServer(DNS_SENTINEL)
         } catch (e: Exception) {
-            Log.w(TAG, "addAllowedApplication($packageName) failed", e)
+            Log.w(TAG, "addDnsServer($DNS_SENTINEL) failed", e)
         }
         val pfd = try {
             builder.establish()
@@ -97,7 +116,7 @@ class MycoVpnService : VpnService() {
         running.set(true)
         readerThread = Thread({ readLoop(pfd) }, "myco-tun-read").apply { start() }
         writerThread = Thread({ writeLoop(pfd) }, "myco-tun-write").apply { start() }
-        Log.i(TAG, "mesh TUN up at $ula (route fd00::/8)")
+        Log.i(TAG, "mesh TUN up at $ula (route fd00::/8, dns $DNS_SENTINEL)")
     }
 
     /** TUN fd → mesh: read IPv6 packets and hand them to FIPS. */
@@ -184,6 +203,10 @@ class MycoVpnService : VpnService() {
     companion object {
         const val EXTRA_ULA = "app.myco.extra.ULA"
         const val EXTRA_MTU = "app.myco.extra.MTU"
+        // In-mesh sentinel DNS resolver (matches myco-core's dns_intercept). Inside
+        // the routed fd00::/8 range but never a node's own address, so query
+        // packets reach the app-owned-TUN pump instead of being delivered locally.
+        private const val DNS_SENTINEL = "fd00::53"
         private const val ACTION_STOP = "app.myco.vpn.STOP"
         private const val CHANNEL = "myco_mesh"
         private const val NOTIF_ID = 42

--- a/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
+++ b/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
@@ -242,7 +242,16 @@ class MycoVpnService : VpnService() {
         val cb = object : ConnectivityManager.NetworkCallback() {
             private fun recheck() {
                 if (!running.get()) return
-                startTun(curUla, curMtu, curExit)
+                // A reconfig clears the live config while it re-establishes; a
+                // callback landing in that window must not drive startTun with
+                // an empty ULA, which would take the "nothing to serve" branch
+                // and stopSelf() the whole tunnel.
+                val ula = curUla
+                if (ula.isEmpty()) return
+                // Only the `::/0` decision depends on the networks underneath,
+                // so leave the tunnel alone unless that answer changed.
+                if (!underlyingHasGlobalIpv6() == curClaimIpv6) return
+                startTun(ula, curMtu, curExit)
             }
             override fun onAvailable(network: android.net.Network) = recheck()
             override fun onLost(network: android.net.Network) = recheck()

--- a/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
+++ b/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
@@ -310,9 +310,13 @@ class MycoVpnService : VpnService() {
 
         private fun handle(client: Socket) {
             val upstream = try {
-                Socket().apply {
-                    connect(InetSocketAddress(InetAddress.getByName(host), port), 10_000)
-                }
+                // NO_PROXY is essential: a bare Socket() picks up the process's
+                // proxy settings, which Android populates from the very proxy
+                // this service advertises — so the relay's own upstream socket
+                // would be routed back into the relay.
+                val target = InetSocketAddress(InetAddress.getByName(host), port)
+                Log.d(TAG, "exit upstream -> $target")
+                Socket(java.net.Proxy.NO_PROXY).apply { connect(target, 10_000) }
             } catch (t: Throwable) {
                 Log.w(TAG, "exit upstream connect [$host]:$port failed", t)
                 try { client.close() } catch (_: Exception) {}

--- a/docs/how-to/exit-node-demo.md
+++ b/docs/how-to/exit-node-demo.md
@@ -1,0 +1,143 @@
+# Exit-node demo — a BLE-only phone loads google.com
+
+Goal: a phone with **only Bluetooth** peering (no Wi-Fi/cell) browses the public
+internet by tunnelling its web traffic through a mesh **exit node** that egresses
+for it.
+
+This is the *simple* first cut: an **HTTP proxy** on the exit + Android's VPN
+`setHttpProxy`. It covers proxy-aware apps (browsers) — enough to load google.com.
+A full-tunnel (capture *all* IP traffic via tun2socks) is a later, bigger step.
+
+The exit is addressed by its **npub**: `<exit-npub>.fips`. Myco resolves `.fips`
+names system-wide (see [System-wide `.fips` DNS](#system-wide-fips-dns)), so the
+exit **does not have to peer the phone** — FIPS forwards multi-hop to it.
+
+```
+[BLE-only phone]                              [exit node: anywhere in mesh + internet]
+  Chrome                                        tinyproxy :8080 (HTTP + CONNECT)
+    │ http proxy = 127.0.0.1:<relay>               ▲
+    ▼                                               │ mesh TCP to <exit-npub>.fips:8080
+  loopback relay (MycoVpnService.ExitRelay)        │
+    │ getByName(<exit-npub>.fips) → fd00:: ────────┤  (multi-hop FIPS forward)
+    ▼                                               │
+  VPN route fd00::/8 → FIPS → BLE → hop → … → exit's fips0 → tinyproxy → INTERNET
+```
+
+Chrome never resolves DNS or touches a public IP itself — it hands the hostname
+to the proxy (`CONNECT google.com:443`), and the **exit** does DNS + egress. So a
+phone with zero internet still works.
+
+## System-wide `.fips` DNS
+
+Naming the exit by npub relies on a feature Myco already ships: the VPN advertises
+an in-mesh sentinel resolver, `fd00::53`, as the DNS server, and the native TUN
+pump ([`dns_intercept`](../../myco-core/src/dns_intercept.rs)) answers
+`<npub>.fips` AAAA queries by pure computation (npub → `fd00::` address — no
+network, no upstream resolver). **Any app** on the phone can address a mesh node
+by its npub, which is why the exit can be `<exit-npub>.fips` rather than a raw
+`fd00::` literal. Non-`.fips` names return NXDOMAIN — in this demo the browser
+reaches the internet through the proxy, which resolves public names on the far
+side.
+
+---
+
+## 1. Exit node (any mesh node with internet)
+
+The exit can be **anywhere in the mesh** — FIPS forwards multi-hop, so it need not
+peer the phone directly. Simplest to *debug*: a box the phone reaches in one hop
+(its BLE peer) that also has internet. Note the exit's **npub** — that is how the
+phone addresses it.
+
+### a. Run a FIPS node with a TUN + a transport reachable from the mesh
+
+Use the `reference/fips` checkout. Minimal `fips.yaml` (TUN on so the mesh addr
+is a real local interface a proxy can bind behind):
+
+```yaml
+node:
+  identity:
+    nsec: "<exit node nsec>"
+  discovery:
+    nostr:
+      enabled: true
+      policy: configured_only
+      app: "fips-overlay-v1"
+
+tun:
+  enabled: true
+  name: fips0
+  mtu: 1280
+
+transports:
+  ble:
+    enabled: true          # so a BLE-only phone can peer it directly
+```
+
+Start it, peer the phone (pair as usual), and confirm the session is up.
+
+### b. Note the exit's npub
+
+Its Nostr `npub` (the app shows the same under Settings → Developer as `npub` /
+`.fips`). The phone addresses the exit as `<exit-npub>.fips`. A raw `fd00::EXIT`
+literal also works if you prefer.
+
+### c. Run the exit proxy bound so mesh peers reach it
+
+Use [`fips-exitnode`](../../fips-exitnode/) — a standalone Rust proxy (HTTP
+`CONNECT` + SOCKS5, no auth) built for exactly this. Runs on Linux/macOS:
+
+```bash
+cd fips-exitnode
+cargo build --release
+./target/release/fips-exitnode      # HTTP :8080 + SOCKS5 :1080 on [::]
+```
+
+Sanity check on the exit box itself (proxy is local there):
+
+```bash
+curl -x http://localhost:8080 https://ifconfig.me   # → the exit's public IP
+```
+
+> No-auth open proxy — **demo only**, firewall the ports to the mesh; don't leave
+> it on a public box. (`tinyproxy` also works if you'd rather: `Listen ::`, `Port
+> 8080`, `Allow ::/0`, `ConnectPort 443`.)
+
+---
+
+## 2. Phone (Myco)
+
+1. Peer the phone to the exit over BLE, mesh **on** (the usual flow).
+2. Settings → Developer mode on → **Developer settings → EXIT NODE**.
+3. Enter the exit's address + port and tap **Apply** — by npub (preferred):
+
+   ```
+   <exit-npub>.fips:8080
+   ```
+
+   or a raw literal `[fd00::EXIT]:8080`. Myco re-establishes the VPN: it advertises
+   the HTTP proxy + the `.fips` resolver to every app, and stands up the loopback
+   relay to the mesh exit.
+4. Open Chrome → **google.com** loads over BLE. 🎉
+5. **Turn off** clears it (back to mesh-only routing).
+
+---
+
+## 3. What's happening / limits
+
+- **Only proxy-aware apps** (browsers) follow `setHttpProxy`. Non-proxy apps and
+  QUIC/UDP won't route — fine for the google.com criterion. Chrome falls back
+  from QUIC to proxied TCP when UDP has nowhere to go.
+- The relay's upstream socket to `fd00::EXIT` is **not** `protect()`ed on purpose:
+  it must ride this same VPN (route `fd00::/8`) into FIPS. Mesh replies return to
+  that socket, never back into the listener — no loop.
+- Bandwidth is BLE-bound (~200 kbps up / ~500 kbps down). Pages load, slowly.
+- Setting or clearing the exit re-establishes the VPN in place (the service
+  compares the incoming config against the live one), so there is no need to
+  toggle the mesh off and on.
+
+## 4. Next step (real full-tunnel)
+
+Capture `0.0.0.0/0 + ::/0`, terminate every flow in a userspace netstack
+(smoltcp / hev-socks5-tunnel embedded in `myco-core`), relay SOCKS to the exit.
+`readLoop` classifies `fd00::` → FIPS, everything else → tun2socks. That makes
+*all* app traffic exit, not just proxy-aware apps.

--- a/myco-core/Cargo.toml
+++ b/myco-core/Cargo.toml
@@ -30,6 +30,8 @@ futures-util = { workspace = true }
 [dev-dependencies]
 nsite-deck = { path = "../nsite-deck", features = ["testing"] }
 tokio-tungstenite = { workspace = true }
+# Only for dns_intercept tests, to craft/parse DNS packets (matches fips's pin).
+simple-dns = "0.11.2"
 
 # The JNI surface only exists on Android. Host (macOS/Linux) builds skip it and
 # drive `AppRuntime` directly (see tests).

--- a/myco-core/src/aware_bridge_jni.rs
+++ b/myco-core/src/aware_bridge_jni.rs
@@ -17,6 +17,7 @@
 //! through `fips::discovery::platform`.
 
 use jni::objects::{JClass, JString};
+use jni::sys::jint;
 use jni::JNIEnv;
 
 const TRANSPORT_TYPE: &str = "udp";
@@ -55,4 +56,22 @@ pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerLost(
         return;
     };
     fips::discovery::platform::platform_peer_lost(&npub, TRANSPORT_TYPE);
+}
+
+/// Rust → Kotlin: the UDP transport's raw socket fd, once it has opened.
+/// Blocks up to `timeout_ms`; returns `-1` on timeout (no transport, or it
+/// hasn't started yet). The fd is sent once per node lifetime (see
+/// [`crate::udp_fd_bridge`]) — callers poll this once at startup, not in a
+/// loop, then use the fd with `android.net.Network.bindSocket` to pin the
+/// socket to whichever local-only network (Wi-Fi Aware NDP, the `!FIPS` AP)
+/// currently carries the platform-pushed peer, so replies aren't lost to a
+/// competing validated default network (e.g. cellular).
+#[no_mangle]
+pub extern "system" fn Java_app_myco_core_NativeCore_nextUdpTransportFd(
+    _env: JNIEnv,
+    _class: JClass,
+    timeout_ms: jint,
+) -> jint {
+    crate::udp_fd_bridge::next_fd(std::time::Duration::from_millis(timeout_ms.max(0) as u64))
+        as jint
 }

--- a/myco-core/src/dns_intercept.rs
+++ b/myco-core/src/dns_intercept.rs
@@ -128,7 +128,9 @@ fn scan_qname(dns_query: &[u8]) -> Option<(usize, bool)> {
 
 /// True if the query asks for a name under the `.fips` pseudo-TLD.
 fn is_fips_name(dns_query: &[u8]) -> bool {
-    scan_qname(dns_query).map(|(_, is_fips)| is_fips).unwrap_or(false)
+    scan_qname(dns_query)
+        .map(|(_, is_fips)| is_fips)
+        .unwrap_or(false)
 }
 
 /// A SERVFAIL response to `dns_query`: the header and question echoed back,
@@ -179,7 +181,7 @@ mod tests {
 
     /// Build a minimal IPv6/UDP DNS query packet for `qname` to `[fd00::53]:53`.
     fn make_query(qname: &str, dst: [u8; 16]) -> Vec<u8> {
-        use simple_dns::{Name, Packet, QCLASS, QTYPE, Question, TYPE};
+        use simple_dns::{Name, Packet, Question, QCLASS, QTYPE, TYPE};
         let mut q = Packet::new_query(0x1234);
         q.questions.push(Question::new(
             Name::new_unchecked(qname),

--- a/myco-core/src/dns_intercept.rs
+++ b/myco-core/src/dns_intercept.rs
@@ -83,6 +83,15 @@ pub fn try_answer(packet: &[u8]) -> Option<Vec<u8>> {
     }
 
     let dns_query = &packet[IPV6_HEADER_LEN + UDP_HEADER_LEN..IPV6_HEADER_LEN + payload_len];
+
+    // Only `.fips` is ours. Everything else gets SERVFAIL, which makes the OS
+    // resolver fail over to the next server it was given (the real one, see the
+    // VpnService) — where NXDOMAIN would be an authoritative "does not exist"
+    // and would end the lookup, breaking all normal DNS on the device.
+    if !is_fips_name(dns_query) {
+        return Some(build_reply(src_addr, src_port, &servfail(dns_query)?));
+    }
+
     // Empty host map: `<npub>.fips` resolves by pure computation without it.
     let (dns_reply, identity) = handle_dns_packet(dns_query, ANSWER_TTL, &HostMap::new())?;
 
@@ -95,6 +104,48 @@ pub fn try_answer(packet: &[u8]) -> Option<Vec<u8>> {
     }
 
     Some(build_reply(src_addr, src_port, &dns_reply))
+}
+
+/// Walk the QNAME in `dns_query` (wire format, labels after the 12-byte
+/// header). Returns the offset just past the terminating zero label, plus
+/// whether the name's last label is `fips` (case-insensitive).
+fn scan_qname(dns_query: &[u8]) -> Option<(usize, bool)> {
+    let mut i = 12; // skip the fixed header
+    let mut last = Vec::new();
+    loop {
+        let len = *dns_query.get(i)? as usize;
+        if len == 0 {
+            return Some((i + 1, last.eq_ignore_ascii_case(b"fips")));
+        }
+        // Compression pointers never appear in a question's QNAME.
+        if len > 63 {
+            return None;
+        }
+        last = dns_query.get(i + 1..i + 1 + len)?.to_vec();
+        i += 1 + len;
+    }
+}
+
+/// True if the query asks for a name under the `.fips` pseudo-TLD.
+fn is_fips_name(dns_query: &[u8]) -> bool {
+    scan_qname(dns_query).map(|(_, is_fips)| is_fips).unwrap_or(false)
+}
+
+/// A SERVFAIL response to `dns_query`: the header and question echoed back,
+/// answer/authority/additional emptied, QR set and RCODE = 2.
+fn servfail(dns_query: &[u8]) -> Option<Vec<u8>> {
+    let (qname_end, _) = scan_qname(dns_query)?;
+    let question_end = qname_end + 4; // QTYPE + QCLASS
+    if dns_query.len() < question_end {
+        return None;
+    }
+    let mut reply = dns_query[..question_end].to_vec();
+    reply[2] |= 0x80; // QR = response
+    reply[3] = (reply[3] & 0xf0) | 2; // RCODE = SERVFAIL
+    reply[6..8].copy_from_slice(&0u16.to_be_bytes()); // ANCOUNT
+    reply[8..10].copy_from_slice(&0u16.to_be_bytes()); // NSCOUNT
+    reply[10..12].copy_from_slice(&0u16.to_be_bytes()); // ARCOUNT
+    Some(reply)
 }
 
 /// Assemble the response IPv6/UDP packet: swap the query's src/dst and ports,
@@ -172,6 +223,22 @@ mod tests {
         let dns = &reply[IPV6_HEADER_LEN + UDP_HEADER_LEN..];
         let parsed = simple_dns::Packet::parse(dns).unwrap();
         assert_eq!(parsed.answers.len(), 1);
+    }
+
+    #[test]
+    fn non_fips_name_gets_servfail_not_nxdomain() {
+        // NXDOMAIN here would be authoritative and would end the lookup, so the
+        // device could resolve nothing but `.fips`. SERVFAIL makes the OS
+        // resolver fail over to the real server listed after our sentinel.
+        let pkt = make_query("google.com", SENTINEL);
+        let reply = try_answer(&pkt).expect("should answer non-.fips queries too");
+
+        let dns = &reply[IPV6_HEADER_LEN + UDP_HEADER_LEN..];
+        assert_eq!(dns[2] & 0x80, 0x80, "QR must be set");
+        assert_eq!(dns[3] & 0x0f, 2, "RCODE must be SERVFAIL");
+        let parsed = simple_dns::Packet::parse(dns).unwrap();
+        assert_eq!(parsed.questions.len(), 1, "question is echoed back");
+        assert_eq!(parsed.answers.len(), 0);
     }
 
     #[test]

--- a/myco-core/src/dns_intercept.rs
+++ b/myco-core/src/dns_intercept.rs
@@ -1,0 +1,193 @@
+//! System-wide `.fips` DNS on the phone.
+//!
+//! The Android `VpnService` advertises [`SENTINEL_STR`] (`fd00::53`) as the DNS
+//! server for every app on the tunnel. Because that address is inside the routed
+//! `fd00::/8` range but is **not** the node's own TUN address, the OS resolver's
+//! query packets are handed to the app-owned-TUN pump instead of being delivered
+//! locally. [`try_answer`] recognises those packets in the app→mesh path and
+//! synthesises a reply, so any app can resolve `<npub>.fips` (and, via a host map
+//! later, aliases) to a mesh `fd00::` address — without a real DNS server socket.
+//!
+//! Resolution itself is pure computation: `<npub>.fips` → `fd00::` is derived from
+//! the public key alone (see [`fips::upper::dns::handle_dns_packet`]), so this
+//! works with no network and no upstream resolver. Non-`.fips` names get NXDOMAIN
+//! — the exit-node demo routes web traffic through an HTTP proxy, which does its
+//! own DNS on the far side, so the phone never needs to resolve public names.
+
+use std::sync::{Mutex, OnceLock};
+
+use fips::upper::dns::{handle_dns_packet, DnsIdentityTx};
+use fips::upper::hosts::HostMap;
+use fips::upper::tcp_mss::recalculate_l4_checksum;
+
+/// Sender that feeds each DNS-resolved identity to the node's rx-loop so it
+/// populates its identity cache — the route-warming side effect the built-in
+/// desktop DNS responder provides. Without it, a resolved `<npub>.fips` answers
+/// the AAAA but the first packet to that address has no cached pubkey to open a
+/// session with, so it is dropped and the connection silently hangs. Installed
+/// from `runtime.rs` via [`fips::Node::enable_app_owned_dns`].
+static IDENTITY_TX: OnceLock<Mutex<Option<DnsIdentityTx>>> = OnceLock::new();
+
+fn identity_tx() -> &'static Mutex<Option<DnsIdentityTx>> {
+    IDENTITY_TX.get_or_init(|| Mutex::new(None))
+}
+
+/// Install the node's DNS-identity sender. Replaces any prior install (the node
+/// is rebuilt on a transport off→on cycle, yielding a fresh channel).
+pub fn set_identity_tx(tx: DnsIdentityTx) {
+    *identity_tx().lock().unwrap() = Some(tx);
+}
+
+/// The sentinel DNS-server address, `fd00::53`. Chosen inside the routed
+/// `fd00::/8` prefix but astronomically unlikely to collide with an
+/// npub-derived node address (those fill the whole 128 bits from a hash).
+const SENTINEL: [u8; 16] = [0xfd, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x53];
+
+/// String form used by the Kotlin VPN builder's `addDnsServer`.
+pub const SENTINEL_STR: &str = "fd00::53";
+
+/// TTL (seconds) on synthesised AAAA answers. Short: a node's mesh address is
+/// stable, but keeping it low means a stale mapping self-heals quickly.
+const ANSWER_TTL: u32 = 30;
+
+const IPV6_HEADER_LEN: usize = 40;
+const UDP_HEADER_LEN: usize = 8;
+const NEXT_HEADER_UDP: u8 = 17;
+const DNS_PORT: u16 = 53;
+
+/// If `packet` is a UDP DNS query to `[fd00::53]:53`, resolve it and return the
+/// reply packet (IPv6+UDP+DNS) to write back to the TUN. Returns `None` for any
+/// packet that is not such a query, so the caller forwards it into the mesh
+/// unchanged.
+pub fn try_answer(packet: &[u8]) -> Option<Vec<u8>> {
+    // IPv6 only, single UDP header (no extension headers — mesh DNS has none).
+    if packet.len() < IPV6_HEADER_LEN + UDP_HEADER_LEN {
+        return None;
+    }
+    if packet[0] >> 4 != 6 || packet[6] != NEXT_HEADER_UDP {
+        return None;
+    }
+    if packet[24..40] != SENTINEL {
+        return None;
+    }
+    let payload_len = u16::from_be_bytes([packet[4], packet[5]]) as usize;
+    if payload_len < UDP_HEADER_LEN || IPV6_HEADER_LEN + payload_len > packet.len() {
+        return None;
+    }
+
+    let src_addr = &packet[8..24];
+    let src_port = u16::from_be_bytes([packet[40], packet[41]]);
+    let dst_port = u16::from_be_bytes([packet[42], packet[43]]);
+    if dst_port != DNS_PORT {
+        return None;
+    }
+
+    let dns_query = &packet[IPV6_HEADER_LEN + UDP_HEADER_LEN..IPV6_HEADER_LEN + payload_len];
+    // Empty host map: `<npub>.fips` resolves by pure computation without it.
+    let (dns_reply, identity) = handle_dns_packet(dns_query, ANSWER_TTL, &HostMap::new())?;
+
+    // Warm the route: hand the resolved identity to the node so it caches the
+    // pubkey and can open a session to this address (see [`set_identity_tx`]).
+    if let Some(id) = identity {
+        if let Some(tx) = identity_tx().lock().unwrap().as_ref() {
+            let _ = tx.try_send(id);
+        }
+    }
+
+    Some(build_reply(src_addr, src_port, &dns_reply))
+}
+
+/// Assemble the response IPv6/UDP packet: swap the query's src/dst and ports,
+/// carry the DNS reply as the UDP payload, and fix lengths + checksum.
+fn build_reply(orig_src_addr: &[u8], orig_src_port: u16, dns_reply: &[u8]) -> Vec<u8> {
+    let udp_len = UDP_HEADER_LEN + dns_reply.len();
+    let mut pkt = vec![0u8; IPV6_HEADER_LEN + udp_len];
+
+    // IPv6 header: version 6, our sentinel as source, the querier as destination.
+    pkt[0] = 0x60;
+    pkt[4..6].copy_from_slice(&(udp_len as u16).to_be_bytes()); // payload length
+    pkt[6] = NEXT_HEADER_UDP;
+    pkt[7] = 64; // hop limit
+    pkt[8..24].copy_from_slice(&SENTINEL);
+    pkt[24..40].copy_from_slice(orig_src_addr);
+
+    // UDP header: from :53 back to the querier's port.
+    pkt[40..42].copy_from_slice(&DNS_PORT.to_be_bytes());
+    pkt[42..44].copy_from_slice(&orig_src_port.to_be_bytes());
+    pkt[44..46].copy_from_slice(&(udp_len as u16).to_be_bytes());
+    // checksum left zero, recomputed below.
+    pkt[IPV6_HEADER_LEN + UDP_HEADER_LEN..].copy_from_slice(dns_reply);
+
+    recalculate_l4_checksum(&mut pkt);
+    pkt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal IPv6/UDP DNS query packet for `qname` to `[fd00::53]:53`.
+    fn make_query(qname: &str, dst: [u8; 16]) -> Vec<u8> {
+        use simple_dns::{Name, Packet, QCLASS, QTYPE, Question, TYPE};
+        let mut q = Packet::new_query(0x1234);
+        q.questions.push(Question::new(
+            Name::new_unchecked(qname),
+            QTYPE::TYPE(TYPE::AAAA),
+            QCLASS::CLASS(simple_dns::CLASS::IN),
+            false,
+        ));
+        let dns = q.build_bytes_vec().unwrap();
+        let udp_len = UDP_HEADER_LEN + dns.len();
+        let mut pkt = vec![0u8; IPV6_HEADER_LEN + udp_len];
+        pkt[0] = 0x60;
+        pkt[4..6].copy_from_slice(&(udp_len as u16).to_be_bytes());
+        pkt[6] = NEXT_HEADER_UDP;
+        pkt[7] = 64;
+        // src = some client addr, dst = sentinel
+        pkt[8..24].copy_from_slice(&[0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        pkt[24..40].copy_from_slice(&dst);
+        pkt[40..42].copy_from_slice(&40000u16.to_be_bytes()); // src port
+        pkt[42..44].copy_from_slice(&DNS_PORT.to_be_bytes()); // dst port 53
+        pkt[44..46].copy_from_slice(&(udp_len as u16).to_be_bytes());
+        pkt[IPV6_HEADER_LEN + UDP_HEADER_LEN..].copy_from_slice(&dns);
+        pkt
+    }
+
+    #[test]
+    fn resolves_npub_fips_query() {
+        // A valid npub (from fips test vectors would be ideal; use a well-formed one).
+        let npub = "npub1mqelkzqp4659fws35h2wvr7z9caka5ml8qddj3ssnwaulwpxdd9sdc3esw";
+        let pkt = make_query(&format!("{npub}.fips"), SENTINEL);
+        let reply = try_answer(&pkt).expect("should answer .fips query");
+
+        // Reply is IPv6/UDP, from :53, back to the querier, addressed to the client.
+        assert_eq!(reply[0] >> 4, 6);
+        assert_eq!(reply[6], NEXT_HEADER_UDP);
+        assert_eq!(&reply[8..24], &SENTINEL); // src = sentinel
+        assert_eq!(&reply[24..40], &pkt[8..24]); // dst = original client
+        assert_eq!(u16::from_be_bytes([reply[40], reply[41]]), DNS_PORT);
+        assert_eq!(u16::from_be_bytes([reply[42], reply[43]]), 40000);
+
+        // The DNS answer carries an AAAA in the mesh prefix.
+        let dns = &reply[IPV6_HEADER_LEN + UDP_HEADER_LEN..];
+        let parsed = simple_dns::Packet::parse(dns).unwrap();
+        assert_eq!(parsed.answers.len(), 1);
+    }
+
+    #[test]
+    fn ignores_wrong_destination() {
+        let npub = "npub1mqelkzqp4659fws35h2wvr7z9caka5ml8qddj3ssnwaulwpxdd9sdc3esw";
+        // Same query but to a non-sentinel address → not ours, forward to mesh.
+        let other = [0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9];
+        let pkt = make_query(&format!("{npub}.fips"), other);
+        assert!(try_answer(&pkt).is_none());
+    }
+
+    #[test]
+    fn ignores_non_dns_udp() {
+        let mut pkt = make_query("whatever.fips", SENTINEL);
+        // Change dst port away from 53.
+        pkt[42..44].copy_from_slice(&4870u16.to_be_bytes());
+        assert!(try_answer(&pkt).is_none());
+    }
+}

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -25,6 +25,9 @@ mod state;
 // installed only on Android, so its fns read as dead on the host build.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod tun_bridge;
+// System-wide `.fips` DNS interception; driven by the TUN pump on Android.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod dns_intercept;
 // Surfaces the UDP transport's raw fd so Android can pin it to a specific
 // `Network` (Wi-Fi Aware / the AP lane). Android-only consumer.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -25,6 +25,10 @@ mod state;
 // installed only on Android, so its fns read as dead on the host build.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod tun_bridge;
+// Surfaces the UDP transport's raw fd so Android can pin it to a specific
+// `Network` (Wi-Fi Aware / the AP lane). Android-only consumer.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod udp_fd_bridge;
 
 #[cfg(target_os = "android")]
 mod jni_abi;

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -665,6 +665,11 @@ impl AppRuntime {
             let max_mss = node.effective_ipv6_mtu().saturating_sub(60);
             let (tun_outbound_tx, tun_inbound_rx) = node.enable_app_owned_tun();
             crate::tun_bridge::install(tun_outbound_tx, tun_inbound_rx, max_mss);
+            // Wire the app-owned DNS interceptor's identity channel into the node
+            // so resolving `<npub>.fips` warms the route (caches the pubkey), the
+            // same side effect fips's own DNS responder has. Without this the
+            // first packet to a resolved address has no session and is dropped.
+            crate::dns_intercept::set_identity_tx(node.enable_app_owned_dns());
             // Let Android learn the UDP transport's raw fd once it opens, so it
             // can pin the socket to whichever local-only network (Wi-Fi Aware
             // NDP, the `!FIPS` AP) carries a platform-pushed peer — otherwise

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -665,6 +665,12 @@ impl AppRuntime {
             let max_mss = node.effective_ipv6_mtu().saturating_sub(60);
             let (tun_outbound_tx, tun_inbound_rx) = node.enable_app_owned_tun();
             crate::tun_bridge::install(tun_outbound_tx, tun_inbound_rx, max_mss);
+            // Let Android learn the UDP transport's raw fd once it opens, so it
+            // can pin the socket to whichever local-only network (Wi-Fi Aware
+            // NDP, the `!FIPS` AP) carries a platform-pushed peer — otherwise
+            // handshake replies can be lost to a competing validated default
+            // network (e.g. cellular).
+            crate::udp_fd_bridge::install(node.enable_app_owned_udp_fd());
         }
         // Clone the lock-free read handle out before the node moves into the loop
         // task — peer state is then readable while run_rx_loop owns the node.

--- a/myco-core/src/tun_bridge.rs
+++ b/myco-core/src/tun_bridge.rs
@@ -7,6 +7,7 @@
 //! the fd (mesh → app). The ends live in statics, not on `AppRuntime`, so the
 //! blocking `next_packet` never holds the reducer lock — mirroring the BLE bridge.
 
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
@@ -32,6 +33,16 @@ fn inbound() -> &'static Mutex<Option<std::sync::mpsc::Receiver<Vec<u8>>>> {
     INBOUND.get_or_init(|| Mutex::new(None))
 }
 
+/// Locally-synthesised packets to deliver to the TUN fd ahead of mesh traffic —
+/// currently `.fips` DNS replies (see [`crate::dns_intercept`]). Kept separate
+/// from the node's inbound channel so a reply is injected without a round-trip
+/// through the mesh.
+static LOCAL: OnceLock<Mutex<VecDeque<Vec<u8>>>> = OnceLock::new();
+
+fn local() -> &'static Mutex<VecDeque<Vec<u8>>> {
+    LOCAL.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
 /// Install the node's app-owned-TUN channel ends and the MSS ceiling
 /// (`effective_ipv6_mtu - 60`). Replaces any prior install (the node is rebuilt on
 /// a BLE off→on cycle, yielding fresh channels).
@@ -48,6 +59,20 @@ pub fn install(
 /// app → mesh: clamp the TCP MSS, then route an IPv6 packet read from the TUN fd
 /// into the mesh. Returns `false` if no TUN is installed or the queue is full.
 pub fn send_packet(mut packet: Vec<u8>) -> bool {
+    // System-wide `.fips` DNS: if this is a query to the sentinel resolver,
+    // answer it locally, queue the reply for the TUN, and don't forward it.
+    if let Some(reply) = crate::dns_intercept::try_answer(&packet) {
+        local().lock().unwrap().push_back(reply);
+        return true;
+    }
+    // Only mesh (fd00::/8) traffic belongs on the app-owned TUN. The VpnService
+    // also routes ::/0 so the OS reports the tunnel as IPv6-capable (without
+    // that, browsers never issue the AAAA query that resolves `<npub>.fips` —
+    // see MycoVpnService), which drags in unrelated IPv6 packets. Drop them here
+    // rather than pushing them into FIPS.
+    if !is_mesh_bound(&packet) {
+        return true; // consumed = dropped
+    }
     fips::upper::tcp_mss::clamp_tcp_mss(&mut packet, MAX_MSS.load(Ordering::Relaxed));
     match outbound().lock().unwrap().as_ref() {
         Some(tx) => tx.try_send(packet).is_ok(),
@@ -55,9 +80,20 @@ pub fn send_packet(mut packet: Vec<u8>) -> bool {
     }
 }
 
+/// True if `packet` is an IPv6 packet destined for the mesh ULA (`fd00::/8`).
+/// FIPS mesh addresses all fall under the `fd` prefix; anything else (IPv4, or
+/// public IPv6) does not belong on the app-owned TUN.
+fn is_mesh_bound(packet: &[u8]) -> bool {
+    packet.len() >= 40 && packet[0] >> 4 == 6 && packet[24] == 0xfd
+}
+
 /// mesh → app: pull the next IPv6 packet for the TUN fd, blocking up to
 /// `timeout`. `None` = timed out (loop again) or no TUN installed.
 pub fn next_packet(timeout: Duration) -> Option<Vec<u8>> {
+    // Locally-synthesised packets (DNS replies) jump ahead of mesh traffic.
+    if let Some(pkt) = local().lock().unwrap().pop_front() {
+        return Some(pkt);
+    }
     let guard = inbound().lock().ok()?;
     let rx = guard.as_ref()?;
     rx.recv_timeout(timeout).ok()
@@ -67,16 +103,35 @@ pub fn next_packet(timeout: Duration) -> Option<Vec<u8>> {
 mod tests {
     use super::*;
 
+    /// A minimal 40-byte IPv6 header with an `fd00::/8` destination, so it
+    /// passes [`is_mesh_bound`]. `tag` is the low byte of the destination, to
+    /// tell packets apart. Payload/L4 omitted — the MSS clamp leaves a
+    /// non-TCP packet unchanged.
+    fn mesh_packet(tag: u8) -> Vec<u8> {
+        let mut p = vec![0u8; 40];
+        p[0] = 0x60; // version 6
+        p[24] = 0xfd; // dst in fd00::/8
+        p[39] = tag;
+        p
+    }
+
     #[tokio::test]
     async fn install_send_next_roundtrip() {
         let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
         let (in_tx, in_rx) = std::sync::mpsc::channel::<Vec<u8>>();
         install(out_tx, in_rx, 1143);
 
-        // app → mesh: send_packet pushes into the node-side outbound channel.
-        // (A short non-TCP packet is left unchanged by the MSS clamp.)
-        assert!(send_packet(vec![0x60, 0, 0, 0]));
-        assert_eq!(out_rx.recv().await.unwrap(), vec![0x60, 0, 0, 0]);
+        // app → mesh: a mesh-bound packet reaches the node outbound channel.
+        let pkt = mesh_packet(1);
+        assert!(send_packet(pkt.clone()));
+        assert_eq!(out_rx.recv().await.unwrap(), pkt);
+
+        // A non-mesh packet (the ::/0 route drags these in) is dropped, not
+        // forwarded into the mesh.
+        let mut public = mesh_packet(2);
+        public[24] = 0x20; // 2000::/3 — public IPv6
+        assert!(send_packet(public)); // consumed…
+        assert!(out_rx.try_recv().is_err()); // …but nothing reached the mesh
 
         // mesh → app: a packet the node writes inbound is pulled by next_packet.
         in_tx.send(vec![0x60, 1, 2, 3]).unwrap();

--- a/myco-core/src/udp_fd_bridge.rs
+++ b/myco-core/src/udp_fd_bridge.rs
@@ -1,0 +1,39 @@
+//! Process-global bridge for the node's UDP transport raw fd (from
+//! [`fips::Node::enable_app_owned_udp_fd`]) — lets the Android side pin that
+//! socket to a specific `android.net.Network` (e.g. the `!FIPS` Wi-Fi AP, or
+//! a Wi-Fi Aware NDP network) via `Network.bindSocket`.
+//!
+//! Platform-pushed peers (Wi-Fi Aware, the AP lane) live on a network that
+//! never passes internet validation, so without an explicit bind the Noise
+//! handshake's replies can be lost to routing/firewall rules that favour a
+//! competing validated default network (e.g. cellular) — the send succeeds
+//! locally, but nothing ever comes back.
+
+use std::os::unix::io::RawFd;
+use std::sync::mpsc::Receiver;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+static RX: OnceLock<Mutex<Option<Receiver<RawFd>>>> = OnceLock::new();
+
+fn rx() -> &'static Mutex<Option<Receiver<RawFd>>> {
+    RX.get_or_init(|| Mutex::new(None))
+}
+
+/// Install the node's fd-notification receiver. Replaces any prior install
+/// (the node is rebuilt on a BLE/mesh off→on cycle, yielding a fresh channel).
+pub fn install(receiver: Receiver<RawFd>) {
+    *rx().lock().unwrap() = Some(receiver);
+}
+
+/// Pull the UDP transport's raw fd, blocking up to `timeout`. Returns `-1` on
+/// timeout or if no receiver is installed — the fd is only ever sent once per
+/// node lifetime (right after the transport starts), so callers poll this
+/// once at startup rather than in a loop.
+pub fn next_fd(timeout: Duration) -> RawFd {
+    let guard = rx().lock().unwrap();
+    match guard.as_ref() {
+        Some(receiver) => receiver.recv_timeout(timeout).unwrap_or(-1),
+        None => -1,
+    }
+}


### PR DESCRIPTION
Makes a node's npub usable as an address by any app on the phone, and adds an experimental exit-node mode on top of it. Also fixes the Wi-Fi AP lane, which could not connect at all on a phone that had mobile data on at the same time.

## What's in it

**`<npub>.fips` resolves system-wide.** The tunnel advertises an in-mesh resolver and answers `<npub>.fips` from the public key alone — no network, no upstream lookup. Because the answer comes from the tunnel rather than from Myco, every app gets it: `http://<npub>.fips/` loads in an ordinary browser, over the mesh.

**Exit-node mode (developer preview).** Point Myco at an HTTP proxy on a mesh node and proxy-aware apps egress through it, so a phone with no internet of its own can browse. The exit is addressed by npub, so it need not be a direct peer. `.fips` names bypass the proxy and stay on the mesh.

**Wi-Fi AP lane fixes.** Two independent faults, either enough to stop it:
- The mesh socket was not bound to the Wi-Fi network. A local-only AP never passes internet validation, so with cellular also up the OS steered the socket to the validated network and discarded the AP's replies — the node logged every handshake arriving while the phone re-sent them forever. Verified by removing the bind: 0 handshakes in 90s.
- We dialled the wrong address. A fips node advertises one address per interface and only the one facing us answers NDP; we took the first. Now all advertised addresses are kept and rotated through until the peer connects.

## Two things worth a careful look

**The `::/0` route.** Browsers gate AAAA queries on an IPv6 reachability probe, and a tunnel offering only a ULA fails it — so `<npub>.fips` was never even *asked* for as AAAA and failed to resolve in a browser while `ping6` worked. The tunnel therefore claims `::/0` to read as IPv6-capable. Since packets arriving that way are dropped in the pump, the route is claimed **only when no non-VPN network has a global IPv6 address**; where real IPv6 exists the probe already succeeds on its own, so the claim isn't needed there.

**DNS delegation.** The sentinel answers `.fips` and returns SERVFAIL for everything else, with the underlying network's real resolvers advertised after it, so the OS fails over rather than treating our answer as authoritative. An earlier revision returned NXDOMAIN, which silently broke all DNS on the device whenever no exit proxy was configured.

## Dependency

Needs `Node::enable_app_owned_udp_fd()` from fips (`006c3314` on `feat/platform-peer-queue`, not yet upstream). Until that lands this will not build against a `reference/fips` checkout on another branch.

## Known issues

- Peering can stall after the phone's Wi-Fi reconnects until the node's old peer entry expires (~1 min). Worst on phones that rotate their Wi-Fi MAC per connection — GrapheneOS by default — since the phone's mesh-facing address changes each time. Upstream: [fips#130](https://github.com/jmcorgan/fips/issues/130).
- Exit mode covers proxy-aware apps only; `setHttpProxy` is the only system-wide proxy hook a VPN app has. Non-proxy apps and QUIC/UDP are unaffected.
- On macOS an exit node's proxy needs allowing through the Application Firewall before it accepts mesh connections — inbound TCP is dropped silently while ICMP still works, so it looks like a routing fault.

## Testing

Workspace tests pass (116); `cargo fmt --check` and clippy clean for the changed crates. Verified on-device (Pixel 7 Pro, GrapheneOS): `.fips` loads in Vanadium over the mesh, normal DNS and browsing work with the proxy off, and traffic egresses through the exit node with it on.

Not re-verified after the final tunnel-teardown fix: repeated `.fips` resolution across several VPN reconfigurations. Worth confirming before tagging, since it is the headline feature.
