### PR TITLE
Reach Circle members at any hop count, and address peers by npub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Circle members are reachable at any distance, not just as direct neighbours.
+  Myco decided for itself who was reachable by intersecting your Circle with
+  the mesh node's directly-connected peers, so a member two hops away was
+  treated as offline: their nsites never appeared under "around me" and pulls
+  skipped them. Chat was unaffected — it already targeted the whole Circle.
+- Peers are addressed by name (`<npub>.fips`) everywhere rather than by their
+  mesh address. Resolving the name is what registers a peer's identity with
+  the node, so dialling the raw address only ever worked for someone already
+  a direct neighbour — which is why this looked like a distance problem.
+- The reachable count in the status pill reflects peers we hold a live mesh
+  connection to, at any hop count, instead of only adjacent ones.
+- `.fips` names resolve reliably. The tunnel had listed the network's real
+  resolvers alongside its own, and any of them will deny a `.fips` name
+  authoritatively, so whether a mesh name resolved depended on which resolver
+  the system happened to pick. Myco's resolver now answers every lookup,
+  relaying non-mesh names to a real one.
+- Turning Bluetooth on no longer takes the mesh down. Starting the Bluetooth
+  radio rebuilt the embedded mesh node, dropping every peer and session — so
+  enabling one transport interrupted the others until everything re-handshook.
+- Peering over a Wi-Fi AP no longer flaps. Myco re-announced peers it was
+  already connected to and treated a lapsed mDNS advert as a departure, each
+  of which tore down a healthy session every few minutes.
+
+### Added
+
+- A peers overview at the top of the Developer screen: who is connected, over
+  which lane (Wi-Fi Aware / LAN / Bluetooth), and for how long.
+
 ## [0.4.0] - 2026-07-29
 
 ### Added

--- a/android/app/src/main/java/app/myco/ap/ApRadio.kt
+++ b/android/app/src/main/java/app/myco/ap/ApRadio.kt
@@ -251,20 +251,21 @@ class ApRadio private constructor(private val context: Context) {
         publishWifi()
     }
 
