### PR TITLE
Add system-aware AMOLED dark mode to Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: gradle-${{ runner.os }}-
 
+      - name: Test Android unit tests
+        working-directory: android
+        run: ./gradlew :app:testDebugUnitTest --no-daemon --stacktrace
+
       - name: Build debug APK
         working-directory: android
         env:

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -140,5 +140,6 @@ dependencies {
     implementation("com.google.zxing:core:3.5.3")
     // …and an in-app camera scanner to read one back.
     implementation("com.journeyapps:zxing-android-embedded:4.3.0")
+    testImplementation("junit:junit:4.13.2")
     debugImplementation("androidx.compose.ui:ui-tooling")
 }

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -22,7 +22,6 @@ import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
@@ -91,16 +90,9 @@ class MainActivity : ComponentActivity() {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         // Draw edge-to-edge with transparent system bars on every API level. The
-        // platform forces this on Android 15+, but pre-15 devices (e.g. Samsung on
-        // One UI 6 / Android 14) otherwise keep opaque bars whose default color
-        // differs from our white background — showing up as big top/bottom borders.
-        // The Compose Scaffold applies the system-bar insets, so content stays clear.
-        //
-        // Force the *light* bar style (dark icons) on both bars: the shell is always
-        // a white background, so the default `auto` style would draw white icons in
-        // system dark mode — invisible white-on-white (seen on Pixel).
-        val barStyle = SystemBarStyle.light(android.graphics.Color.TRANSPARENT, android.graphics.Color.TRANSPARENT)
-        enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
+        // default auto style follows Android's light/dark configuration, keeping
+        // system icons legible when the AMOLED scheme is active.
+        enableEdgeToEdge()
         core = MycoCore.client(this)
         // Restore the mesh-only (no IP fallback) preference into the core.
         core.dispatch(NativeActions.setOfflineOnly(prefs.getBoolean(PREF_OFFLINE_ONLY, false)))

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -73,8 +73,7 @@ import app.myco.ui.screens.DevScreen
 import app.myco.ui.screens.DiscoverScreen
 import app.myco.ui.screens.QrScreen
 import app.myco.ui.screens.SettingsScreen
-import app.myco.ui.theme.EmeraldSoft
-import app.myco.ui.theme.Slate
+
 import app.myco.ui.theme.StatusAlone
 import app.myco.ui.theme.StatusConnected
 import app.myco.ui.theme.StatusThin
@@ -233,9 +232,9 @@ fun MycoApp(
                             colors = NavigationBarItemDefaults.colors(
                                 selectedIconColor = MaterialTheme.colorScheme.primary,
                                 selectedTextColor = MaterialTheme.colorScheme.primary,
-                                indicatorColor = EmeraldSoft,
-                                unselectedIconColor = Slate,
-                                unselectedTextColor = Slate,
+                                indicatorColor = MaterialTheme.colorScheme.primaryContainer,
+                                unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
                             ),
                         )
                     }
@@ -436,7 +435,7 @@ fun ScreenHeader(title: String, state: AppState, subtitle: String? = null) {
         }
         if (subtitle != null) {
             Spacer(Modifier.size(6.dp))
-            Text(subtitle, color = Slate, style = MaterialTheme.typography.bodyMedium)
+            Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyMedium)
         }
     }
 }