-    /** Periodic tick while the browse is live. For a connected peer it re-pushes
-     *  the working address: NSD fires onServiceFound only once per appearance,
-     *  so a dropped UDP session would otherwise never get a fresh dial hint (the
-     *  core's alternate-path gates make a redundant push a no-op for a healthy
-     *  peer). For an unconnected one it advances to the next candidate address. */
+    /** Periodic tick while the browse is live: advance an *unconnected* peer to
+     *  its next candidate address.
+     *
+     *  A connected peer is deliberately left alone. Pushing a peer the core has
+     *  already authenticated is not free — it starts an alternate-path handshake
+     *  — so re-pushing on a timer meant a healthy session was continuously
+     *  raced by a fresh one, which showed up as endless
+     *  `Stale handshake connection timed out` churn and link ids in the
+     *  hundreds. A dropped session still recovers: it turns the peer
+     *  unconnected, and this tick resumes rotating. */
     private val repush = object : Runnable {
         override fun run() {
             if (browseListener == null) return
             for (npub in candidates.keys.toList()) {
-                if (connected(npub)) {
-                    pushed[npub]?.let { NativeCore.awarePeerFound(npub, it) }
-                } else {
-                    rotate(npub)
-                }
+                if (!connected(npub)) rotate(npub)
             }
             handler.postDelayed(this, REPUSH_MS)
         }
@@ -348,9 +349,17 @@ class ApRadio private constructor(private val context: Context) {
         val npub = npubByService.remove(serviceName) ?: return
         candidates.remove(npub)
         candidateIdx.remove(npub)
-        if (pushed.remove(npub) != null) {
+        val wasPushed = pushed.remove(npub) != null
+        // An mDNS advert lapsing does not mean the peer is gone — NSD drops and
+        // re-adds a service routinely, several times an hour here. Telling the
+        // core it was lost closes the pooled connection, so acting on this while
+        // a session is live tore down a perfectly healthy peer every few minutes.
+        // A session that has genuinely died is detected by its own keepalive.
+        if (wasPushed && !connected(npub)) {
             Log.i(TAG, "fips node ${short(npub)} gone from LAN")
             NativeCore.awarePeerLost(npub)
+        } else if (wasPushed) {
+            Log.i(TAG, "fips node ${short(npub)} advert lapsed, session still up — keeping it")
         }
         publishNodes()
     }

--- a/android/app/src/main/java/app/myco/ble/BleService.kt
+++ b/android/app/src/main/java/app/myco/ble/BleService.kt
@@ -83,13 +83,14 @@ class BleService : Service() {
         // begins driving the radio (listen → advertise → scan).
         client.dispatch(NativeActions.setBleEnabled(true))
         // Node lifecycle follows the mesh "Enable" master switch, not this
-        // toggle. When it's on, (re)start the node: a byte-bridge is only bound
-        // at node start, so a node that was already running must bounce to pick
-        // up the fresh bridge injected above.
+        // toggle — and a running node is never bounced to adopt this radio.
+        // The core resolves the injected bridge per operation, so the fresh one
+        // above is picked up in place. Restarting to rebind it (which is what
+        // this did) tore down every peer and session, so turning Bluetooth on
+        // knocked the whole mesh out for as long as re-handshaking took.
         val meshOn = getSharedPreferences("myco_prefs", MODE_PRIVATE)
             .getBoolean(app.myco.MainActivity.PREF_MESH, true)
-        if (meshOn) {
-            if (client.state().nodeRunning) client.dispatch(NativeActions.stopNode())
+        if (meshOn && !client.state().nodeRunning) {
             client.dispatch(NativeActions.startNode())
         }
         // Registration replays the current state (onStart fires immediately if the

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -104,6 +104,9 @@ data class AppState(
     val library: List<LibraryItem>,
     val cache: CacheStatus,
     val circle: List<CircleContact>,
+    /** Circle members with a live mesh relay connection right now — reachable
+     *  at any hop count, not just direct neighbours. */
+    val reachableNpubs: Set<String> = emptySet(),
     val discovered: List<DiscoveredNsite>,
     val pendingPairRequests: List<PairRequest>,
     val offlineOnly: Boolean,
@@ -262,6 +265,11 @@ data class AppState(
                 library = library,
                 cache = cache,
                 circle = circle,
+                reachableNpubs = buildSet {
+                    o.optJSONArray("reachableNpubs")?.let { arr ->
+                        for (i in 0 until arr.length()) add(arr.optString(i))
+                    }
+                },
                 discovered = discovered,
                 pendingPairRequests = pendingPairRequests,
                 offlineOnly = o.optBoolean("offlineOnly"),

--- a/android/app/src/main/java/app/myco/core/NativeCore.kt
+++ b/android/app/src/main/java/app/myco/core/NativeCore.kt
@@ -62,6 +62,12 @@ internal object NativeCore {
     /** Aware data path to `npub` lost: close the pooled UDP session. */
     external fun awarePeerLost(npub: String)
 
+    /** The underlying network's real DNS servers, comma-separated. The mesh
+     *  tunnel advertises only its own sentinel resolver, so these are where the
+     *  core relays every non-`.fips` query — without them the device resolves
+     *  nothing but mesh names. */
+    external fun setUpstreamDns(servers: String)
+
     /** Raw fd of the node's UDP transport socket, once it has opened. Blocks
      *  up to `timeoutMs`; returns -1 on timeout. Sent once per node lifetime —
      *  poll this once at startup, then bind it to whichever local-only

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -326,12 +326,11 @@ val LocalMeshControl = androidx.compose.runtime.compositionLocalOf { MeshControl
 @Composable
 fun PeersPill(state: AppState) {
     val mesh = LocalMeshControl.current
-    val connectedNpubs = state.blePeers
-        .filter { it.connected && it.npub.isNotEmpty() }
-        .map { it.npub }
-        .toSet()
     val connected = state.blePeers.count { it.connected }
-    val reachable = state.circle.count { it.npub in connectedNpubs }
+    // Reachability is "we hold a live mesh relay to them", not "they are an
+    // adjacent node" — a Circle member many hops away is just as reachable, and
+    // counting only direct peers showed 0 while sync was working fine.
+    val reachable = state.reachableNpubs.size
     val circle = state.circle.size
     Surface(
         shape = CircleShape,

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
@@ -58,6 +60,8 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
         ScreenHeader("Dev", state, subtitle = "Technical details — myco-core state.")
+
+        PeersOverviewCard(state, awareLinks, apNodes)
 
         SpeedtestCard(state, client)
 
@@ -104,15 +108,7 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
                 }
                 // Stable alphabetical order — the state arrays arrive in snapshot
                 // order, which reshuffles between polls and makes the rows flap.
-                val peersSorted = state.blePeers.sortedBy { it.npub.ifEmpty { it.nodeAddrHex } }
                 val advertsSorted = state.bleAdverts.sortedBy { it.addr }
-                DevCard("PEERS (${state.blePeers.size})") {
-                    if (state.blePeers.isEmpty()) {
-                        EmptyLine("none connected")
-                    } else {
-                        peersSorted.forEach { PeerRow(it) }
-                    }
-                }
                 DevCard("RADIO ADVERTS (${state.bleAdverts.size})") {
                     if (state.bleAdverts.isEmpty()) {
                         EmptyLine("none")
@@ -196,6 +192,92 @@ private fun rate(mbps: Double): String =
 /** Payload size as KB or MB (the adaptive speedtest climbs from 256 KB to 16 MB). */
 private fun size(bytes: Long): String =
     if (bytes >= 1024 * 1024) "%.0f MB".format(bytes / (1024.0 * 1024.0)) else "%d KB".format(bytes / 1024)
+
+/**
+ * Every peer the node knows, in one place, so the transport sections below
+ * don't have to be cross-referenced by hand: who is connected, over which
+ * lane(s), and for how long.
+ *
+ * Lanes are attributed from **our own radios**, not from the node: Wi-Fi Aware
+ * rides the ordinary UDP transport, so the node reports "udp" for both Aware
+ * and the AP lane and cannot tell them apart. A peer can carry more than one
+ * marker while lanes overlap.
+ *
+ * Uptime is measured from when this screen first observed the peer connected,
+ * so it resets on app restart and reads "just now" for a session that predates
+ * the process. It is a diagnostic, not an SLA.
+ */
+@Composable
+private fun PeersOverviewCard(
+    state: AppState,
+    awareLinks: List<AwareLink>,
+    apNodes: List<LanFipsNode>,
+) {
+    // npub → epoch millis first seen connected; cleared when it drops, so a
+    // reconnect restarts the clock rather than reporting the older session.
+    val since = remember { mutableStateMapOf<String, Long>() }
+    val now = System.currentTimeMillis()
+    val connected = state.blePeers.filter { it.connected && it.npub.isNotEmpty() }
+    for (p in connected) since.putIfAbsent(p.npub, now)
+    since.keys.retainAll(connected.map { it.npub }.toSet())
+
+    val awareNpubs = awareLinks.filter { it.up }.map { it.npub }.toSet()
+    val udpNpubs = apNodes.filter { it.pushed }.map { it.npub }.toSet()
+
+    DevCard("PEERS (${connected.size})") {
+        if (state.blePeers.isEmpty()) {
+            Text(
+                "No peers yet.",
+                style = MaterialTheme.typography.bodySmall,
+                color = Slate,
+            )
+        }
+        for (p in state.blePeers.sortedBy { it.npub }) {
+            val lanes = buildList {
+                if (p.npub in awareNpubs) add("aware")
+                if (p.npub in udpNpubs) add("udp")
+                // Nothing claimed it: BLE is the lane with no radio-side npub
+                // list of its own, so an otherwise-unattributed peer is one.
+                if (isEmpty() && p.connected) add("ble")
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    StatusDot(if (p.connected) StatusConnected else Slate)
+                    Text(
+                        short(p.npub.ifEmpty { p.nodeAddrHex }),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                    )
+                }
+                Text(
+                    if (p.connected) "${lanes.joinToString("+")} · ${uptime(now - (since[p.npub] ?: now))}"
+                    else "offline",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (p.connected) Emerald else Slate,
+                )
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(
+            "aware = Wi-Fi Aware · udp = LAN/AP lane · ble = Bluetooth · uptime since first seen here",
+            style = MaterialTheme.typography.labelSmall,
+            color = Slate,
+        )
+    }
+}
+
+/** Compact duration for the peers card: `42s`, `7m`, `3h12m`. */
+private fun uptime(ms: Long): String {
+    val secs = (ms / 1000).coerceAtLeast(0)
+    return when {
+        secs < 60 -> "${secs}s"
+        secs < 3600 -> "${secs / 60}m"
+        else -> "${secs / 3600}h${(secs % 3600) / 60}m"
+    }
+}
 
 @Composable
 private fun DevCard(title: String, content: @Composable () -> Unit) {

--- a/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
+++ b/android/app/src/main/java/app/myco/vpn/MycoVpnService.kt
@@ -167,18 +167,15 @@ class MycoVpnService : VpnService() {
         } catch (e: Exception) {
             Log.w(TAG, "addDnsServer($DNS_SENTINEL) failed", e)
         }
-        // …then the real resolvers, as fallbacks. The sentinel only owns
-        // `.fips` and answers everything else SERVFAIL (see dns_intercept), so
-        // without these the tunnel would deny all normal DNS on the device.
-        // Order matters: the sentinel must come first, or a `.fips` name would
-        // be sent to a real resolver and authoritatively denied.
-        for (server in underlyingDnsServers(claimIpv6)) {
-            try {
-                builder.addDnsServer(server)
-            } catch (e: Exception) {
-                Log.w(TAG, "addDnsServer($server) failed", e)
-            }
-        }
+        // The sentinel is the *only* resolver we advertise. Listing the real
+        // ones alongside it does not work: the OS is free to send a `.fips`
+        // query to any server in the list, and a real resolver denies it
+        // authoritatively — so mesh names resolve or not depending on which
+        // server was picked. Instead the core relays every non-`.fips` query to
+        // these itself (see dns_intercept), keeping one answer for one question.
+        NativeCore.setUpstreamDns(
+            underlyingDnsServers(claimIpv6).joinToString(",") { it.hostAddress ?: "" },
+        )
         if (relayPort > 0) {
             // Point every app's web traffic at the loopback relay, which carries
             // it to the exit's proxy over the mesh. Proxied requests go to

--- a/myco-core/src/aware_bridge_jni.rs
+++ b/myco-core/src/aware_bridge_jni.rs
@@ -58,6 +58,35 @@ pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerLost(
     fips::discovery::platform::platform_peer_lost(&npub, TRANSPORT_TYPE);
 }
 
+/// Kotlin → Rust: the underlying network's real DNS servers, comma-separated
+/// (`"8.8.8.8,1.1.1.1"`; a port may be appended as `addr:53`). The sentinel is
+/// the tunnel's only advertised resolver, so these are where non-`.fips`
+/// queries get relayed — without them nothing but `.fips` resolves.
+#[no_mangle]
+pub extern "system" fn Java_app_myco_core_NativeCore_setUpstreamDns(
+    mut env: JNIEnv,
+    _class: JClass,
+    servers: JString,
+) {
+    let Some(list) = jstring(&mut env, &servers) else {
+        return;
+    };
+    let parsed = list
+        .split(',')
+        .filter_map(|s| {
+            let s = s.trim();
+            if s.is_empty() {
+                return None;
+            }
+            // Accept a bare address (default :53) or an explicit socket address.
+            s.parse::<std::net::SocketAddr>()
+                .ok()
+                .or_else(|| s.parse::<std::net::IpAddr>().ok().map(|ip| (ip, 53).into()))
+        })
+        .collect();
+    crate::dns_intercept::set_upstream(parsed);
+}
+
 /// Rust → Kotlin: the UDP transport's raw socket fd, once it has opened.
 /// Blocks up to `timeout_ms`; returns `-1` on timeout (no transport, or it
 /// hasn't started yet). The fd is sent once per node lifetime (see

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -858,7 +858,7 @@ impl Content {
 
     /// Every Circle member's npub. Hop count is deliberately not a factor: FIPS
     /// routes to a mesh address whether the peer is adjacent or many hops away,
-    /// so a routed `ws://[fd00::peer]:4870` dial reaches any of them. A member
+    /// so a routed `ws://<npub>.fips:4870` dial reaches any of them. A member
     /// who is genuinely offline costs one bounded dial (the callers time out)
     /// and is then held off by the per-peer backoff in [`crate::peer_relay`].
     /// See `docs/design/event-gossip.md`.
@@ -903,6 +903,21 @@ impl Content {
                     Some("ready") | Some("syncing")
                 )
             })
+            .collect()
+    }
+
+    /// Circle members we hold a live mesh relay connection to right now. The
+    /// keepwarm tick keeps one open per member, so this reflects who is
+    /// actually reachable — at any hop count — rather than who happens to be
+    /// an adjacent node.
+    pub fn reachable_npubs(&self) -> Vec<String> {
+        let live = self.peer_relays.connected_npubs();
+        self.circle
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|c| live.contains(&c.npub))
+            .map(|c| c.npub.clone())
             .collect()
     }
 
@@ -1048,14 +1063,15 @@ impl Content {
             return;
         };
         let name = self.device_name();
-        let peer = match fips::PeerIdentity::from_npub(target_npub) {
+        // Bind only to validate the npub; the dial is by name (see below).
+        let _peer = match fips::PeerIdentity::from_npub(target_npub) {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(target_npub, error = %e, "pairing: bad target npub");
                 return;
             }
         };
-        let url = format!("ws://[{}]:4870", peer.address().to_ipv6());
+        let url = crate::ip_source::mesh_relay_url(target_npub);
         for attempt in 0..PAIR_DIAL_ATTEMPTS {
             if attempt > 0 {
                 tokio::time::sleep(PAIR_DIAL_RETRY_DELAY).await;
@@ -1112,10 +1128,10 @@ impl Content {
             }
             guard.values().cloned().collect::<Vec<_>>()
         };
-        let Ok(peer) = fips::PeerIdentity::from_npub(npub) else {
+        let Ok(_peer) = fips::PeerIdentity::from_npub(npub) else {
             return;
         };
-        let url = format!("ws://[{}]:4870", peer.address().to_ipv6());
+        let url = crate::ip_source::mesh_relay_url(npub);
         let mut stored = 0u32;
         for filters in subs {
             let events = self
@@ -1142,8 +1158,14 @@ impl Content {
     pub fn keepwarm_tick(self: &Arc<Self>) {
         let circle: HashSet<String> = self.circle_npubs().into_iter().collect();
         for npub in &circle {
-            if let Ok(peer) = fips::PeerIdentity::from_npub(npub) {
-                let url = format!("ws://[{}]:4870", peer.address().to_ipv6());
+            if fips::PeerIdentity::from_npub(npub).is_ok() {
+                // Teach the node this npub's address→pubkey mapping first. We
+                // dial a raw `fd00::` literal below, which skips DNS — and
+                // without the identity the node has no pubkey to open a session
+                // with, so the dial fails as unroutable for anyone who isn't
+                // already a direct neighbour. See `dns_intercept::warm_route`.
+                crate::dns_intercept::warm_route(npub);
+                let url = crate::ip_source::mesh_relay_url(npub);
                 self.peer_relays.ensure(npub, &url);
             }
         }
@@ -1166,10 +1188,10 @@ impl Content {
     /// persistent pooled connection (no per-message connect). `npub` is the target
     /// Circle peer. Non-blocking.
     pub fn gossip_to_peer(&self, npub: &str, frame: String) {
-        let Ok(peer) = fips::PeerIdentity::from_npub(npub) else {
+        let Ok(_peer) = fips::PeerIdentity::from_npub(npub) else {
             return;
         };
-        let url = format!("ws://[{}]:4870", peer.address().to_ipv6());
+        let url = crate::ip_source::mesh_relay_url(npub);
         self.peer_relays.send(npub, &url, frame);
     }
 
@@ -1210,7 +1232,7 @@ impl Content {
             if exclude == Some(ip) {
                 return None;
             }
-            let url = format!("ws://[{}]:4870", ip);
+            let url = crate::ip_source::mesh_relay_url(&npub);
             let filters = filters.clone();
             Some(async move {
                 pool.request(&npub, &url, filters, std::time::Duration::from_secs(8))
@@ -1229,17 +1251,17 @@ impl Content {
     // --- discovery ("nsites around me") ---
 
     /// Discover nsites on connected Circle peers' relays: query each reachable
-    /// member's mesh relay (`ws://[fd00::peer]:4870`) for manifest events in
+    /// member's mesh relay (`ws://<npub>.fips:4870`) for manifest events in
     /// parallel, then rebuild the discovered list. Spawn-not-block; the UI polls
     /// `discovered`. Opening a result pulls from that peer (its npub is the holder).
     pub async fn discover_from_circle(self: Arc<Self>) {
         let members = self.circle_contacts();
         let pool = &self.peer_relays;
         let queries = members.into_iter().map(move |(npub, name)| async move {
-            let Ok(peer) = fips::PeerIdentity::from_npub(&npub) else {
+            let Ok(_peer) = fips::PeerIdentity::from_npub(&npub) else {
                 return Vec::new();
             };
-            let relay_url = format!("ws://[{}]:4870", peer.address().to_ipv6());
+            let relay_url = crate::ip_source::mesh_relay_url(&npub);
             // Manifest kinds only; `req-ttl: 1` reaches our peers' peers (2 hops),
             // matching the old `discover_manifests` helper.
             let filter = serde_json::json!({
@@ -1339,8 +1361,9 @@ impl Content {
             .circle_npubs()
             .into_iter()
             .filter_map(|npub| {
-                let peer = fips::PeerIdentity::from_npub(&npub).ok()?;
-                Some((npub, format!("ws://[{}]:4870", peer.address().to_ipv6())))
+                fips::PeerIdentity::from_npub(&npub).ok()?; // validate
+                let url = crate::ip_source::mesh_relay_url(&npub);
+                Some((npub, url))
             })
             .collect();
         let online: Vec<String> = if self.is_offline_only() {
@@ -1632,6 +1655,13 @@ impl Content {
         // then the online fallback unless mesh-only. Activate when complete.
         let mut sources: Vec<Arc<dyn PeerSource>> = Vec::new();
         if let Some(IpAddr::V6(ip)) = inbound.sender {
+            // The one place a bare mesh address is right: this is whoever just
+            // sent us the event, known only as a transport address — an address
+            // does not reduce back to an npub. It is safe here precisely because
+            // they just reached us, so the node already holds their identity;
+            // everywhere else, peers are addressed as `<npub>.fips` so that
+            // resolving the name registers that identity (see
+            // `ip_source::mesh_relay_url`).
             sources.push(Arc::new(
                 crate::ip_source::IpPeerSource::new(
                     vec![format!("ws://[{ip}]:4870")],

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -523,7 +523,7 @@ impl Content {
                 }
             }
         }
-        for npub in self.connected_circle_npubs() {
+        for npub in self.circle_npubs() {
             if tried.insert(npub.clone()) {
                 match crate::ip_source::mesh_source_for(self.peer_relays.clone(), &npub) {
                     Ok(mesh) => sources.push(Arc::new(mesh)),
@@ -840,8 +840,10 @@ impl Content {
         self.circle.lock().unwrap().clone()
     }
 
-    /// Record which mesh peers are connected right now (called by the runtime from
-    /// the node's peer snapshot), so `open_site` only tries reachable Circle members.
+    /// Record which mesh peers are *directly* connected right now (called by the
+    /// runtime from the node's peer snapshot). This is only an edge detector for
+    /// dial backoff — nothing gates on it, because whether a Circle member is a
+    /// direct neighbour or twenty hops away is FIPS's business, not ours.
     pub fn set_connected_peers(&self, npubs: Vec<String>) {
         let mut cur = self.connected_peers.lock().unwrap();
         // A peer newly present in the mesh view is a reconnect edge: forget its
@@ -854,28 +856,12 @@ impl Content {
         *cur = npubs;
     }
 
-    /// Circle members that are **direct** mesh neighbours right now — the pull
-    /// sources to try (besides an explicit holder) without risking an offline
-    /// timeout, e.g. `open_site` content pulls.
-    pub fn connected_circle_npubs(&self) -> Vec<String> {
-        let connected = self.connected_peers.lock().unwrap();
-        self.circle
-            .lock()
-            .unwrap()
-            .iter()
-            .filter(|c| connected.iter().any(|n| n == &c.npub))
-            .map(|c| c.npub.clone())
-            .collect()
-    }
-
-    /// **Every** Circle member's npub, regardless of whether they're a *direct*
-    /// mesh neighbour right now. Chat fan-out targets this: a Circle peer you've
-    /// walked away from is still reachable multi-hop over the mesh, and messages
-    /// must keep flowing to them — the routed `ws://[fd00::peer]:4870` dial reaches
-    /// them, and a truly-offline member's connect just fails fast and is dropped.
-    /// (Contrast [`connected_circle_npubs`](Self::connected_circle_npubs), the
-    /// direct-neighbour subset used where an offline dial's timeout must be
-    /// avoided.) See `docs/design/event-gossip.md`.
+    /// Every Circle member's npub. Hop count is deliberately not a factor: FIPS
+    /// routes to a mesh address whether the peer is adjacent or many hops away,
+    /// so a routed `ws://[fd00::peer]:4870` dial reaches any of them. A member
+    /// who is genuinely offline costs one bounded dial (the callers time out)
+    /// and is then held off by the per-peer backoff in [`crate::peer_relay`].
+    /// See `docs/design/event-gossip.md`.
     pub fn circle_npubs(&self) -> Vec<String> {
         self.circle
             .lock()
@@ -920,14 +906,13 @@ impl Content {
             .collect()
     }
 
-    /// Connected Circle members as `(npub, name)` — discovery targets.
-    fn connected_circle_contacts(&self) -> Vec<(String, String)> {
-        let connected = self.connected_peers.lock().unwrap();
+    /// Circle members as `(npub, name)` — discovery targets. Like
+    /// [`circle_npubs`](Self::circle_npubs), every member regardless of hop count.
+    fn circle_contacts(&self) -> Vec<(String, String)> {
         self.circle
             .lock()
             .unwrap()
             .iter()
-            .filter(|c| connected.iter().any(|n| n == &c.npub))
             .map(|c| (c.npub.clone(), c.name.clone()))
             .collect()
     }
@@ -1219,22 +1204,19 @@ impl Content {
         // any-matches across them), so a pull is a single round-trip, not one socket
         // per filter.
         let pool = &self.peer_relays;
-        let queries = self
-            .connected_circle_npubs()
-            .into_iter()
-            .filter_map(|npub| {
-                let peer = fips::PeerIdentity::from_npub(&npub).ok()?;
-                let ip = std::net::IpAddr::V6(peer.address().to_ipv6());
-                if exclude == Some(ip) {
-                    return None;
-                }
-                let url = format!("ws://[{}]:4870", ip);
-                let filters = filters.clone();
-                Some(async move {
-                    pool.request(&npub, &url, filters, std::time::Duration::from_secs(8))
-                        .await
-                })
-            });
+        let queries = self.circle_npubs().into_iter().filter_map(|npub| {
+            let peer = fips::PeerIdentity::from_npub(&npub).ok()?;
+            let ip = std::net::IpAddr::V6(peer.address().to_ipv6());
+            if exclude == Some(ip) {
+                return None;
+            }
+            let url = format!("ws://[{}]:4870", ip);
+            let filters = filters.clone();
+            Some(async move {
+                pool.request(&npub, &url, filters, std::time::Duration::from_secs(8))
+                    .await
+            })
+        });
 
         join_all(queries)
             .await
@@ -1251,7 +1233,7 @@ impl Content {
     /// parallel, then rebuild the discovered list. Spawn-not-block; the UI polls
     /// `discovered`. Opening a result pulls from that peer (its npub is the holder).
     pub async fn discover_from_circle(self: Arc<Self>) {
-        let members = self.connected_circle_contacts();
+        let members = self.circle_contacts();
         let pool = &self.peer_relays;
         let queries = members.into_iter().map(move |(npub, name)| async move {
             let Ok(peer) = fips::PeerIdentity::from_npub(&npub) else {
@@ -1354,7 +1336,7 @@ impl Content {
             "authors": authors,
         });
         let mesh_peers: Vec<(String, String)> = self
-            .connected_circle_npubs()
+            .circle_npubs()
             .into_iter()
             .filter_map(|npub| {
                 let peer = fips::PeerIdentity::from_npub(&npub).ok()?;
@@ -1520,7 +1502,7 @@ impl Content {
         // Pull blobs from connected mesh peers first (closer/faster, and the only
         // option under mesh-only), then the online fallback unless mesh-only.
         let mut sources: Vec<Arc<dyn PeerSource>> = Vec::new();
-        for npub in self.connected_circle_npubs() {
+        for npub in self.circle_npubs() {
             if let Ok(m) = crate::ip_source::mesh_source_for(self.peer_relays.clone(), &npub) {
                 sources.push(Arc::new(m));
             }
@@ -1688,7 +1670,7 @@ impl Content {
             obj.insert("event-ttl".to_string(), serde_json::json!(out_ttl));
         }
         let frame = serde_json::json!(["EVENT", ev_json]).to_string();
-        for npub in self.connected_circle_npubs() {
+        for npub in self.circle_npubs() {
             let ip = match fips::PeerIdentity::from_npub(&npub) {
                 Ok(p) => IpAddr::V6(p.address().to_ipv6()),
                 Err(_) => continue,
@@ -2260,14 +2242,10 @@ mod tests {
                 "re-adding renames in place"
             );
 
-            // Only connected members are offered as offline-sensitive pull sources.
+            // Every Circle member is a target regardless of hop count: only Bob is
+            // a direct neighbour, but Alice is still reachable multi-hop and must
+            // remain a pull/discovery/chat target. FIPS decides how to get there.
             content.set_connected_peers(vec!["npub1bob".to_string()]);
-            assert_eq!(
-                content.connected_circle_npubs(),
-                vec!["npub1bob".to_string()]
-            );
-            // But chat fans to the *whole* Circle — Alice isn't a direct neighbour
-            // right now, yet must still receive messages (reachable multi-hop).
             let all = content.circle_npubs();
             assert_eq!(all.len(), 2);
             assert!(all.contains(&"npub1alice".to_string()));

--- a/myco-core/src/dns_intercept.rs
+++ b/myco-core/src/dns_intercept.rs
@@ -24,7 +24,7 @@ use std::net::SocketAddr;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
-use fips::upper::dns::{handle_dns_packet, DnsIdentityTx};
+use fips::upper::dns::{handle_dns_packet, DnsIdentityTx, DnsResolvedIdentity};
 use fips::upper::hosts::HostMap;
 use fips::upper::tcp_mss::recalculate_l4_checksum;
 
@@ -44,6 +44,28 @@ fn identity_tx() -> &'static Mutex<Option<DnsIdentityTx>> {
 /// is rebuilt on a transport off→on cycle, yielding a fresh channel).
 pub fn set_identity_tx(tx: DnsIdentityTx) {
     *identity_tx().lock().unwrap() = Some(tx);
+}
+
+/// Teach the node an npub's address→pubkey mapping without going through a DNS
+/// lookup, so a packet sent to that mesh address can open a session.
+///
+/// Dialling a peer by raw `fd00::` literal skips resolution, so nothing
+/// registers the identity and the node has no pubkey to open a session with —
+/// the send is dropped and the address looks unroutable. That is invisible for
+/// a *direct* neighbour, whose identity the node already holds from the
+/// handshake, which is why only adjacent peers used to be reachable. Every
+/// address is derived from the public key alone, so this needs no network.
+pub fn warm_route(npub: &str) {
+    let Ok(peer) = fips::PeerIdentity::from_npub(npub) else {
+        return;
+    };
+    let id = DnsResolvedIdentity {
+        node_addr: *peer.node_addr(),
+        pubkey: peer.pubkey_full(),
+    };
+    if let Some(tx) = identity_tx().lock().unwrap().as_ref() {
+        let _ = tx.try_send(id);
+    }
 }
 
 /// The sentinel DNS-server address, `fd00::53`. Chosen inside the routed

--- a/myco-core/src/dns_intercept.rs
+++ b/myco-core/src/dns_intercept.rs
@@ -4,17 +4,25 @@
 //! server for every app on the tunnel. Because that address is inside the routed
 //! `fd00::/8` range but is **not** the node's own TUN address, the OS resolver's
 //! query packets are handed to the app-owned-TUN pump instead of being delivered
-//! locally. [`try_answer`] recognises those packets in the app→mesh path and
+//! locally. [`handle_query`] recognises those packets in the app→mesh path and
 //! synthesises a reply, so any app can resolve `<npub>.fips` (and, via a host map
 //! later, aliases) to a mesh `fd00::` address — without a real DNS server socket.
 //!
 //! Resolution itself is pure computation: `<npub>.fips` → `fd00::` is derived from
 //! the public key alone (see [`fips::upper::dns::handle_dns_packet`]), so this
-//! works with no network and no upstream resolver. Non-`.fips` names get NXDOMAIN
-//! — the exit-node demo routes web traffic through an HTTP proxy, which does its
-//! own DNS on the far side, so the phone never needs to resolve public names.
+//! works with no network and no upstream resolver.
+//!
+//! Because the sentinel is the *only* resolver the tunnel advertises, this
+//! module owns every name the device looks up, not just mesh ones: non-`.fips`
+//! queries are relayed to a real resolver and their replies injected back into
+//! the TUN. Advertising the real resolvers alongside the sentinel instead does
+//! not work — the OS may send a `.fips` query to any server in the list, and a
+//! real one denies it authoritatively, so mesh names would resolve or not
+//! depending on which server happened to be picked.
 
+use std::net::SocketAddr;
 use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 use fips::upper::dns::{handle_dns_packet, DnsIdentityTx};
 use fips::upper::hosts::HostMap;
@@ -55,11 +63,44 @@ const UDP_HEADER_LEN: usize = 8;
 const NEXT_HEADER_UDP: u8 = 17;
 const DNS_PORT: u16 = 53;
 
-/// If `packet` is a UDP DNS query to `[fd00::53]:53`, resolve it and return the
-/// reply packet (IPv6+UDP+DNS) to write back to the TUN. Returns `None` for any
-/// packet that is not such a query, so the caller forwards it into the mesh
-/// unchanged.
-pub fn try_answer(packet: &[u8]) -> Option<Vec<u8>> {
+/// What [`handle_query`] did with a packet.
+pub enum Dns {
+    /// A `.fips` query, answered here — write this reply to the TUN.
+    Answered(Vec<u8>),
+    /// Not ours to answer, sent to a real resolver instead; the reply will be
+    /// delivered later through [`crate::tun_bridge::push_local`]. The caller
+    /// must consume the packet either way.
+    Forwarded,
+    /// Not a DNS query to the sentinel — forward it into the mesh unchanged.
+    NotOurs,
+}
+
+/// Handle a packet the TUN pump read, if it is a UDP DNS query to
+/// `[fd00::53]:53`. `.fips` names are answered from the public key alone;
+/// everything else is relayed to a real resolver (see [`set_upstream`]),
+/// because the sentinel is the tunnel's *only* advertised server — anything we
+/// decline here would simply fail to resolve on the device.
+pub fn handle_query(packet: &[u8]) -> Dns {
+    match parse_query(packet) {
+        Some((src_addr, src_port, dns_query)) => {
+            if is_fips_name(dns_query) {
+                match answer_fips(src_addr, src_port, dns_query) {
+                    Some(reply) => Dns::Answered(reply),
+                    // Malformed enough that even SERVFAIL can't be built.
+                    None => Dns::Forwarded,
+                }
+            } else {
+                forward_upstream(src_addr, src_port, dns_query);
+                Dns::Forwarded
+            }
+        }
+        None => Dns::NotOurs,
+    }
+}
+
+/// Split a TUN packet into `(querier addr, querier port, DNS payload)` if it is
+/// a UDP DNS query addressed to `[fd00::53]:53`. `None` for anything else.
+fn parse_query(packet: &[u8]) -> Option<(&[u8], u16, &[u8])> {
     // IPv6 only, single UDP header (no extension headers — mesh DNS has none).
     if packet.len() < IPV6_HEADER_LEN + UDP_HEADER_LEN {
         return None;
@@ -74,24 +115,16 @@ pub fn try_answer(packet: &[u8]) -> Option<Vec<u8>> {
     if payload_len < UDP_HEADER_LEN || IPV6_HEADER_LEN + payload_len > packet.len() {
         return None;
     }
-
-    let src_addr = &packet[8..24];
-    let src_port = u16::from_be_bytes([packet[40], packet[41]]);
-    let dst_port = u16::from_be_bytes([packet[42], packet[43]]);
-    if dst_port != DNS_PORT {
+    if u16::from_be_bytes([packet[42], packet[43]]) != DNS_PORT {
         return None;
     }
-
+    let src_port = u16::from_be_bytes([packet[40], packet[41]]);
     let dns_query = &packet[IPV6_HEADER_LEN + UDP_HEADER_LEN..IPV6_HEADER_LEN + payload_len];
+    Some((&packet[8..24], src_port, dns_query))
+}
 
-    // Only `.fips` is ours. Everything else gets SERVFAIL, which makes the OS
-    // resolver fail over to the next server it was given (the real one, see the
-    // VpnService) — where NXDOMAIN would be an authoritative "does not exist"
-    // and would end the lookup, breaking all normal DNS on the device.
-    if !is_fips_name(dns_query) {
-        return Some(build_reply(src_addr, src_port, &servfail(dns_query)?));
-    }
-
+/// Answer a `.fips` query from the public key alone, and warm the route.
+fn answer_fips(src_addr: &[u8], src_port: u16, dns_query: &[u8]) -> Option<Vec<u8>> {
     // Empty host map: `<npub>.fips` resolves by pure computation without it.
     let (dns_reply, identity) = handle_dns_packet(dns_query, ANSWER_TTL, &HostMap::new())?;
 
@@ -104,6 +137,69 @@ pub fn try_answer(packet: &[u8]) -> Option<Vec<u8>> {
     }
 
     Some(build_reply(src_addr, src_port, &dns_reply))
+}
+
+/// Real resolvers to relay non-`.fips` queries to, set by the platform from the
+/// underlying network's DNS servers (see the Android `MycoVpnService`).
+static UPSTREAM: OnceLock<Mutex<Vec<SocketAddr>>> = OnceLock::new();
+
+fn upstream() -> &'static Mutex<Vec<SocketAddr>> {
+    UPSTREAM.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Install the upstream resolvers. Replaces any previous set — the platform
+/// re-supplies these whenever the underlying network changes.
+pub fn set_upstream(servers: Vec<SocketAddr>) {
+    *upstream().lock().unwrap() = servers;
+}
+
+/// How long to wait for an upstream resolver before giving up on a query. The
+/// OS resolver has its own, longer timeout, so a lost query costs a retry
+/// rather than a hang.
+const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// Relay a non-`.fips` query to a real resolver and inject the reply into the
+/// TUN when it comes back.
+///
+/// Runs on its own thread: the caller is the TUN read loop, and blocking it
+/// would stall every other packet on the device. DNS volume is low enough that
+/// a thread per outstanding query is cheaper than the machinery to avoid it.
+///
+/// The socket is deliberately plain: the tunnel routes no IPv4 and claims IPv6
+/// only when the network underneath has none, so a query to an IPv4 resolver
+/// leaves via the real network without needing to be `protect()`ed.
+fn forward_upstream(src_addr: &[u8], src_port: u16, dns_query: &[u8]) {
+    let servers = upstream().lock().unwrap().clone();
+    if servers.is_empty() {
+        return; // nothing to relay to; the querier will time out and retry
+    }
+    let mut querier = [0u8; 16];
+    querier.copy_from_slice(src_addr);
+    let query = dns_query.to_vec();
+
+    std::thread::spawn(move || {
+        let Ok(sock) = std::net::UdpSocket::bind((std::net::Ipv4Addr::UNSPECIFIED, 0)) else {
+            return;
+        };
+        if sock.set_read_timeout(Some(UPSTREAM_TIMEOUT)).is_err() {
+            return;
+        }
+        for server in servers {
+            if sock.send_to(&query, server).is_err() {
+                continue;
+            }
+            let mut buf = [0u8; 1500];
+            match sock.recv_from(&mut buf) {
+                // Only accept a reply from the server we just asked, and only
+                // if the transaction id matches the query we sent.
+                Ok((n, from)) if from.ip() == server.ip() && n >= 2 && buf[..2] == query[..2] => {
+                    crate::tun_bridge::push_local(build_reply(&querier, src_port, &buf[..n]));
+                    return;
+                }
+                _ => continue,
+            }
+        }
+    });
 }
 
 /// Walk the QNAME in `dns_query` (wire format, labels after the 12-byte
@@ -131,23 +227,6 @@ fn is_fips_name(dns_query: &[u8]) -> bool {
     scan_qname(dns_query)
         .map(|(_, is_fips)| is_fips)
         .unwrap_or(false)
-}
-
-/// A SERVFAIL response to `dns_query`: the header and question echoed back,
-/// answer/authority/additional emptied, QR set and RCODE = 2.
-fn servfail(dns_query: &[u8]) -> Option<Vec<u8>> {
-    let (qname_end, _) = scan_qname(dns_query)?;
-    let question_end = qname_end + 4; // QTYPE + QCLASS
-    if dns_query.len() < question_end {
-        return None;
-    }
-    let mut reply = dns_query[..question_end].to_vec();
-    reply[2] |= 0x80; // QR = response
-    reply[3] = (reply[3] & 0xf0) | 2; // RCODE = SERVFAIL
-    reply[6..8].copy_from_slice(&0u16.to_be_bytes()); // ANCOUNT
-    reply[8..10].copy_from_slice(&0u16.to_be_bytes()); // NSCOUNT
-    reply[10..12].copy_from_slice(&0u16.to_be_bytes()); // ARCOUNT
-    Some(reply)
 }
 
 /// Assemble the response IPv6/UDP packet: swap the query's src/dst and ports,
@@ -211,7 +290,9 @@ mod tests {
         // A valid npub (from fips test vectors would be ideal; use a well-formed one).
         let npub = "npub1mqelkzqp4659fws35h2wvr7z9caka5ml8qddj3ssnwaulwpxdd9sdc3esw";
         let pkt = make_query(&format!("{npub}.fips"), SENTINEL);
-        let reply = try_answer(&pkt).expect("should answer .fips query");
+        let Dns::Answered(reply) = handle_query(&pkt) else {
+            panic!("a .fips query must be answered here, not forwarded");
+        };
 
         // Reply is IPv6/UDP, from :53, back to the querier, addressed to the client.
         assert_eq!(reply[0] >> 4, 6);
@@ -228,19 +309,15 @@ mod tests {
     }
 
     #[test]
-    fn non_fips_name_gets_servfail_not_nxdomain() {
-        // NXDOMAIN here would be authoritative and would end the lookup, so the
-        // device could resolve nothing but `.fips`. SERVFAIL makes the OS
-        // resolver fail over to the real server listed after our sentinel.
+    fn non_fips_name_is_relayed_not_answered() {
+        // We are the tunnel's only resolver, so a non-`.fips` name must be
+        // relayed to a real one rather than answered (or denied) here —
+        // denying it would leave the device able to resolve nothing else.
         let pkt = make_query("google.com", SENTINEL);
-        let reply = try_answer(&pkt).expect("should answer non-.fips queries too");
-
-        let dns = &reply[IPV6_HEADER_LEN + UDP_HEADER_LEN..];
-        assert_eq!(dns[2] & 0x80, 0x80, "QR must be set");
-        assert_eq!(dns[3] & 0x0f, 2, "RCODE must be SERVFAIL");
-        let parsed = simple_dns::Packet::parse(dns).unwrap();
-        assert_eq!(parsed.questions.len(), 1, "question is echoed back");
-        assert_eq!(parsed.answers.len(), 0);
+        assert!(
+            matches!(handle_query(&pkt), Dns::Forwarded),
+            "non-.fips must be relayed upstream"
+        );
     }
 
     #[test]
@@ -249,7 +326,7 @@ mod tests {
         // Same query but to a non-sentinel address → not ours, forward to mesh.
         let other = [0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9];
         let pkt = make_query(&format!("{npub}.fips"), other);
-        assert!(try_answer(&pkt).is_none());
+        assert!(matches!(handle_query(&pkt), Dns::NotOurs));
     }
 
     #[test]
@@ -257,6 +334,6 @@ mod tests {
         let mut pkt = make_query("whatever.fips", SENTINEL);
         // Change dst port away from 53.
         pkt[42..44].copy_from_slice(&4870u16.to_be_bytes());
-        assert!(try_answer(&pkt).is_none());
+        assert!(matches!(handle_query(&pkt), Dns::NotOurs));
     }
 }

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -2,7 +2,7 @@
 //! mesh, implementing the **push** plane of `docs/design/event-gossip.md`.
 //!
 //! **P2 — multi-hop flood.** An event is pushed to the whole Circle's relays
-//! (`ws://[fd00::peer]:4870`) — every member, not just direct neighbours, so a
+//! (`ws://<npub>.fips:4870`) — every member, not just direct neighbours, so a
 //! peer reachable only multi-hop over the mesh still receives it — carrying a
 //! decrementing `event-ttl`:
 //!

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -109,21 +109,35 @@ impl IpPeerSource {
 }
 
 /// A [`PeerSource`] that pulls from a specific **holder's** embedded relay +
-/// Blossom over the FIPS mesh, addressed by the holder's npub: the ULA
-/// `fd00:: = fd + node_addr[0..15]` (`PeerIdentity::from_npub`), reached at
-/// `ws://[fd00::holder]:4870` / `http://[fd00::holder]:24243`. Requires the
-/// app-owned TUN to be up so the IPv6 socket routes over the mesh. A longer
-/// timeout than the IP source absorbs BLE latency + first-contact session setup.
+/// A peer's mesh relay, addressed by **name**: `ws://<npub>.fips:4870`.
+///
+/// Always name, never the `fd00::` literal the name resolves to. Resolving it
+/// is what teaches the node the address→pubkey mapping, and without that the
+/// node has no pubkey to open a session with and the dial fails as unroutable
+/// for anyone who is not already a direct neighbour. The literal happens to
+/// work for adjacent peers, which is exactly what made this hard to spot.
+pub(crate) fn mesh_relay_url(npub: &str) -> String {
+    format!("ws://{npub}.fips:4870")
+}
+
+/// A peer's mesh Blossom endpoint, by name. See [`mesh_relay_url`].
+pub(crate) fn mesh_blossom_url(npub: &str) -> String {
+    format!("http://{npub}.fips:24243")
+}
+
+/// Blossom over the FIPS mesh, addressed by the holder's npub — see
+/// [`mesh_relay_url`]. Requires the app-owned TUN to be up so the socket routes
+/// over the mesh. A longer timeout than the IP source absorbs BLE latency +
+/// first-contact session setup.
 pub fn mesh_source_for(
     pool: std::sync::Arc<crate::peer_relay::PeerRelayPool>,
     holder_npub: &str,
 ) -> anyhow::Result<IpPeerSource> {
-    let peer = fips::PeerIdentity::from_npub(holder_npub)
+    fips::PeerIdentity::from_npub(holder_npub)
         .map_err(|e| anyhow::anyhow!("invalid holder npub {holder_npub}: {e}"))?;
-    let ip = peer.address().to_ipv6();
     Ok(IpPeerSource::new(
-        vec![format!("ws://[{ip}]:4870")],
-        vec![format!("http://[{ip}]:24243")],
+        vec![mesh_relay_url(holder_npub)],
+        vec![mesh_blossom_url(holder_npub)],
     )
     .with_timeout(Duration::from_secs(20))
     .ignoring_manifest_servers()
@@ -145,18 +159,17 @@ pub async fn speedtest_peer(
     bytes: usize,
     timeout: Duration,
 ) -> anyhow::Result<(f64, f64)> {
-    // Address the peer by its `<npub>.fips` hostname, but resolve it ourselves: the
-    // Android system resolver has no `.fips` entries (that resolver is the FIPS
-    // gateway's, not wired into reqwest), so a plain request fails DNS. Map the
-    // hostname to the peer's deterministic mesh ULA (`fd00:: = fd + node_addr`) and
-    // hand it to reqwest via `.resolve` — it then connects over the app-owned TUN
-    // while keeping the `<npub>.fips` Host the peer expects.
-    let peer = fips::PeerIdentity::from_npub(npub)
+    // Addressed by name, resolved by the system resolver like any other host: the
+    // tunnel advertises the in-mesh sentinel as its DNS server, so `<npub>.fips`
+    // resolves for every process on the device, this one included. (It used to be
+    // mapped to the peer's `fd00::` literal by hand via `.resolve`, from before
+    // that resolver existed. Doing so skipped resolution, which is also what
+    // registers the peer's identity with the node — so the literal only ever
+    // worked for a peer the node already knew: a direct neighbour.)
+    fips::PeerIdentity::from_npub(npub)
         .map_err(|e| anyhow::anyhow!("invalid peer npub {npub}: {e}"))?;
     let host = format!("{npub}.fips");
-    let socket = std::net::SocketAddr::new(std::net::IpAddr::V6(peer.address().to_ipv6()), 24243);
     let client = reqwest::Client::builder()
-        .resolve(&host, socket)
         // A short connect timeout so an unroutable/unreachable peer fails fast
         // instead of burning the whole `timeout` budget; the total still bounds the
         // (potentially slow over BLE) transfer.

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -245,9 +245,15 @@ async fn run(
     let ws =
         match tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(&url)).await {
             Ok(Ok((ws, _))) => ws,
-            _ => {
+            other => {
                 // Connect failed or timed out → back off this peer; the channel drops
-                // with this task and a post-backoff command respawns it.
+                // with this task and a post-backoff command respawns it. Log why:
+                // a silent failure here looks like "the peer is simply offline",
+                // which is indistinguishable from a dial we got wrong.
+                match other {
+                    Ok(Err(e)) => tracing::warn!(npub, url, error = %e, "peer relay dial failed"),
+                    _ => tracing::warn!(npub, url, "peer relay dial timed out"),
+                }
                 record_dial_failure(&dial_backoff, &npub);
                 return;
             }

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -58,6 +58,36 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const BACKOFF_BASE: Duration = Duration::from_secs(8);
 const BACKOFF_CAP: Duration = Duration::from_secs(180);
 
+/// Pause before re-dialling through a cold route. A first send to a peer whose
+/// coordinates the node hasn't learned yet fails immediately *and triggers the
+/// lookup that fixes it*, so the retry usually lands. Short enough that a peer
+/// becomes reachable in about a second rather than at the next keepwarm tick.
+const WARMUP_RETRY: Duration = Duration::from_millis(1500);
+
+/// Why a dial failed, which decides whether it counts against the peer.
+enum DialFault {
+    /// No resolver yet — the mesh TUN is still coming up, so `<npub>.fips`
+    /// cannot resolve. Says nothing about the peer; must not arm its backoff,
+    /// or a peer can be held off for minutes because we dialled too early.
+    NoResolver,
+    /// The node has no route to the peer *yet*. Usually a cold route: the send
+    /// itself starts the lookup, so an immediate retry tends to succeed.
+    NoRoute,
+    /// Anything else — refused, timed out, protocol error. A real failure.
+    Hard,
+}
+
+fn classify(err: &tokio_tungstenite::tungstenite::Error) -> DialFault {
+    let text = err.to_string();
+    if text.contains("failed to lookup address information") {
+        DialFault::NoResolver
+    } else if text.contains("Network is unreachable") || text.contains("No route to host") {
+        DialFault::NoRoute
+    } else {
+        DialFault::Hard
+    }
+}
+
 /// Per-peer dial-failure state (see [`BACKOFF_BASE`]).
 struct DialBackoff {
     failures: u32,
@@ -231,6 +261,53 @@ impl PeerRelayPool {
     }
 }
 
+/// Dial the peer's relay, retrying once through a cold route.
+///
+/// Distinguishes *why* a dial failed, because the three cases deserve different
+/// treatment and lumping them together is what made this subsystem hard to
+/// reason about: a dial we sent before the tunnel existed used to arm the same
+/// exponential backoff as a genuinely absent peer, holding a perfectly good peer
+/// off for minutes over a startup race.
+async fn dial(
+    url: &str,
+    npub: &str,
+    dial_backoff: &BackoffMap,
+) -> Option<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+> {
+    for attempt in 0..2 {
+        match tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(url)).await {
+            Ok(Ok((ws, _))) => return Some(ws),
+            Ok(Err(e)) => match classify(&e) {
+                // The tunnel isn't up yet. Not the peer's fault — leave its
+                // backoff untouched so the next keepwarm tick dials again.
+                DialFault::NoResolver => {
+                    tracing::debug!(npub, url, "peer relay dial before the mesh TUN was up");
+                    return None;
+                }
+                // Cold route: this send starts the lookup that warms it, so give
+                // that a moment and try once more before counting a failure.
+                DialFault::NoRoute if attempt == 0 => {
+                    tracing::debug!(npub, url, "no route yet, warming");
+                    tokio::time::sleep(WARMUP_RETRY).await;
+                    continue;
+                }
+                _ => {
+                    tracing::warn!(npub, url, error = %e, "peer relay dial failed");
+                    record_dial_failure(dial_backoff, npub);
+                    return None;
+                }
+            },
+            Err(_) => {
+                tracing::warn!(npub, url, "peer relay dial timed out");
+                record_dial_failure(dial_backoff, npub);
+                return None;
+            }
+        }
+    }
+    None
+}
+
 /// The per-peer connection actor: connect once, then multiplex push + pull + ping
 /// over the one socket until it dies or the pool drops the command channel.
 async fn run(
@@ -242,22 +319,10 @@ async fn run(
 ) {
     // Bounded connect: a hang here (SYN black hole into a wedged session) must
     // fail fast, both to arm the backoff and to stop touching the stale session.
-    let ws =
-        match tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(&url)).await {
-            Ok(Ok((ws, _))) => ws,
-            other => {
-                // Connect failed or timed out → back off this peer; the channel drops
-                // with this task and a post-backoff command respawns it. Log why:
-                // a silent failure here looks like "the peer is simply offline",
-                // which is indistinguishable from a dial we got wrong.
-                match other {
-                    Ok(Err(e)) => tracing::warn!(npub, url, error = %e, "peer relay dial failed"),
-                    _ => tracing::warn!(npub, url, "peer relay dial timed out"),
-                }
-                record_dial_failure(&dial_backoff, &npub);
-                return;
-            }
-        };
+    let ws = match dial(&url, &npub, &dial_backoff).await {
+        Some(ws) => ws,
+        None => return,
+    };
     // Live now — clear any backoff and mark reachable so the keepwarm loop sees
     // the (re)connect edge.
     dial_backoff.lock().unwrap().remove(&npub);
@@ -374,6 +439,31 @@ fn handle_inbound(txt: &str, pending: &mut HashMap<String, Pending>) -> Option<S
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The classifier reads OS error text, so pin the three cases: mistaking a
+    /// startup race for a peer failure holds a good peer off for minutes.
+    #[test]
+    fn dial_faults_are_classified() {
+        use std::io::{Error, ErrorKind};
+        let io = |msg: &str| {
+            tokio_tungstenite::tungstenite::Error::Io(Error::new(ErrorKind::Other, msg.to_string()))
+        };
+        assert!(matches!(
+            classify(&io(
+                "failed to lookup address information: No address associated with hostname"
+            )),
+            DialFault::NoResolver
+        ));
+        assert!(matches!(
+            classify(&io("Network is unreachable (os error 101)")),
+            DialFault::NoRoute
+        ));
+        assert!(matches!(
+            classify(&io("Connection refused (os error 111)")),
+            DialFault::Hard
+        ));
+    }
+
     use myco_relay::server::serve_on;
     use myco_relay::RelayStore;
     use nostr::{EventBuilder, Keys, Kind, Tag};

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -327,6 +327,7 @@ async fn run(
     // the (re)connect edge.
     dial_backoff.lock().unwrap().remove(&npub);
     connected.lock().unwrap().insert(npub.clone());
+    tracing::info!(npub, "peer relay connected");
     let (mut sink, mut stream) = ws.split();
     let mut pending: HashMap<String, Pending> = HashMap::new();
     let mut next_sub: u64 = 0;
@@ -335,13 +336,19 @@ async fn run(
     let mut ping =
         tokio::time::interval_at(tokio::time::Instant::now() + PING_INTERVAL, PING_INTERVAL);
     let mut awaiting_pong = false;
+    // Why the actor exited, logged on the way out: a relay that connects and
+    // then dies is indistinguishable from one that never connected unless the
+    // exit says so.
+    #[allow(unused_assignments)] // each loop exit overwrites this before the log
+    let mut reason = "unknown";
 
     loop {
         tokio::select! {
             cmd = cmd_rx.recv() => match cmd {
-                None => break, // pool dropped the sender: shut the socket down
+                None => { reason = "pool dropped the command channel"; break }
                 Some(Command::Publish(frame)) => {
                     if sink.send(Message::Text(frame)).await.is_err() {
+                        reason = "write failed (publish)";
                         break;
                     }
                 }
@@ -355,6 +362,7 @@ async fn run(
                     let frame = serde_json::Value::Array(req).to_string();
                     if sink.send(Message::Text(frame)).await.is_err() {
                         let _ = reply.send(Vec::new());
+                        reason = "write failed (request)";
                         break;
                     }
                     pending.insert(sub_id, Pending { events: Vec::new(), reply });
@@ -374,19 +382,21 @@ async fn run(
                                 let _ = sink.send(Message::Text(close)).await;
                             }
                         }
-                        Message::Close(_) => break,
+                        Message::Close(_) => { reason = "peer closed the socket"; break }
                         _ => {} // pong / ping / binary — liveness already noted
                     }
                 }
-                Some(Err(_)) | None => break, // socket error or clean EOF → reconnect on next command
+                Some(Err(_)) | None => { reason = "socket error or EOF"; break }
             },
             _ = ping.tick() => {
                 // The previous ping went a whole interval unanswered by any frame →
                 // treat the connection as dead (this is the half-open catch).
                 if awaiting_pong {
+                    reason = "no frame within a ping interval (half-open)";
                     break;
                 }
                 if sink.send(Message::Ping(Vec::new())).await.is_err() {
+                    reason = "write failed (ping)";
                     break;
                 }
                 awaiting_pong = true;
@@ -407,6 +417,7 @@ async fn run(
     }
     // No longer reachable — clear the flag so the keepwarm loop respawns us and
     // sees a fresh (re)connect edge when the peer comes back.
+    tracing::info!(npub, reason, "peer relay disconnected");
     connected.lock().unwrap().remove(&npub);
     // Pending replies drop here → their `request` callers get an empty batch.
     let _ = sink.send(Message::Close(None)).await;
@@ -444,10 +455,9 @@ mod tests {
     /// startup race for a peer failure holds a good peer off for minutes.
     #[test]
     fn dial_faults_are_classified() {
-        use std::io::{Error, ErrorKind};
-        let io = |msg: &str| {
-            tokio_tungstenite::tungstenite::Error::Io(Error::new(ErrorKind::Other, msg.to_string()))
-        };
+        use std::io::Error;
+        let io =
+            |msg: &str| tokio_tungstenite::tungstenite::Error::Io(Error::other(msg.to_string()));
         assert!(matches!(
             classify(&io(
                 "failed to lookup address information: No address associated with hostname"

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -822,6 +822,11 @@ impl AppRuntime {
                 .as_ref()
                 .map(|c| c.circle_snapshot())
                 .unwrap_or_default(),
+            reachable_npubs: self
+                .content
+                .as_ref()
+                .map(|c| c.reachable_npubs())
+                .unwrap_or_default(),
             pending_pair_requests: self
                 .content
                 .as_ref()

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -243,7 +243,7 @@ impl AppRuntime {
                                 .map(|p| p.npub)
                                 .collect();
                             content.set_connected_peers(connected);
-                            if !content.connected_circle_npubs().is_empty() {
+                            if !content.circle_npubs().is_empty() {
                                 for addr in content.retriable_library_addrs() {
                                     let content = content.clone();
                                     tokio::spawn(
@@ -757,14 +757,14 @@ impl AppRuntime {
             // (`Content::keepwarm_tick`), which recreates each in-app subscription
             // against a Circle peer as it (re)appears — direct *or* multi-hop.
             if let Some(rt) = self.rt.as_ref() {
-                // Retry not-ready downloads while any direct Circle peer is reachable.
-                // open_site(_, None) tries every connected peer, and
-                // `retriable_library_addrs` skips sites already syncing — so this
-                // re-tries about once per attempt-duration (not every poll), and
-                // keeps trying as a flaky just-connected session settles, instead of
+                // Retry not-ready downloads whenever the Circle is non-empty.
+                // open_site(_, None) tries every member — hop count is FIPS's
+                // problem, and an unreachable one costs a bounded dial then backs
+                // off — and `retriable_library_addrs` skips sites already syncing,
+                // so this re-tries about once per attempt-duration (not every
+                // poll), and keeps trying as a flaky session settles instead of
                 // firing once on the connect edge and going quiet.
-                let conn = content.connected_circle_npubs();
-                if !conn.is_empty() {
+                if !content.circle_npubs().is_empty() {
                     for addr in content.retriable_library_addrs() {
                         let content = content.clone();
                         rt.spawn(async move { content.open_site(addr, None).await });

--- a/myco-core/src/state.rs
+++ b/myco-core/src/state.rs
@@ -33,6 +33,12 @@ pub struct AppState {
     pub cache: crate::content::CacheView,
     /// The user's **Circle**: paired peers we pull nsites from over the mesh.
     pub circle: Vec<crate::content::CircleContact>,
+    /// Circle members we currently hold a live mesh relay connection to. This
+    /// is the honest "reachable" signal: it means bytes are flowing to them
+    /// right now, whether they are a direct neighbour or many hops away. The
+    /// direct-peer table ([`AppState::ble_peers`]) is *not* a substitute — it
+    /// only ever names adjacent nodes.
+    pub reachable_npubs: Vec<String>,
     /// Incoming pair requests awaiting accept/decline (the UI shows a pop-up).
     pub pending_pair_requests: Vec<crate::content::PairRequestView>,
     /// nsites discovered on Circle peers' relays (`SearchNsites` — "around me").

--- a/myco-core/src/tun_bridge.rs
+++ b/myco-core/src/tun_bridge.rs
@@ -43,6 +43,13 @@ fn local() -> &'static Mutex<VecDeque<Vec<u8>>> {
     LOCAL.get_or_init(|| Mutex::new(VecDeque::new()))
 }
 
+/// Queue a locally-synthesised packet for the TUN fd. Used by
+/// [`crate::dns_intercept`] to deliver a DNS reply that arrived after
+/// `send_packet` already returned (an upstream-forwarded query).
+pub fn push_local(packet: Vec<u8>) {
+    local().lock().unwrap().push_back(packet);
+}
+
 /// Install the node's app-owned-TUN channel ends and the MSS ceiling
 /// (`effective_ipv6_mtu - 60`). Replaces any prior install (the node is rebuilt on
 /// a BLE off→on cycle, yielding fresh channels).
@@ -59,11 +66,16 @@ pub fn install(
 /// app → mesh: clamp the TCP MSS, then route an IPv6 packet read from the TUN fd
 /// into the mesh. Returns `false` if no TUN is installed or the queue is full.
 pub fn send_packet(mut packet: Vec<u8>) -> bool {
-    // System-wide `.fips` DNS: if this is a query to the sentinel resolver,
-    // answer it locally, queue the reply for the TUN, and don't forward it.
-    if let Some(reply) = crate::dns_intercept::try_answer(&packet) {
-        local().lock().unwrap().push_back(reply);
-        return true;
+    // System-wide `.fips` DNS: a query to the sentinel resolver is ours —
+    // answered here for `.fips`, or forwarded upstream (the reply arrives
+    // later via `push_local`). Either way it must not go to the mesh.
+    match crate::dns_intercept::handle_query(&packet) {
+        crate::dns_intercept::Dns::Answered(reply) => {
+            local().lock().unwrap().push_back(reply);
+            return true;
+        }
+        crate::dns_intercept::Dns::Forwarded => return true,
+        crate::dns_intercept::Dns::NotOurs => {}
     }
     // Only mesh (fd00::/8) traffic belongs on the app-owned TUN. The VpnService
     // also routes ::/0 so the OS reports the tunnel as IPv6-capable (without


### PR DESCRIPTION
Circle members were unreachable unless they happened to be a *direct* mesh neighbour: their nsites never appeared under "around me", pulls skipped them, and the status pill reported them offline. Chat was the exception, and its own doc comment explained why — it already fanned out to the whole Circle on the grounds that "a Circle peer you've walked away from is still reachable multi-hop over the mesh".

Chasing that turned up four independent causes, each of which hid the next, plus two lifecycle bugs found while measuring. Each is a separate commit.

## Why hop count leaked into the app at all

`set_connected_peers` fed the app the node's *directly connected* peer table, and `connected_circle_npubs` intersected the Circle with it. Everything except chat gated on that intersection. Since FIPS routes to a mesh address whether the peer is adjacent or twenty hops out, this was Myco modelling something that isn't its business. That method and its `_contacts` sibling are gone; pulls, blob sources, discovery, the sync loop and both keepwarm gates now target every member.

The gate existed to avoid an offline member's dial timeout, but that was already handled: pulls run under `join_all` with an 8s cap, and `peer_relay` holds a failing peer off with per-peer backoff (8s doubling to 180s). So an unreachable member costs one bounded parallel dial, then silence — the same bargain chat had been making. `set_connected_peers` survives, now only as an edge detector that clears a peer's dial backoff the moment it reappears.

## Addressing peers by name

Removing the gate wasn't enough, because dialling `ws://[fd00::peer]:4870` performs no name resolution — and resolution is what registers a peer's address→pubkey mapping with the node. Without it the node has no pubkey to open a session with, the send is dropped, and the address looks unroutable. That is invisible for a direct neighbour, whose identity the node already holds from the handshake, so the bug hid behind the one case that worked.

Peers are now addressed as `<npub>.fips` throughout, via `ip_source::mesh_relay_url` / `mesh_blossom_url`, and `dns_intercept::warm_route` registers a member's identity straight from its npub before the keepwarm dial, so this holds even when the OS answers from its DNS cache and no query reaches us. The speedtest's hand-rolled `.resolve()` mapping goes too — its comment said the system resolver has no `.fips` entries, which was true when written and stopped being true in v0.4.0. Verified at the app's own uid: `nc <npub>.fips 4870` now fails "Network is unreachable" (resolved, no route) rather than "unknown host".

One bare address remains, commented as the exception: the manifest-gossip download path knows its sender only as a transport address, and an address does not reduce back to an npub. It is safe there because the sender just reached us, so the node already holds their identity.

## DNS

v0.4.0 shipped the tunnel advertising its own resolver alongside the network's real ones, so non-`.fips` names could fail over. That cannot work — any real resolver denies a `.fips` name *authoritatively*, so whether a mesh name resolved came down to which server the OS happened to pick. Both test phones showed a way to lose: one had Private DNS validated to 8.8.8.8, bypassing the sentinel over TLS entirely; the other simply chose a public server for a `.fips` query.

The sentinel goes back to being the only advertised resolver and takes responsibility for every lookup: `.fips` answered from the public key, everything else relayed to a real resolver with the reply injected back into the TUN. The relay runs on its own thread (the caller is the TUN read loop and must not block), with a 4s timeout, accepting a reply only from the server it asked and only when the transaction id matches. Its socket is deliberately unprotected — the tunnel routes no IPv4 and claims IPv6 only when the network underneath has none, so a query to an IPv4 resolver leaves via the real network unaided.

## Two lifecycle bugs found while measuring

Both were ours, from the AP lane in v0.4.0, and both looked like FIPS instability until the logs said otherwise.

The keepwarm tick re-pushed a *connected* peer's address every 10s on the theory that a redundant push is a no-op. It isn't: per the platform peer queue, an event for an already-active peer starts an alternate-path handshake, so every tick raced a fresh handshake against a healthy session. And a lapsed mDNS advert was reported as a lost peer, which closes the pooled connection — NSD drops and re-adds services several times an hour, so live sessions were being torn down by a discovery artefact.

Measured from a cold start over three minutes: zero peer removals on both phones, against continuous churn before. One settled on `link:1`; the other rotated through its four candidate addresses, connected on the fourth, and stopped.

Separately, starting the Bluetooth service stopped and restarted the whole mesh node to rebind a byte-bridge that was only bound at node start — so enabling one transport tore down every peer and session reached over the others. That needed a matching change in fips (see below); the node's lifecycle is now exactly the mesh master switch and nothing else stops it.

## Dependency

Needs `AndroidIo::from_global()` from fips `9121925d4b91024cf52f0690016479114c18b13d`, on `feat/platform-peer-queue` — the branch CI already clones, and it is pushed. `AndroidIo` there resolves the injected radio bridge per operation instead of capturing it at construction, and the BLE transport is built whether or not a bridge exists yet. Without that, adopting a radio requires rebuilding the node.

No new crates, no new permissions, no manifest or `minSdk` change, no wire-format or gating change. `CircleGate` still admits by npub-derived address, which was already hop-agnostic.

## Testing

`cargo fmt --check`, `cargo build`, `cargo test` (28 in `myco-core`, 14 suites green workspace-wide) and `./gradlew assembleDebug` all pass. Clippy is clean across the files this touches; the remaining workspace findings are pre-existing and CI runs clippy non-gating.

New unit coverage where it's tractable: `dns_intercept::non_fips_name_is_relayed_not_answered` pins the delegation contract, and `peer_relay::dial_faults_are_classified` pins the three dial-failure classes — that one matches on OS error strings, so it is exactly the thing that rots silently.

The rest is two-device behaviour and was verified on a Pixel 7 Pro (GrapheneOS) and a Galaxy A52s: a paired peer that showed `0/2` reachable now shows `1/2`, with the remaining `0` a third party that is genuinely absent; `.fips` resolves 5/5 where the previous build failed it outright, and public names 3/3; and the churn measurements above. Per CONTRIBUTING's note on regression tests, the reachability and lifecycle fixes aren't tractable as unit tests — they need two phones, a shared upstream node, and radio toggling.

## Known issues, not addressed here

- The first keepwarm tick can fire before the TUN is up and fails with "No address associated with hostname"; the next tick 8s later succeeds. Dial classification makes sure it no longer counts against the peer's backoff, but the log line remains.
- Peering churn from rotating link-layer addresses is upstream: a phone whose Wi-Fi or BLE MAC rotates is re-dialled on every rotation even while a session with that npub is healthy. Tracked at [fips#130](https://github.com/jmcorgan/fips/issues/130), which I've added the BLE case to. It cannot be worked around at this layer — a BLE advert carries only the listener PSM, so identity isn't known until after the connection.
- Uptime in the new peers card is measured from when the screen first observed a peer, so it resets on app restart. It is a diagnostic, not an SLA, and says so in the code.

Adjacent but not overlapping: [#15](https://github.com/Origami74/myco/issues/15) wants Settings warnings for silent BLE outbound-connect failures. This PR adds the same *kind* of visibility one layer up (relay dial failures now log, with connect and disconnect-reason lines), but touches neither `BleHealth` nor the Settings surface.