@@ -447,6 +446,7 @@ fun SectionCard(content: @Composable () -> Unit) {
     Surface(
         shape = RoundedCornerShape(18.dp),
         color = MaterialTheme.colorScheme.surfaceVariant,
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Column(modifier = Modifier.padding(vertical = 4.dp)) { content() }
@@ -458,7 +458,7 @@ fun SectionCard(content: @Composable () -> Unit) {
 fun GroupLabel(text: String) {
     Text(
         text,
-        color = Slate,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
         fontWeight = FontWeight.Bold,
         style = MaterialTheme.typography.labelMedium,
         modifier = Modifier.padding(start = 4.dp),
@@ -510,7 +510,7 @@ fun KeyVal(label: String, value: String, valueColor: Color = MaterialTheme.color
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        Text(label, color = Slate, style = MaterialTheme.typography.bodyMedium)
+        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyMedium)
         Spacer(Modifier.width(12.dp))
         Text(
             value,

--- a/android/app/src/main/java/app/myco/ui/screens/AppsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/AppsScreen.kt
@@ -71,9 +71,7 @@ import app.myco.nfc.NfcReader
 import app.myco.nfc.PairPresent
 import app.myco.share.NsiteShare
 import app.myco.ui.ScreenHeader
-import app.myco.ui.theme.EmeraldInk
-import app.myco.ui.theme.EmeraldSoft
-import app.myco.ui.theme.Slate
+
 import app.myco.ui.theme.tileColorFor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -147,7 +145,7 @@ fun AppsScreen(
             item(span = { GridItemSpan(maxLineSpan) }) {
                 Text(
                     "No apps yet — scan a friend's share QR or paste a link to add one.",
-                    color = Slate,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
@@ -218,7 +216,7 @@ private fun SearchField(query: String, onChange: (String) -> Unit) {
         value = query,
         onValueChange = onChange,
         singleLine = true,
-        leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null, tint = Slate) },
+        leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
         placeholder = { Text("Search apps") },
         shape = RoundedCornerShape(16.dp),
         modifier = Modifier.fillMaxWidth(),
@@ -344,10 +342,10 @@ private fun AddTile(onClick: () -> Unit) {
                 .background(MaterialTheme.colorScheme.surfaceVariant),
             contentAlignment = Alignment.Center,
         ) {
-            Icon(Icons.Filled.Add, contentDescription = "Add app", tint = Slate, modifier = Modifier.size(28.dp))
+            Icon(Icons.Filled.Add, contentDescription = "Add app", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(28.dp))
         }
         Spacer(Modifier.height(6.dp))
-        Text("Add", color = Slate, style = MaterialTheme.typography.labelMedium)
+        Text("Add", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.labelMedium)
     }
 }
 
@@ -379,7 +377,7 @@ private fun AppSheet(
                 Text(
                     if (updating) "Updating… ${site.updatePulled}/${site.updateTotal}"
                     else "nsite · ${site.filesTotal} files · ${site.state}",
-                    color = if (updating) MaterialTheme.colorScheme.primary else Slate,
+                    color = if (updating) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodySmall,
                 )
             }
@@ -437,7 +435,12 @@ private fun ShareQrSheet(target: ShareTarget, pendingRequestCount: Int, onDismis
         ) {
             Text("Share this app", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
             Spacer(Modifier.height(12.dp))
-            Surface(shape = RoundedCornerShape(20.dp), color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.fillMaxWidth()) {
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
                 Column(
                     modifier = Modifier.fillMaxWidth().padding(16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -448,7 +451,7 @@ private fun ShareQrSheet(target: ShareTarget, pendingRequestCount: Int, onDismis
                     Spacer(Modifier.height(2.dp))
                     Text(
                         "Scan to open this app — and pair with this device",
-                        color = Slate,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         style = MaterialTheme.typography.bodySmall,
                         textAlign = TextAlign.Center,
                     )
@@ -457,7 +460,7 @@ private fun ShareQrSheet(target: ShareTarget, pendingRequestCount: Int, onDismis
             Spacer(Modifier.height(12.dp))
             // The headline action: just bump phones (no scanning needed). The
             // breathing NFC bubble mirrors the Circle tab's tap-to-connect hint.
-            Surface(shape = RoundedCornerShape(16.dp), color = EmeraldSoft, modifier = Modifier.fillMaxWidth()) {
+            Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.primaryContainer, modifier = Modifier.fillMaxWidth()) {
                 Row(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -468,12 +471,12 @@ private fun ShareQrSheet(target: ShareTarget, pendingRequestCount: Int, onDismis
                         Text(
                             "Tap phones together to share",
                             fontWeight = FontWeight.ExtraBold,
-                            color = EmeraldInk,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
                             style = MaterialTheme.typography.titleSmall,
                         )
                         Text(
                             "Hold the backs together — no scan needed",
-                            color = Color(0xFF047857),
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
                             style = MaterialTheme.typography.bodySmall,
                         )
                     }
@@ -518,7 +521,7 @@ private fun AddAppSheet(siteCount: Int, onScanned: (String) -> Unit, onDismiss: 
             }
             Spacer(Modifier.height(12.dp))
             // Same breathing NFC bubble as the share sheet — here you're the reader.
-            Surface(shape = RoundedCornerShape(16.dp), color = EmeraldSoft, modifier = Modifier.fillMaxWidth()) {
+            Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.primaryContainer, modifier = Modifier.fillMaxWidth()) {
                 Row(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -529,12 +532,12 @@ private fun AddAppSheet(siteCount: Int, onScanned: (String) -> Unit, onDismiss: 
                         Text(
                             "Or tap a friend's phone",
                             fontWeight = FontWeight.ExtraBold,
-                            color = EmeraldInk,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
                             style = MaterialTheme.typography.titleSmall,
                         )
                         Text(
                             "Hold the backs together to add their app",
-                            color = Color(0xFF047857),
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
                             style = MaterialTheme.typography.bodySmall,
                         )
                     }

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -74,16 +74,9 @@ import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
 import app.myco.share.NsiteShare
 import app.myco.ui.PeersPill
-import app.myco.ui.theme.Emerald
-import app.myco.ui.theme.EmeraldInk
-import app.myco.ui.theme.EmeraldSoft
-import app.myco.ui.theme.Slate
 import app.myco.ui.theme.StatusConnected
 import app.myco.ui.theme.avatarColorFor
 
-private val Ink = Color(0xFF0F172A)
-private val Hairline = Color(0xFFCBD5E1)
-private val CardBg = Color(0xFFF4F5F7)
 
 private enum class Ring { ONLINE, DASHED, NONE }
 private enum class Badge { NONE, PLUS, SENT }
@@ -173,7 +166,7 @@ fun CircleScreen(
                 item {
                     Text(
                         "Nobody nearby yet. Keep this screen open near another phone.",
-                        color = Slate,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
@@ -211,7 +204,7 @@ fun CircleScreen(
                 item {
                     Text(
                         "No one yet. Bump phones, or tap someone in Nearby.",
-                        color = Slate,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
@@ -303,7 +296,7 @@ fun CircleScreen(
         // QR bubble — scan / show / paste.
         Surface(
             shape = CircleShape,
-            color = Emerald,
+            color = MaterialTheme.colorScheme.primary,
             shadowElevation = 6.dp,
             modifier = Modifier
                 .align(Alignment.BottomEnd)
@@ -312,7 +305,7 @@ fun CircleScreen(
                 .clickable(onClick = onOpenQr),
         ) {
             Box(contentAlignment = Alignment.Center) {
-                Icon(Icons.Filled.QrCode2, contentDescription = "Scan or show a code", tint = Color.White, modifier = Modifier.size(26.dp))
+                Icon(Icons.Filled.QrCode2, contentDescription = "Scan or show a code", tint = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.size(26.dp))
             }
         }
     }
@@ -401,7 +394,7 @@ private fun PersonSheet(
             Spacer(Modifier.width(12.dp))
             Column {
                 Text(contact.name.ifEmpty { "unknown" }, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-                Text("in your circle", color = Slate, style = MaterialTheme.typography.bodySmall)
+                Text("in your circle", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
             }
         }
         Spacer(Modifier.height(16.dp))
@@ -416,7 +409,12 @@ private fun shortNpub(npub: String): String =
 
 @Composable
 private fun IdentityChip(name: String, onEdit: () -> Unit) {
-    Surface(shape = RoundedCornerShape(50), color = CardBg, modifier = Modifier.clickable(onClick = onEdit)) {
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        modifier = Modifier.clickable(onClick = onEdit),
+    ) {
         Row(
             modifier = Modifier.padding(start = 6.dp, end = 12.dp, top = 5.dp, bottom = 5.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -429,7 +427,7 @@ private fun IdentityChip(name: String, onEdit: () -> Unit) {
                 Text(name.firstOrNull()?.uppercase() ?: "?", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 11.sp)
             }
             Text(name, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.titleSmall)
-            Icon(Icons.Filled.Edit, contentDescription = "Rename", tint = Slate, modifier = Modifier.size(15.dp))
+            Icon(Icons.Filled.Edit, contentDescription = "Rename", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(15.dp))
         }
     }
 }
@@ -450,11 +448,11 @@ private fun TapToConnect(nfc: NfcState, onEnableNfc: () -> Unit) {
             NfcBubble(warn = warn)
             Column(modifier = Modifier.weight(1f)) {
                 if (warn) {
-                    Text("NFC is off", fontWeight = FontWeight.ExtraBold, color = Color(0xFF9A3412), style = MaterialTheme.typography.titleSmall)
-                    Text("Tap to turn it on, then bump phones", color = Color(0xFFB45309), style = MaterialTheme.typography.bodySmall)
+                    Text("NFC is off", fontWeight = FontWeight.ExtraBold, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.titleSmall)
+                    Text("Tap to turn it on, then bump phones", color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
                 } else {
-                    Text("Bump phones to connect", fontWeight = FontWeight.ExtraBold, color = Ink, style = MaterialTheme.typography.titleSmall)
-                    Text("Hold the backs together — pairs instantly", color = Slate, style = MaterialTheme.typography.bodySmall)
+                    Text("Bump phones to connect", fontWeight = FontWeight.ExtraBold, color = MaterialTheme.colorScheme.onSurface, style = MaterialTheme.typography.titleSmall)
+                    Text("Hold the backs together — pairs instantly", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
                 }
             }
         }
@@ -467,10 +465,10 @@ private fun TapToConnect(nfc: NfcState, onEnableNfc: () -> Unit) {
 private fun NfcBubble(warn: Boolean) {
     if (warn) {
         Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFFB45309), CircleShape),
+            modifier = Modifier.size(48.dp).background(MaterialTheme.colorScheme.error, CircleShape),
             contentAlignment = Alignment.Center,
         ) {
-            Icon(Icons.Filled.Contactless, contentDescription = null, tint = Color.White, modifier = Modifier.size(26.dp))
+            Icon(Icons.Filled.Contactless, contentDescription = null, tint = MaterialTheme.colorScheme.onError, modifier = Modifier.size(26.dp))
         }
     } else {
         NfcPulseBubble()
@@ -480,14 +478,14 @@ private fun NfcBubble(warn: Boolean) {
 @Composable
 private fun SectionLabel(text: String, trailing: String?, scanning: Boolean) {
     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-        Text(text, color = Slate, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
+        Text(text, color = MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
         if (trailing != null) {
             Spacer(Modifier.width(6.dp))
-            Text(trailing, color = Color(0xFF94A3B8), style = MaterialTheme.typography.labelMedium)
+            Text(trailing, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.labelMedium)
         }
         if (scanning) {
             Spacer(Modifier.weight(1f))
-            Text("looking…", color = Color(0xFF94A3B8), style = MaterialTheme.typography.labelSmall)
+            Text("looking…", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.labelSmall)
         }
     }
 }
@@ -503,6 +501,7 @@ private fun PersonBubble(
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
 ) {
+    val outlineColor = MaterialTheme.colorScheme.outline
     Column(
         modifier = Modifier
             .width(58.dp)
@@ -522,7 +521,7 @@ private fun PersonBubble(
                 when (ring) {
                     Ring.ONLINE -> drawCircle(StatusConnected, r, style = Stroke(2.5.dp.toPx()))
                     Ring.DASHED -> drawCircle(
-                        Hairline, r,
+                        outlineColor, r,
                         style = Stroke(1.5.dp.toPx(), pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 8f))),
                     )
                     Ring.NONE -> {}
@@ -540,7 +539,7 @@ private fun PersonBubble(
                         .align(Alignment.BottomEnd)
                         .size(18.dp)
                         .clip(CircleShape)
-                        .background(if (badge == Badge.SENT) Slate else Emerald)
+                        .background(if (badge == Badge.SENT) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.primary)
                         .border(2.dp, Color.White, CircleShape),
                     contentAlignment = Alignment.Center,
                 ) {
@@ -559,7 +558,7 @@ private fun PersonBubble(
             fontSize = 10.sp,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            color = if (dim) Slate else Ink,
+            color = if (dim) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -574,7 +573,7 @@ private fun RenameDialog(initial: String, onDismiss: () -> Unit, onSave: (String
         title = { Text("Your name") },
         text = {
             Column {
-                Text("How you appear to people you pair with. Pick something you can say out loud.", color = Slate, style = MaterialTheme.typography.bodyMedium)
+                Text("How you appear to people you pair with. Pick something you can say out loud.", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyMedium)
                 Spacer(Modifier.height(12.dp))
                 OutlinedTextField(value = value, onValueChange = { value = it }, singleLine = true, modifier = Modifier.fillMaxWidth())
             }

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -38,8 +38,6 @@ import app.myco.ui.KeyVal
 import app.myco.ui.ScreenHeader
 import app.myco.ui.SectionCard
 import app.myco.ui.StatusDot
-import app.myco.ui.theme.Emerald
-import app.myco.ui.theme.Slate
 import app.myco.ui.theme.StatusConnected
 import kotlin.math.pow
 
@@ -176,7 +174,7 @@ private fun SpeedtestCard(state: AppState, client: AppCoreClient) {
         if (resultLine != null) {
             Text(
                 resultLine,
-                color = if (st.error.isNotEmpty() && !st.running) MaterialTheme.colorScheme.error else Slate,
+                color = if (st.error.isNotEmpty() && !st.running) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
                 style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
             )
@@ -229,7 +227,7 @@ private fun PeersOverviewCard(
             Text(
                 "No peers yet.",
                 style = MaterialTheme.typography.bodySmall,
-                color = Slate,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
         for (p in state.blePeers.sortedBy { it.npub }) {
@@ -245,7 +243,7 @@ private fun PeersOverviewCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    StatusDot(if (p.connected) StatusConnected else Slate)
+                    StatusDot(if (p.connected) StatusConnected else MaterialTheme.colorScheme.onSurfaceVariant)
                     Text(
                         short(p.npub.ifEmpty { p.nodeAddrHex }),
                         style = MaterialTheme.typography.bodySmall,
@@ -256,7 +254,7 @@ private fun PeersOverviewCard(
                     if (p.connected) "${lanes.joinToString("+")} · ${uptime(now - (since[p.npub] ?: now))}"
                     else "offline",
                     style = MaterialTheme.typography.bodySmall,
-                    color = if (p.connected) Emerald else Slate,
+                    color = if (p.connected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
@@ -264,7 +262,7 @@ private fun PeersOverviewCard(
         Text(
             "aware = Wi-Fi Aware · udp = LAN/AP lane · ble = Bluetooth · uptime since first seen here",
             style = MaterialTheme.typography.labelSmall,
-            color = Slate,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
@@ -284,7 +282,7 @@ private fun DevCard(title: String, content: @Composable () -> Unit) {
     Column {
         Text(
             title,
-            color = Emerald,
+            color = MaterialTheme.colorScheme.primary,
             fontWeight = FontWeight.Bold,
             style = MaterialTheme.typography.titleSmall,
             modifier = Modifier.padding(start = 4.dp, bottom = 6.dp),
@@ -302,9 +300,9 @@ private fun KeyValDot(label: String, value: String, ok: Boolean) {
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
     ) {
-        Text(label, color = Slate, style = MaterialTheme.typography.bodyMedium)
+        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyMedium)
         Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-            StatusDot(if (ok) StatusConnected else Slate)
+            StatusDot(if (ok) StatusConnected else MaterialTheme.colorScheme.onSurfaceVariant)
             Text(
                 value,
                 color = if (ok) StatusConnected else MaterialTheme.colorScheme.onSurface,
@@ -320,7 +318,7 @@ private fun PeerRow(peer: BlePeer) {
     Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) {
         Text(
             if (peer.connected) "● connected" else "○ seen",
-            color = if (peer.connected) StatusConnected else Slate,
+            color = if (peer.connected) StatusConnected else MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.labelMedium,
         )
         Text(
@@ -335,7 +333,7 @@ private fun AwareLinkRow(l: AwareLink) {
     Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) {
         Text(
             if (l.up) "● ndp up" else "○ ndp requested",
-            color = if (l.up) StatusConnected else Slate,
+            color = if (l.up) StatusConnected else MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.labelMedium,
         )
         Text(
@@ -350,7 +348,7 @@ private fun ApNodeRow(n: LanFipsNode) {
     Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) {
         Text(
             if (n.pushed) "● pushed to node" else "○ resolved",
-            color = if (n.pushed) StatusConnected else Slate,
+            color = if (n.pushed) StatusConnected else MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.labelMedium,
         )
         Text(
@@ -371,7 +369,7 @@ private fun AdvertRow(a: BleAdvert) {
 
 @Composable
 private fun EmptyLine(text: String) {
-    Text(text, color = Slate, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp))
+    Text(text, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp))
 }
 
 private fun short(hex: String): String =

--- a/android/app/src/main/java/app/myco/ui/screens/DiscoverScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DiscoverScreen.kt
@@ -45,7 +45,7 @@ import app.myco.core.AppCoreClient
 import app.myco.core.AppState
 import app.myco.core.NativeActions
 import app.myco.ui.ScreenHeader
-import app.myco.ui.theme.Slate
+
 import app.myco.ui.theme.tileColorFor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -117,7 +117,7 @@ fun DiscoverScreen(
             item(span = { GridItemSpan(maxLineSpan) }) {
                 Text(
                     "Nothing found yet. Make sure a Circle peer is connected, then tap Discover.",
-                    color = Slate,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(top = 4.dp),
                 )

--- a/android/app/src/main/java/app/myco/ui/screens/NfcVisuals.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/NfcVisuals.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import app.myco.ui.theme.Emerald
 
 /**
  * The animated "tap to connect" NFC bubble — a filled circle whose two outer
@@ -33,10 +32,11 @@ import app.myco.ui.theme.Emerald
 internal fun NfcPulseBubble(
     modifier: Modifier = Modifier,
     size: Dp = 48.dp,
-    background: Color = Emerald,
+    background: Color? = null,
 ) {
+    val bubbleColor = background ?: androidx.compose.material3.MaterialTheme.colorScheme.primary
     androidx.compose.foundation.layout.Box(
-        modifier = modifier.size(size).background(background, CircleShape),
+        modifier = modifier.size(size).background(bubbleColor, CircleShape),
         contentAlignment = Alignment.Center,
     ) {
         val transition = rememberInfiniteTransition(label = "nfc")

--- a/android/app/src/main/java/app/myco/ui/screens/PairScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/PairScreen.kt
@@ -59,9 +59,6 @@ import app.myco.core.AppState
 import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
 import app.myco.share.NsiteShare
-import app.myco.ui.theme.Emerald
-import app.myco.ui.theme.EmeraldSoft
-import app.myco.ui.theme.Slate
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.ResultPoint
 import com.journeyapps.barcodescanner.BarcodeCallback
@@ -90,12 +87,12 @@ fun QrScreen(
         }
 
         Spacer(Modifier.height(12.dp))
-        Text("SCAN A FRIEND'S CODE", color = Slate, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
+        Text("SCAN A FRIEND'S CODE", color = MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
         Spacer(Modifier.height(8.dp))
         Box(modifier = Modifier.fillMaxWidth().height(240.dp)) { ScanPanel(onScanned = onScanned) }
 
         Spacer(Modifier.height(20.dp))
-        Text("OR SHOW YOURS", color = Slate, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
+        Text("OR SHOW YOURS", color = MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
         Spacer(Modifier.height(8.dp))
         MyCodePanel(state = state, deviceName = name)
 
@@ -116,7 +113,7 @@ internal fun ScanPanel(onScanned: (String) -> Unit) {
     LaunchedEffect(Unit) { if (!granted) permLauncher.launch(Manifest.permission.CAMERA) }
 
     Box(
-        modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(22.dp)).background(Color(0xFF0F172A)),
+        modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(22.dp)).background(Color.Black),
         contentAlignment = Alignment.Center,
     ) {
         if (granted) {
@@ -197,6 +194,7 @@ private fun CameraScanner(onScanned: (String) -> Unit) {
 /** Emerald corner brackets framing the viewfinder. */
 @Composable
 private fun ReticleOverlay() {
+    val accent = MaterialTheme.colorScheme.primary
     Canvas(modifier = Modifier.fillMaxSize().padding(28.dp)) {
         val arm = 34.dp.toPx()
         val sw = 5.dp.toPx()
@@ -204,7 +202,7 @@ private fun ReticleOverlay() {
         val t = 0f
         val r = size.width
         val b = size.height
-        fun line(a: Offset, c: Offset) = drawLine(Emerald, a, c, strokeWidth = sw, cap = StrokeCap.Round)
+        fun line(a: Offset, c: Offset) = drawLine(accent, a, c, strokeWidth = sw, cap = StrokeCap.Round)
         line(Offset(l, t + arm), Offset(l, t)); line(Offset(l, t), Offset(l + arm, t))
         line(Offset(r - arm, t), Offset(r, t)); line(Offset(r, t), Offset(r, t + arm))
         line(Offset(l, b - arm), Offset(l, b)); line(Offset(l, b), Offset(l + arm, b))
@@ -221,7 +219,12 @@ private fun MyCodePanel(state: AppState, deviceName: String) {
     }
     val pairUri = PairPresent.payload.value ?: fallback
     val qr = remember(pairUri) { NsiteShare.qrBitmap(pairUri) }
-    Surface(shape = RoundedCornerShape(20.dp), color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.fillMaxWidth()) {
+    Surface(
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -230,16 +233,16 @@ private fun MyCodePanel(state: AppState, deviceName: String) {
             Spacer(Modifier.height(12.dp))
             Text(deviceName, fontWeight = FontWeight.ExtraBold, style = MaterialTheme.typography.titleMedium)
             Spacer(Modifier.height(4.dp))
-            Text("Friend scans this — or taps phones — to add you", color = Slate, style = MaterialTheme.typography.bodySmall, textAlign = TextAlign.Center)
+            Text("Friend scans this — or taps phones — to add you", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall, textAlign = TextAlign.Center)
             Spacer(Modifier.height(10.dp))
-            Surface(shape = RoundedCornerShape(50), color = EmeraldSoft) {
+            Surface(shape = RoundedCornerShape(50), color = MaterialTheme.colorScheme.primaryContainer) {
                 Row(
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 5.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
-                    Icon(Icons.Filled.Contactless, contentDescription = null, tint = Emerald, modifier = Modifier.size(14.dp))
-                    Text("also tap-to-pair ready", color = Color(0xFF047857), fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
+                    Icon(Icons.Filled.Contactless, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(14.dp))
+                    Text("also tap-to-pair ready", color = MaterialTheme.colorScheme.onPrimaryContainer, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
                 }
             }
         }

--- a/android/app/src/main/java/app/myco/ui/screens/PairingUi.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/PairingUi.kt
@@ -44,18 +44,18 @@ import app.myco.core.AppCoreClient
 import app.myco.core.AppState
 import app.myco.core.NativeActions
 import app.myco.core.PairRequest
-import app.myco.ui.theme.Emerald
-import app.myco.ui.theme.EmeraldInk
-import app.myco.ui.theme.EmeraldSoft
-import app.myco.ui.theme.Slate
 import app.myco.ui.theme.avatarColorFor
 
-private val CardBg = Color(0xFFF4F5F7)
 
 @Composable
 fun RequestCard(req: PairRequest, onAccept: () -> Unit, onIgnore: () -> Unit) {
     val name = req.name.ifEmpty { "Unknown device" }
-    Surface(shape = RoundedCornerShape(18.dp), color = CardBg, modifier = Modifier.fillMaxWidth()) {
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
         Column(modifier = Modifier.padding(14.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Box(
@@ -69,7 +69,7 @@ fun RequestCard(req: PairRequest, onAccept: () -> Unit, onIgnore: () -> Unit) {
                     Text(name, fontWeight = FontWeight.ExtraBold, style = MaterialTheme.typography.titleSmall)
                     Text(
                         shortNpub(req.npub),
-                        color = Slate,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                     )
                 }
@@ -78,17 +78,17 @@ fun RequestCard(req: PairRequest, onAccept: () -> Unit, onIgnore: () -> Unit) {
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 Surface(
                     shape = RoundedCornerShape(50),
-                    color = Color.White,
-                    border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFCBD5E1)),
+                    color = MaterialTheme.colorScheme.surface,
+                    border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
                     modifier = Modifier.weight(1f).clickable(onClick = onIgnore),
                 ) {
                     Box(modifier = Modifier.padding(vertical = 8.dp), contentAlignment = Alignment.Center) {
-                        Text("Ignore", color = Slate, fontWeight = FontWeight.Bold)
+                        Text("Ignore", color = MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = FontWeight.Bold)
                     }
                 }
                 Surface(
                     shape = RoundedCornerShape(50),
-                    color = Emerald,
+                    color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.weight(1f).clickable(onClick = onAccept),
                 ) {
                     Row(
@@ -96,9 +96,9 @@ fun RequestCard(req: PairRequest, onAccept: () -> Unit, onIgnore: () -> Unit) {
                         horizontalArrangement = Arrangement.Center,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Icon(Icons.Filled.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(18.dp))
+                        Icon(Icons.Filled.Check, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.size(18.dp))
                         Spacer(Modifier.size(6.dp))
-                        Text("Accept", color = Color.White, fontWeight = FontWeight.Bold)
+                        Text("Accept", color = MaterialTheme.colorScheme.onPrimary, fontWeight = FontWeight.Bold)
                     }
                 }
             }
@@ -110,19 +110,19 @@ fun RequestCard(req: PairRequest, onAccept: () -> Unit, onIgnore: () -> Unit) {
 fun VerifyHint() {
     Surface(
         shape = RoundedCornerShape(14.dp),
-        color = Color(0xFFFFF7ED),
-        border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFFED7AA)),
+        color = MaterialTheme.colorScheme.surface,
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.tertiary),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
             Box(
-                modifier = Modifier.size(22.dp).background(Color(0xFFFDE68A), CircleShape),
+                modifier = Modifier.size(22.dp).background(MaterialTheme.colorScheme.tertiary, CircleShape),
                 contentAlignment = Alignment.Center,
-            ) { Text("!", color = Color(0xFFB45309), fontWeight = FontWeight.ExtraBold) }
+            ) { Text("!", color = MaterialTheme.colorScheme.onTertiary, fontWeight = FontWeight.ExtraBold) }
             Spacer(Modifier.size(10.dp))
             Column {
-                Text("Names are self-chosen", color = Color(0xFF9A3412), fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelLarge)
-                Text("check it matches what they tell you out loud", color = Color(0xFFB45309), style = MaterialTheme.typography.bodySmall)
+                Text("Names are self-chosen", color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelLarge)
+                Text("check it matches what they tell you out loud", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
             }
         }
     }
@@ -132,7 +132,11 @@ fun VerifyHint() {
 @Composable
 fun PairConnectedDialog(theirName: String, onDone: () -> Unit) {
     Dialog(onDismissRequest = onDone) {
-        Surface(shape = RoundedCornerShape(24.dp), color = Color.White) {
+        Surface(
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surface,
+            border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        ) {
             Column(
                 modifier = Modifier.padding(24.dp).fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -143,40 +147,44 @@ fun PairConnectedDialog(theirName: String, onDone: () -> Unit) {
                         Avatar("Y", Color(0xFF4F46E5))
                         Avatar(theirName.firstOrNull()?.uppercase() ?: "?", Color(0xFFF59E0B))
                     }
-                    Surface(shape = CircleShape, color = Color(0xFF16A34A), border = androidx.compose.foundation.BorderStroke(3.dp, Color.White)) {
+                    Surface(
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.primary,
+                        border = androidx.compose.foundation.BorderStroke(3.dp, MaterialTheme.colorScheme.surface),
+                    ) {
                         Box(modifier = Modifier.size(34.dp), contentAlignment = Alignment.Center) {
-                            Icon(Icons.Filled.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
+                            Icon(Icons.Filled.Check, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.size(20.dp))
                         }
                     }
                 }
                 Spacer(Modifier.height(18.dp))
                 Text("You're connected", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.ExtraBold)
                 Spacer(Modifier.height(10.dp))
-                Surface(shape = RoundedCornerShape(50), color = EmeraldSoft) {
+                Surface(shape = RoundedCornerShape(50), color = MaterialTheme.colorScheme.primaryContainer) {
                     Row(
                         modifier = Modifier.padding(horizontal = 14.dp, vertical = 5.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                     ) {
-                        Icon(Icons.Filled.SwapHoriz, contentDescription = null, tint = Emerald, modifier = Modifier.size(16.dp))
-                        Text("mutual", color = EmeraldInk, fontWeight = FontWeight.ExtraBold, style = MaterialTheme.typography.labelMedium)
+                        Icon(Icons.Filled.SwapHoriz, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
+                        Text("mutual", color = MaterialTheme.colorScheme.onPrimaryContainer, fontWeight = FontWeight.ExtraBold, style = MaterialTheme.typography.labelMedium)
                     }
                 }
                 Spacer(Modifier.height(14.dp))
                 Text(
                     "You and $theirName are now in each other's circle — one tap did both. Their apps will show up in Discover.",
-                    color = Slate,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )
                 Spacer(Modifier.height(20.dp))
                 Surface(
                     shape = RoundedCornerShape(24.dp),
-                    color = Emerald,
+                    color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.fillMaxWidth().height(48.dp).clickable(onClick = onDone),
                 ) {
                     Box(contentAlignment = Alignment.Center) {
-                        Text("Done", color = Color.White, fontWeight = FontWeight.ExtraBold)
+                        Text("Done", color = MaterialTheme.colorScheme.onPrimary, fontWeight = FontWeight.ExtraBold)
                     }
                 }
             }
@@ -197,7 +205,11 @@ fun PairConnectedDialog(theirName: String, onDone: () -> Unit) {
 @Composable
 fun PairPendingDialog(theirName: String, onDone: () -> Unit) {
     Dialog(onDismissRequest = onDone) {
-        Surface(shape = RoundedCornerShape(24.dp), color = Color.White) {
+        Surface(
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surface,
+            border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        ) {
             Column(
                 modifier = Modifier.padding(24.dp).fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -209,14 +221,14 @@ fun PairPendingDialog(theirName: String, onDone: () -> Unit) {
                     }
                     Surface(
                         shape = CircleShape,
-                        color = Color(0xFFF59E0B),
-                        border = androidx.compose.foundation.BorderStroke(3.dp, Color.White),
+                        color = MaterialTheme.colorScheme.tertiary,
+                        border = androidx.compose.foundation.BorderStroke(3.dp, MaterialTheme.colorScheme.surface),
                     ) {
                         Box(modifier = Modifier.size(34.dp), contentAlignment = Alignment.Center) {
                             Icon(
                                 Icons.Filled.HourglassTop,
                                 contentDescription = null,
-                                tint = Color.White,
+                                tint = MaterialTheme.colorScheme.onTertiary,
                                 modifier = Modifier.size(18.dp),
                             )
                         }
@@ -229,7 +241,11 @@ fun PairPendingDialog(theirName: String, onDone: () -> Unit) {
                     fontWeight = FontWeight.ExtraBold,
                 )
                 Spacer(Modifier.height(10.dp))
-                Surface(shape = RoundedCornerShape(50), color = Color(0xFFFEF3C7)) {
+                Surface(
+                    shape = RoundedCornerShape(50),
+                    color = MaterialTheme.colorScheme.surface,
+                    border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.tertiary),
+                ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 14.dp, vertical = 5.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -238,12 +254,12 @@ fun PairPendingDialog(theirName: String, onDone: () -> Unit) {
                         Icon(
                             Icons.Filled.HourglassTop,
                             contentDescription = null,
-                            tint = Color(0xFFB45309),
+                            tint = MaterialTheme.colorScheme.tertiary,
                             modifier = Modifier.size(16.dp),
                         )
                         Text(
                             "waiting",
-                            color = Color(0xFF92400E),
+                            color = MaterialTheme.colorScheme.tertiary,
                             fontWeight = FontWeight.ExtraBold,
                             style = MaterialTheme.typography.labelMedium,
                         )
@@ -253,18 +269,18 @@ fun PairPendingDialog(theirName: String, onDone: () -> Unit) {
                 Text(
                     "$theirName needs to accept. If their phone isn't reachable yet, " +
                         "this keeps waiting — no need to bump again.",
-                    color = Slate,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )
                 Spacer(Modifier.height(20.dp))
                 Surface(
                     shape = RoundedCornerShape(24.dp),
-                    color = Emerald,
+                    color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.fillMaxWidth().height(48.dp).clickable(onClick = onDone),
                 ) {
                     Box(contentAlignment = Alignment.Center) {
-                        Text("Got it", color = Color.White, fontWeight = FontWeight.ExtraBold)
+                        Text("Got it", color = MaterialTheme.colorScheme.onPrimary, fontWeight = FontWeight.ExtraBold)
                     }
                 }
             }
@@ -277,8 +293,8 @@ private fun Avatar(initial: String, color: Color) {
     Box(
         modifier = Modifier
             .size(60.dp)
-            .background(Color.White, CircleShape)
-            .border(3.dp, Color(0xFFBBF7D0), CircleShape)
+            .background(MaterialTheme.colorScheme.surface, CircleShape)
+            .border(3.dp, MaterialTheme.colorScheme.primary, CircleShape)
             .padding(4.dp)
             .background(color, CircleShape),
         contentAlignment = Alignment.Center,

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -65,7 +65,7 @@ import app.myco.ui.RadioWarning
 import app.myco.ui.ScreenHeader
 import app.myco.ui.SectionCard
 import app.myco.ui.radioWarnings
-import app.myco.ui.theme.Slate
+
 
 /** The Settings surfaces: the root list and its three drill-in sub-pages. */
 private enum class SettingsPage { Root, Identity, Storage, Developer }
@@ -281,7 +281,7 @@ private fun RootSettings(
         }
         Text(
             "Myco ${state.appVersion}",
-            color = Slate,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.bodySmall,
             modifier = Modifier.padding(top = 8.dp, start = 4.dp),
         )
@@ -308,7 +308,7 @@ private fun IdentitySettings(state: AppState, client: AppCoreClient, onBack: () 
                 Text(
                     "Nearby devices see this name when you pair, so they can confirm " +
                         "they're connecting to the right device.",
-                    color = Slate,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodySmall,
                 )
                 OutlinedTextField(
@@ -378,7 +378,7 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
                 Text(
                     "${humanBytes(used)} of 2 GB · ${humanBytes(free)} free · " +
                         "${state.cache.blobCount} blobs · ${state.cache.relayEvents} events",
-                    color = Slate,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodySmall,
                 )
             }
@@ -644,9 +644,9 @@ private fun SettingRow(
         }
         Column(modifier = Modifier.weight(1f)) {
             Text(title, color = titleColor, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.titleMedium)
-            Text(subtitle, color = Slate, style = MaterialTheme.typography.bodySmall)
+            Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
         }
-        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = Slate)
+        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 
@@ -659,7 +659,7 @@ private fun ToggleRow(
     onToggle: (Boolean) -> Unit,
     enabled: Boolean = true,
 ) {
-    val contentColor = if (enabled) MaterialTheme.colorScheme.onSurface else Slate
+    val contentColor = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -668,7 +668,7 @@ private fun ToggleRow(
         Spacer(Modifier.size(14.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(title, color = contentColor, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.titleMedium)
-            Text(subtitle, color = Slate, style = MaterialTheme.typography.bodySmall)
+            Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
         }
         Switch(checked = checked, onCheckedChange = onToggle, enabled = enabled)
     }
@@ -681,16 +681,16 @@ private fun SoonRow(icon: ImageVector, title: String, subtitle: String) {
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        LeadingIcon(icon, tint = Slate)
+        LeadingIcon(icon, tint = MaterialTheme.colorScheme.onSurfaceVariant)
         Spacer(Modifier.size(14.dp))
         Column(modifier = Modifier.weight(1f)) {
-            Text(title, color = Slate, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.titleMedium)
-            Text(subtitle, color = Slate, style = MaterialTheme.typography.bodySmall)
+            Text(title, color = MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.titleMedium)
+            Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
         }
         Surface(shape = RoundedCornerShape(8.dp), color = MaterialTheme.colorScheme.surface) {
             Text(
                 "SOON",
-                color = Slate,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontWeight = FontWeight.Bold,
                 style = MaterialTheme.typography.labelSmall,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
@@ -719,7 +719,7 @@ private fun RowDivider() {
 @Composable
 private fun IdField(label: String, value: String) {
     Column {
-        Text(label, color = Slate, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.labelMedium)
+        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.labelMedium)
         Text(
             value.ifEmpty { "—" },
             style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),

--- a/android/app/src/main/java/app/myco/ui/screens/SheetComponents.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SheetComponents.kt
@@ -86,8 +86,8 @@ internal fun PasteCodeButton(label: String, onPaste: (String) -> Unit) {
     val context = LocalContext.current
     Surface(
         shape = RoundedCornerShape(14.dp),
-        color = Color.White,
-        border = BorderStroke(1.dp, Color(0xFFCBD5E1)),
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
         modifier = Modifier.fillMaxWidth().height(48.dp).clickable {
             val text = clipboard.getText()?.text?.trim().orEmpty()
             if (text.isNotEmpty()) onPaste(text)
@@ -99,9 +99,9 @@ internal fun PasteCodeButton(label: String, onPaste: (String) -> Unit) {
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Icon(Icons.Filled.ContentPaste, contentDescription = null, tint = Color(0xFF334155), modifier = Modifier.size(18.dp))
+            Icon(Icons.Filled.ContentPaste, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(18.dp))
             Spacer(Modifier.size(8.dp))
-            Text(label, color = Color(0xFF334155), fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelLarge)
+            Text(label, color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelLarge)
         }
     }
 }

--- a/android/app/src/main/java/app/myco/ui/theme/Theme.kt
+++ b/android/app/src/main/java/app/myco/ui/theme/Theme.kt
@@ -1,7 +1,10 @@
 package app.myco.ui.theme
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -30,6 +33,15 @@ val Hairline = Color(0xFFE7E9EE)
 val CardBg = Color(0xFFF4F5F7)
 val ScreenBg = Color(0xFFFFFFFF)
 
+/** Bright emerald retained as the primary brand accent on AMOLED black. */
+val AmoledAccent = Color(0xFF34D399)
+private val LightWarning = Color(0xFFB45309)
+private val LightWarningContainer = Color(0xFFFFF7ED)
+private val LightOnWarningContainer = Color(0xFF9A3412)
+private val AmoledWarning = Color(0xFFFFB74D)
+private val AmoledOutline = Color(0xFF3F3F46)
+private val AmoledError = Color(0xFFFF6B6B)
+
 private val MycoLightColors = lightColorScheme(
     primary = Emerald,
     onPrimary = Color.White,
@@ -39,6 +51,10 @@ private val MycoLightColors = lightColorScheme(
     onSecondary = Color.White,
     secondaryContainer = IndigoSoft,
     onSecondaryContainer = IndigoInk,
+    tertiary = LightWarning,
+    onTertiary = Color.White,
+    tertiaryContainer = LightWarningContainer,
+    onTertiaryContainer = LightOnWarningContainer,
     background = ScreenBg,
     onBackground = Ink,
     surface = ScreenBg,
@@ -49,6 +65,44 @@ private val MycoLightColors = lightColorScheme(
     outlineVariant = Hairline,
     error = Color(0xFFDC2626),
 )
+
+private val MycoAmoledColors = darkColorScheme(
+    primary = AmoledAccent,
+    onPrimary = Color.Black,
+    primaryContainer = Color.Black,
+    onPrimaryContainer = AmoledAccent,
+    secondary = Color(0xFFA5B4FC),
+    onSecondary = Color.Black,
+    secondaryContainer = Color.Black,
+    onSecondaryContainer = Color(0xFFA5B4FC),
+    tertiary = AmoledWarning,
+    onTertiary = Color.Black,
+    tertiaryContainer = Color.Black,
+    onTertiaryContainer = AmoledWarning,
+    background = Color.Black,
+    onBackground = Color.White,
+    surface = Color.Black,
+    onSurface = Color.White,
+    surfaceVariant = Color.Black,
+    onSurfaceVariant = Color.White,
+    surfaceDim = Color.Black,
+    surfaceBright = Color.Black,
+    surfaceContainerLowest = Color.Black,
+    surfaceContainerLow = Color.Black,
+    surfaceContainer = Color.Black,
+    surfaceContainerHigh = Color.Black,
+    surfaceContainerHighest = Color.Black,
+    surfaceTint = Color.Black,
+    outline = AmoledOutline,
+    outlineVariant = AmoledOutline,
+    error = AmoledError,
+    onError = Color.Black,
+    errorContainer = Color.Black,
+    onErrorContainer = AmoledError,
+)
+
+internal fun mycoColorScheme(darkTheme: Boolean): ColorScheme =
+    if (darkTheme) MycoAmoledColors else MycoLightColors
 
 /** Vibrant tile colors for nsite icons, assigned deterministically by host. */
 val TilePalette = listOf(
@@ -81,8 +135,13 @@ private val MycoTypography = Typography(
 )
 
 @Composable
-fun MycoTheme(content: @Composable () -> Unit) {
-    // Light-only for now: the mockups are light, and a fixed scheme is the most
-    // consistent choice across API levels.
-    MaterialTheme(colorScheme = MycoLightColors, typography = MycoTypography, content = content)
+fun MycoTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    MaterialTheme(
+        colorScheme = mycoColorScheme(darkTheme),
+        typography = MycoTypography,
+        content = content,
+    )
 }

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Keep the hand-off from the black splash to Compose black in system dark
+         mode. Compose owns the content colors; these values prevent a white
+         window flash and keep pre-Compose system-bar icons legible. -->
+    <style name="Theme.Myco" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:statusBarColor">@android:color/black</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+</resources>

--- a/android/app/src/test/java/app/myco/ui/theme/ThemeTest.kt
+++ b/android/app/src/test/java/app/myco/ui/theme/ThemeTest.kt
@@ -1,0 +1,45 @@
+package app.myco.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThemeTest {
+    @Test
+    fun `dark scheme is pure AMOLED black with white content and brand accent`() {
+        val colors = mycoColorScheme(darkTheme = true)
+
+        assertEquals(Color.Black, colors.background)
+        assertEquals(Color.Black, colors.surface)
+        assertEquals(Color.Black, colors.surfaceVariant)
+        assertEquals(Color.Black, colors.surfaceDim)
+        assertEquals(Color.Black, colors.surfaceBright)
+        assertEquals(Color.Black, colors.surfaceContainerLowest)
+        assertEquals(Color.Black, colors.surfaceContainerLow)
+        assertEquals(Color.Black, colors.surfaceContainer)
+        assertEquals(Color.Black, colors.surfaceContainerHigh)
+        assertEquals(Color.Black, colors.surfaceContainerHighest)
+        assertEquals(Color.Black, colors.surfaceTint)
+        assertEquals(Color.White, colors.onBackground)
+        assertEquals(Color.White, colors.onSurface)
+        assertEquals(Color.White, colors.onSurfaceVariant)
+        assertEquals(AmoledAccent, colors.primary)
+        assertEquals(Color.Black, colors.onPrimary)
+        assertEquals(Color(0xFFFFB74D), colors.tertiary)
+        assertEquals(Color.Black, colors.onTertiary)
+        assertEquals(Color.Black, colors.tertiaryContainer)
+        assertEquals(Color(0xFFFFB74D), colors.onTertiaryContainer)
+    }
+
+    @Test
+    fun `light scheme remains the existing brand palette`() {
+        val colors = mycoColorScheme(darkTheme = false)
+
+        assertEquals(ScreenBg, colors.background)
+        assertEquals(Ink, colors.onBackground)
+        assertEquals(CardBg, colors.surfaceVariant)
+        assertEquals(Emerald, colors.primary)
+        assertEquals(Color(0xFFB45309), colors.tertiary)
+        assertEquals(Color.White, colors.onTertiary)
+    }
+}


### PR DESCRIPTION
## Summary

- follow the Android system theme and use pure `#000000` for dark backgrounds, surfaces, elevated containers, and launch-window handoff
- replace fixed light UI colors with Material 3 semantic roles while preserving a white QR card for scanner reliability
- keep emerald as the primary brand accent and retain distinct, accessible amber warning/pending states
- make edge-to-edge system-bar icons adapt to light and dark mode
- add theme palette unit tests and run them in CI

## Validation

- `./gradlew :app:testDebugUnitTest --no-daemon` — 2 passed
- full native + Android `:app:assembleDebug` — passed
- `cargo fmt --all --check` — passed
- `git diff --check` — passed
- independent follow-up review — PASS, no blocking findings
- [fork CI](https://github.com/Datawav/myco/actions/runs/30767311917) — Rust fmt/clippy/tests and Android unit tests/assembleDebug passed

Upstream CI is waiting for a maintainer to approve the first workflow run from this fork: [run 30767322057](https://github.com/Origami74/myco/actions/runs/30767322057). Android lint still reports three pre-existing permission/manifest errors outside this diff.