### PR TITLE
First-run intro: grow the mark, dive through the pupil into the app

### DIFF
--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -246,9 +246,14 @@ rather than inventing new ones:
 | `StatusThin` | Exactly one peer — works, but no redundancy |
 | `StatusAlone` | No peers; a real fault state |
 
-Two deliberate exceptions to theme-following: the QR card stays white in both
-themes (scanners read dark-on-light far more reliably), and pending/warning
-states keep a distinct amber rather than collapsing into the theme's accent.
+Three deliberate exceptions to theme-following: the QR card stays white in both
+themes (scanners read dark-on-light far more reliably), pending/warning states
+keep a distinct amber rather than collapsing into the theme's accent, and the
+first-run intro (`ui/intro/`) draws its mark in fixed cyan on near-black. The
+intro runs before any app chrome and owns the whole screen, so it has nothing
+to sit against and no light-mode variant to render — those are the logo's own
+colours rather than a colour choice, and they live as the `Mark*` constants in
+`Theme.kt`, next to the peer-state ones.
 
 `ThemeTest.kt` asserts palette invariants and runs in CI, so a new screen that
 reaches past the colour scheme will be caught there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each time. Previously every change looked like a brand-new device dialling
   in, and with a connection limit of seven those duplicates could crowd out
   peers you were actually talking to.
+- A first-run intro. A spark appears, mycelial filaments grow out of it into
+  the Myco mark, and the ring closes around them; the mark then breathes while
+  it waits. Tapping anywhere opens a pupil in the middle of it, which contracts
+  and dilates the way a real one does before the camera falls into it and the
+  app is there. The pupil is a hole rather than a black disc, so the app itself
+  shows through it: frosted at first, clearing as the dive starts. It plays in
+  full on first launch only; later launches take a shorter path straight into
+  the dive, and Settings has a developer control to play it again. The mark is
+  generated at runtime rather than shipped as an asset — one quadrant of
+  branching filaments drawn four times, which is where the logo's fourfold
+  symmetry comes from. Geometry is covered by unit tests that run in CI.
 
 ## [0.4.2] - 2026-08-04
 

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -24,6 +24,17 @@ import android.os.SystemClock
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.unit.dp
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions
@@ -43,6 +54,8 @@ import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
 import app.myco.share.NsiteShare
 import app.myco.ui.MycoApp
+import app.myco.ui.intro.IntroMode
+import app.myco.ui.intro.IntroScreen
 import app.myco.ui.theme.MycoTheme
 import app.myco.vpn.MycoVpnService
 import kotlinx.coroutines.Dispatchers
@@ -137,22 +150,64 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             MycoTheme {
-                MycoApp(
-                    client = core,
-                    onBleToggle = { enabled -> setBleEnabled(enabled) },
-                    wifiAwareSupported = AwareRadio.isSupported(this),
-                    onWifiAwareToggle = { enabled -> setWifiAwareEnabled(enabled) },
-                    onLaunchNsite = { hostLabel, title -> launchNsite(hostLabel, title) },
-                    onPinToHome = { hostLabel, title -> pinToHomeScreen(hostLabel, title) },
-                    onScanned = { text -> handleScannedText(text) },
-                    initialMeshEnabled = prefs.getBoolean(PREF_MESH, true),
-                    onMeshToggle = { enabled -> setMeshEnabled(enabled) },
-                    onOfflineOnlyToggle = { enabled -> setOfflineOnly(enabled) },
-                    initialDeveloperMode = prefs.getBoolean(PREF_DEV, BuildConfig.DEBUG),
-                    onDeveloperModeToggle = { enabled -> prefs.edit().putBoolean(PREF_DEV, enabled).apply() },
-                    initialExitProxy = prefs.getString(PREF_EXIT_PROXY, "").orEmpty(),
-                    onExitProxyChange = { spec -> setExitProxy(spec) },
-                )
+                // The intro is an overlay, not a nav destination: the app is
+                // composed and laid out underneath it from the first frame. The
+                // pupil is a hole in that overlay, so the app is what shows
+                // through it — live, from the moment it opens — and the dive is
+                // that hole growing until there is no overlay left to see. A
+                // nav destination would have had nothing behind it to reveal.
+                // The full sequence is a first-launch event; after that the
+                // intro is only the dive, so it never stands between someone
+                // and the app they opened. Reset it from Dev.
+                val introMode = remember {
+                    if (prefs.getBoolean(PREF_INTRO_SEEN, false)) {
+                        IntroMode.Returning
+                    } else {
+                        IntroMode.FirstRun
+                    }
+                }
+                var introShowing by rememberSaveable { mutableStateOf(true) }
+                // How frosted the pupil is. The intro washes the hole itself;
+                // this blurs what shows through it by the same amount, so
+                // early on you can see there is something behind the mark
+                // without being able to read it. Modifier.blur is a no-op
+                // below API 31, where the wash carries it alone.
+                var frost by remember { mutableFloatStateOf(if (introShowing) 1f else 0f) }
+
+                Box(Modifier.fillMaxSize()) {
+                    Box(Modifier.blur(14.dp * frost)) {
+                        MycoApp(
+                            client = core,
+                            onBleToggle = { enabled -> setBleEnabled(enabled) },
+                            wifiAwareSupported = AwareRadio.isSupported(this@MainActivity),
+                            onWifiAwareToggle = { enabled -> setWifiAwareEnabled(enabled) },
+                            onLaunchNsite = { hostLabel, title -> launchNsite(hostLabel, title) },
+                            onPinToHome = { hostLabel, title -> pinToHomeScreen(hostLabel, title) },
+                            onScanned = { text -> handleScannedText(text) },
+                            initialMeshEnabled = prefs.getBoolean(PREF_MESH, true),
+                            onMeshToggle = { enabled -> setMeshEnabled(enabled) },
+                            onOfflineOnlyToggle = { enabled -> setOfflineOnly(enabled) },
+                            initialDeveloperMode = prefs.getBoolean(PREF_DEV, BuildConfig.DEBUG),
+                            onDeveloperModeToggle = { enabled -> prefs.edit().putBoolean(PREF_DEV, enabled).apply() },
+                            initialExitProxy = prefs.getString(PREF_EXIT_PROXY, "").orEmpty(),
+                            onExitProxyChange = { spec -> setExitProxy(spec) },
+                            onReplayIntro = {
+                                prefs.edit().putBoolean(PREF_INTRO_SEEN, false).apply()
+                            },
+                        )
+                    }
+
+                    if (introShowing) {
+                        IntroScreen(
+                            mode = introMode,
+                            onFrost = { frost = it },
+                            onFinished = {
+                                introShowing = false
+                                prefs.edit().putBoolean(PREF_INTRO_SEEN, true).apply()
+                            },
+                        )
+                    }
+                }
             }
         }
 
@@ -573,5 +628,7 @@ class MainActivity : ComponentActivity() {
         private const val HOME_OFFER_TIMEOUT_MS = 3 * 60 * 1000L
         private const val HOME_OFFER_POLL_MS = 1500L
         const val PREF_EXIT_PROXY = "exit_proxy"
+        /** Set once the intro has played all the way through. */
+        const val PREF_INTRO_SEEN = "intro_seen"
     }
 }

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -114,6 +114,8 @@ fun MycoApp(
     onDeveloperModeToggle: (Boolean) -> Unit,
     initialExitProxy: String = "",
     onExitProxyChange: (String) -> Unit = {},
+    /** Clears the intro's "already seen" flag so it plays in full again. */
+    onReplayIntro: () -> Unit = {},
 ) {
     var state by remember { mutableStateOf(client.state()) }
     // Mesh toggle is hoisted here so it survives tab switches.
@@ -266,6 +268,7 @@ fun MycoApp(
                         bleExhausted = bleExhausted,
                         initialExitProxy = initialExitProxy,
                         onExitProxyChange = onExitProxyChange,
+                        onReplayIntro = onReplayIntro,
                     )
                 }
                 composable("dev") { DevScreen(state, client) }

--- a/android/app/src/main/java/app/myco/ui/intro/IntroScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/intro/IntroScreen.kt
@@ -1,0 +1,587 @@
+package app.myco.ui.intro
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathMeasure
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.Text
+import app.myco.ui.theme.MarkBright
+import app.myco.ui.theme.MarkFilament
+import app.myco.ui.theme.MarkGround
+import app.myco.ui.theme.MarkNodeColor
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.sin
+
+/**
+ * The first-run intro: a spark, roots growing out of it into the Myco mark,
+ * the ring closing, and — on a tap — a pupil opening in the middle of the mark
+ * that the camera then falls into.
+ *
+ * The pupil is a hole in the intro, not a black disc: the ground is drawn
+ * inside the same off-screen layer the hole is punched through, so whatever is
+ * composed underneath — the app itself — shows through it from the moment it
+ * opens. Diving is then literally that hole growing until it is the whole
+ * screen, at which point [onFinished] fires and the overlay comes off.
+ *
+ * Until the dive starts the hole is frosted rather than clear: a wash of the
+ * ground is laid back over it, and [onFrost] reports how much, so the caller
+ * can blur what it has composed underneath by the same amount. You can see
+ * that there is something behind the mark long before you can read it.
+ *
+ * The growing and the waiting are a first-launch event. On every launch after
+ * that [IntroMode.Returning] keeps the pupil and drops everything in front of
+ * it, so what is otherwise a piece of theatre stays out of the way of someone
+ * who just wants to open the app.
+ *
+ * ### How it is driven
+ *
+ * One clock, in seconds, advanced from `withFrameNanos`, and every beat is a
+ * window on it (see [phase]). That mirrors the timeline this was designed
+ * against and keeps the whole thing seekable — hand [elapsed] a different
+ * starting value and you land mid-animation, which is how it was tuned.
+ */
+enum class IntroMode {
+    /** The whole thing: the mark grows, then waits to be tapped. */
+    FirstRun,
+
+    /** Straight to the pupil, and quicker. Roughly two seconds, start to app. */
+    Returning,
+}
+
+@Composable
+fun IntroScreen(
+    modifier: Modifier = Modifier,
+    mode: IntroMode = IntroMode.FirstRun,
+    /** 1 while the pupil is frosted, easing to 0 as the dive clears it. */
+    onFrost: (Float) -> Unit = {},
+    onFinished: () -> Unit,
+) {
+    val returning = mode == IntroMode.Returning
+    val mark = remember { buildMycoMark() }
+    val tendril = remember { buildTendril() }
+    val markPaths = remember(mark) { mark.segments.map { it.toPath() } }
+    val markLengths = remember(markPaths) { markPaths.map { it.measuredLength() } }
+    val tendrilPaths = remember(tendril) { tendril.segments.map { it.toPath() } }
+    val tendrilLengths = remember(tendrilPaths) { tendrilPaths.map { it.measuredLength() } }
+
+    // Growth schedule: generation g starts GEN_STEP after g-1. Within a
+    // generation each filament is nudged a little further along so the front
+    // goes ragged, but the nudge is capped — generations roughly double in
+    // size, so an uncapped per-element stagger leaves the outermost few
+    // hundred fibres trickling in seconds after the rest of the mark is done.
+    val markStarts = remember(mark) { mark.segments.growthOffsets() }
+
+    // Returning: the mark is already fully grown on the first frame, and it is
+    // already going in.
+    var elapsed by remember { mutableFloatStateOf(if (returning) MARK_SETTLED else 0f) }
+    var diveAt by remember { mutableStateOf(if (returning) MARK_SETTLED else null) }
+    var finished by remember { mutableStateOf(false) }
+
+    val finish by rememberUpdatedState(onFinished)
+    val frosted by rememberUpdatedState(onFrost)
+
+    LaunchedEffect(Unit) {
+        var last = withFrameNanos { it }
+        while (!finished) {
+            val now = withFrameNanos { it }
+            elapsed += (now - last) / 1_000_000_000f
+            last = now
+
+            // No auto-start: on first launch it waits as long as it takes.
+            frosted(frost(diveClock(diveAt, elapsed, returning)))
+
+            if (diveClock(diveAt, elapsed, returning).let { it != null && it >= DIVE_END }) {
+                finished = true
+                finish()
+            }
+        }
+    }
+
+    val dive = diveClock(diveAt, elapsed, returning)
+    val pupil = pupilRadius(dive)
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures { if (diveAt == null) diveAt = elapsed }
+            },
+    ) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                // Ground and mark are drawn together in one off-screen layer
+                // so a single Clear punches through both, leaving a genuine
+                // window rather than a black disc. Working the retraction out
+                // per filament instead is cheaper and wrong twice over: it
+                // cannot make the ground transparent, and a filament that bows
+                // inward mid-curve reads as outside the pupil on its endpoints,
+                // leaving a bead of itself floating in the hole.
+                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+        ) {
+            Canvas(Modifier.fillMaxSize()) {
+                drawRect(MarkGround)
+
+                val fit = min(size.width, size.height) / MARK_VIEWPORT
+                val zoom = fit * MARK_FILL * diveZoom(dive)
+                val breath = 1f + 0.05f * breathPhase(elapsed, dive)
+                val dim = 1f - 0.28f * breathPhase(elapsed, dive)
+
+                translate(size.width / 2f, size.height / 2f) {
+                    scale(zoom * breath, zoom * breath, Offset.Zero) {
+                        translate(-MARK_CENTER, -MARK_CENTER) {
+                            drawMark(
+                                mark = mark,
+                                paths = markPaths,
+                                lengths = markLengths,
+                                starts = markStarts,
+                                elapsed = elapsed,
+                                dive = dive,
+                                pupil = pupil,
+                                dim = dim,
+                            )
+                        }
+                    }
+                }
+
+                // …and the hole, punched through ground and mark alike.
+                if (pupil > 0f) {
+                    drawCircle(
+                        color = Color.Transparent,
+                        radius = pupil * zoom,
+                        center = center,
+                        blendMode = BlendMode.Clear,
+                    )
+                    // Frost: a wash of the ground laid back over the hole, so
+                    // early on it reads as something seen through the mark
+                    // rather than a window straight onto the app. It clears as
+                    // the dive starts.
+                    val haze = frost(dive)
+                    if (haze > 0f) {
+                        drawCircle(
+                            color = MarkGround.copy(alpha = 0.62f * haze),
+                            radius = pupil * zoom,
+                            center = center,
+                        )
+                    }
+                }
+            }
+        }
+
+        IdlePrompt(
+            elapsed = elapsed,
+            diving = dive != null,
+            tendril = tendril,
+            paths = tendrilPaths,
+            lengths = tendrilLengths,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+// ── the mark ────────────────────────────────────────────────────────────────
+
+private fun DrawScope.drawMark(
+    mark: MycoMark,
+    paths: List<Path>,
+    lengths: List<Float>,
+    starts: List<Float>,
+    elapsed: Float,
+    dive: Float?,
+    pupil: Float,
+    dim: Float,
+) {
+    // Filaments stop at the ring rather than straggling past it.
+    val bound = Path().apply {
+        addOval(
+            Rect(
+                MARK_CENTER - MARK_RING_RADIUS,
+                MARK_CENTER - MARK_RING_RADIUS,
+                MARK_CENTER + MARK_RING_RADIUS,
+                MARK_CENTER + MARK_RING_RADIUS,
+            ),
+        )
+    }
+
+    val fade = dive?.let { 1f - phase(it, FILAMENT_FADE_AT, FILAMENT_FADE_FOR) } ?: 1f
+    if (fade <= 0f) return
+
+    clipPath(bound) {
+        // One quadrant, drawn four times. This is the <use rotate(90/180/270)>
+        // of the original: a quarter of the geometry, all of the symmetry.
+        for (turn in 0 until 4) {
+            rotate(turn * 90f, Offset(MARK_CENTER, MARK_CENTER)) {
+                mark.segments.forEachIndexed { i, segment ->
+                    val drawn = phase(elapsed, starts[i], GEN_DRAW)
+                    if (drawn <= 0f) return@forEachIndexed
+
+                    val head = paths[i].head(drawn.easeOutQuad(), lengths[i]) ?: return@forEachIndexed
+                    val colour = if (segment.bright) MarkBright else MarkFilament
+                    val alpha = segment.alpha * dim * fade
+
+                    // Bloom without a blur filter: a wide translucent pass
+                    // under a narrow bright one. Cheaper than a real
+                    // BlurMaskFilter and survives hardware layers.
+                    if (segment.bright) {
+                        drawPath(
+                            path = head,
+                            color = colour,
+                            alpha = alpha * 0.22f,
+                            style = Stroke(width = segment.strokeWidth * 3.2f, cap = ROUND),
+                        )
+                    }
+                    drawPath(
+                        path = head,
+                        color = colour,
+                        alpha = alpha,
+                        style = Stroke(width = segment.strokeWidth, cap = ROUND),
+                    )
+                }
+
+                // Nutrients running the spines, once the mark is mostly there.
+                val pulse = pulsePhase(elapsed, dive)
+                if (pulse != null) {
+                    mark.spineIndices.forEach { i ->
+                        val seg = paths[i].segment(pulse, min(pulse + 0.22f, 1f), lengths[i])
+                            ?: return@forEach
+                        drawPath(
+                            path = seg,
+                            color = Color.White,
+                            alpha = 0.85f * fade,
+                            style = Stroke(width = 2.6f, cap = ROUND),
+                        )
+                    }
+                }
+
+                mark.nodes.forEach { node ->
+                    val appeared = phase(elapsed, NODE_AT, 0.26f)
+                    if (appeared <= 0f) return@forEach
+                    // The pupil pushes the nodes out ahead of itself rather
+                    // than swallowing them; +7 keeps them clear of the cut.
+                    val distance = max(node.distance, pupil + 7f)
+                    drawCircle(
+                        color = MarkNodeColor,
+                        radius = node.radius * appeared.easeOutBack() * fade,
+                        center = Offset(
+                            MARK_CENTER + kotlin.math.cos(node.angle) * distance,
+                            MARK_CENTER + kotlin.math.sin(node.angle) * distance,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    // The ring, closing as the growth reaches the rim.
+    val ring = phase(elapsed, RING_AT, RING_FOR)
+    if (ring > 0f) {
+        val ringFade = dive?.let { 1f - phase(it, RING_FADE_AT, 0.9f) } ?: 1f
+        drawArc(
+            color = MarkFilament,
+            startAngle = -90f,
+            sweepAngle = 360f * ring.easeInOutQuad(),
+            useCenter = false,
+            topLeft = Offset(MARK_CENTER - MARK_RING_RADIUS, MARK_CENTER - MARK_RING_RADIUS),
+            size = Size(MARK_RING_RADIUS * 2, MARK_RING_RADIUS * 2),
+            alpha = 0.85f * dim * ringFade * fade,
+            style = Stroke(width = 2.5f),
+        )
+    }
+
+    // The spark, before the pupil takes its place.
+    val spark = phase(elapsed, 0f, 0.35f)
+    val sparkOut = dive?.let { 1f - phase(it, 0f, 0.45f) } ?: 1f
+    if (spark > 0f && sparkOut > 0f) {
+        drawCircle(
+            color = MarkNodeColor,
+            radius = 10f * spark.easeOutBack(),
+            center = Offset(MARK_CENTER, MARK_CENTER),
+            alpha = sparkOut,
+        )
+    }
+
+    // The pupil's edge. Radius and fade both come off the pupil radius, so it
+    // can never drift off the cut.
+    if (pupil > 0f) {
+        drawCircle(
+            color = MarkNodeColor,
+            radius = pupil,
+            center = Offset(MARK_CENTER, MARK_CENTER),
+            alpha = min(pupil / 35f, 1f) * 0.75f * fade,
+            style = Stroke(width = 1.2f),
+        )
+    }
+}
+
+// ── the idle prompt ─────────────────────────────────────────────────────────
+
+@Composable
+private fun IdlePrompt(
+    elapsed: Float,
+    diving: Boolean,
+    tendril: MycoMark,
+    paths: List<Path>,
+    lengths: List<Float>,
+    modifier: Modifier = Modifier,
+) {
+    // Follows the mark rather than waiting on a timer of its own.
+    val shown = phase(elapsed, PROMPT_AT, 0.45f)
+    if (shown <= 0f || diving) return
+
+    val words = phase(elapsed, PROMPT_AT + 0.28f, 0.45f)
+    // Then it just breathes, waiting.
+    val breathing = if (words >= 1f) 0.72f + 0.28f * (0.5f + 0.5f * sin(elapsed * 2.2f)) else words
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Canvas(
+            Modifier
+                .fillMaxWidth(0.5f)
+                // Sized off the tendril's own proportions. Fixing the height
+                // independently of the width let the sprig scale past the
+                // bottom of its canvas and grow down over the words.
+                .aspectRatio(TENDRIL_WIDTH / TENDRIL_HEIGHT),
+        ) {
+            // Fit both ways, so a wide phone cannot scale it taller than the
+            // box it was given either.
+            val fit = min(size.width / TENDRIL_WIDTH, size.height / TENDRIL_HEIGHT)
+            scale(fit, fit, Offset.Zero) {
+                tendril.segments.forEachIndexed { i, segment ->
+                    val drawn = phase(elapsed, PROMPT_AT + segment.generation * 0.1f, 0.3f)
+                    if (drawn <= 0f) return@forEachIndexed
+                    val head = paths[i].head(drawn.easeOutQuad(), lengths[i]) ?: return@forEachIndexed
+                    drawPath(
+                        path = head,
+                        color = MarkFilament,
+                        alpha = segment.alpha,
+                        style = Stroke(width = segment.strokeWidth, cap = ROUND),
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(14.dp))
+
+        Text(
+            text = "tap to start",
+            style = TextStyle(
+                color = MarkBright,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Normal,
+                letterSpacing = 4.4.sp,
+                textAlign = TextAlign.Center,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 56.dp)
+                .graphicsLayer { alpha = breathing },
+        )
+    }
+}
+
+// ── the clock ───────────────────────────────────────────────────────────────
+//
+// Every beat below is app-relative seconds. They were tuned as a timeline, so
+// they read as one: change a number here and only that beat moves.
+
+private const val GEN_STEP = 0.21f          // gap between generations
+private const val GEN_DRAW = 0.45f          // how long one filament takes to draw
+private const val GEN_SPREAD_CAP = 1.2f     // ceiling on within-generation stagger
+private const val GROWTH_AT = 0.2f
+private const val NODE_AT = 0.75f
+private const val RING_AT = 1.15f
+private const val RING_FOR = 0.75f
+private const val PULSE_AT = 1.95f
+
+/** When the mark is done and the prompt follows it. */
+private const val PROMPT_AT = 2.55f
+private const val MARK_SETTLED = PROMPT_AT
+
+private const val BREATH_PERIOD = 4.6f      // a full in-and-out
+
+// Dive-relative, from the moment of the tap.
+private const val PUPIL_OPEN_AT = 0.25f
+private const val PUPIL_OPEN_FOR = 1.5f
+private const val PUPIL_OPEN_TO = 112f
+private const val CONSTRICT_AT = 1.8f
+private const val CONSTRICT_FOR = 0.28f
+private const val CONSTRICT_TO = 72f
+private const val DILATE_AT = 2.12f
+private const val DILATE_FOR = 1.05f
+private const val DILATE_TO = 100f
+/** Where a returning launch joins the dive, and how much faster it runs. */
+private const val RETURNING_FROM = 2.55f
+private const val RETURNING_SPEED = 1.6f
+
+private const val FROST_CLEARS_AT = 2.9f
+private const val FROST_CLEARS_FOR = 0.8f
+private const val DIVE_AT = 3.3f
+private const val DIVE_FOR = 2.2f
+private const val DIVE_TO = 175f
+private const val DIVE_ZOOM = 15f
+private const val RING_FADE_AT = 3.8f
+private const val FILAMENT_FADE_AT = 4.0f
+private const val FILAMENT_FADE_FOR = 1.6f
+private const val DIVE_END = 5.6f
+
+/** How much of the viewport the mark fills. */
+private const val MARK_FILL = 1.22f
+
+/**
+ * Progress through a window: 0 before [start], 1 after `start + duration`.
+ * The timeline is nothing but a stack of these.
+ */
+private fun phase(now: Float, start: Float, duration: Float): Float =
+    ((now - start) / duration).coerceIn(0f, 1f)
+
+private fun List<MarkSegment>.growthOffsets(): List<Float> {
+    val perGeneration = groupingBy { it.generation }.eachCount()
+    val seen = mutableMapOf<Int, Int>()
+    return map { segment ->
+        val index = seen.merge(segment.generation, 1, Int::plus)!! - 1
+        val count = perGeneration.getValue(segment.generation)
+        val spread = min(count * GEN_DRAW * 0.14f, GEN_SPREAD_CAP)
+        GROWTH_AT + segment.generation * GEN_STEP + spread * (index.toFloat() / count)
+    }
+}
+
+private fun pupilRadius(dive: Float?): Float {
+    if (dive == null) return 0f
+    var r = PUPIL_OPEN_TO * phase(dive, PUPIL_OPEN_AT, PUPIL_OPEN_FOR).easeInOutQuad()
+    // Constriction is fast and dilation is slow. That asymmetry is most of
+    // what makes it read as an eye rather than a circle.
+    val constrict = phase(dive, CONSTRICT_AT, CONSTRICT_FOR).easeOutQuart()
+    if (constrict > 0f) r = lerp(r, CONSTRICT_TO, constrict)
+    val dilate = phase(dive, DILATE_AT, DILATE_FOR)
+    if (dilate > 0f) r = lerp(r, DILATE_TO, dilate)
+    val swallow = phase(dive, DIVE_AT, DIVE_FOR).easeInQuad()
+    if (swallow > 0f) r = lerp(r, DIVE_TO, swallow)
+    return r
+}
+
+/**
+ * Where the dive is up to, or null before it starts.
+ *
+ * Returning runs the same schedule from [RETURNING_FROM] — past the pupil
+ * opening and its light response, which are only worth watching once — and
+ * runs it faster. One timeline, two ways through it, rather than a second
+ * animation to keep in step with the first.
+ */
+private fun diveClock(diveAt: Float?, elapsed: Float, returning: Boolean): Float? {
+    val start = diveAt ?: return null
+    val t = elapsed - start
+    return if (returning) RETURNING_FROM + t * RETURNING_SPEED else t
+}
+
+/**
+ * How frosted the pupil is: solid until the dive, then gone by the time the
+ * hole starts running away with itself.
+ */
+private fun frost(dive: Float?): Float {
+    if (dive == null) return 1f
+    return 1f - phase(dive, FROST_CLEARS_AT, FROST_CLEARS_FOR)
+}
+
+private fun diveZoom(dive: Float?): Float {
+    if (dive == null) return 1f
+    return lerp(1f, DIVE_ZOOM, phase(dive, DIVE_AT, DIVE_FOR).easeInQuad())
+}
+
+/** −1…1, the mark's slow in-and-out once it has settled. Still during the dive. */
+private fun breathPhase(elapsed: Float, dive: Float?): Float {
+    if (dive != null) return 0f
+    val settled = phase(elapsed, MARK_SETTLED, BREATH_PERIOD * 0.4f)
+    if (settled <= 0f) return 0f
+    return settled * (0.5f - 0.5f * kotlin.math.cos((elapsed - MARK_SETTLED) * 2f * Math.PI.toFloat() / BREATH_PERIOD))
+}
+
+/** Where the nutrient dash currently sits along a spine, or null when they are off. */
+private fun pulsePhase(elapsed: Float, dive: Float?): Float? {
+    if (dive != null && dive > 0.2f) return null      // snuffed the moment we start in
+    if (elapsed < PULSE_AT) return null
+    val cycle = ((elapsed - PULSE_AT) / 3.4f) % 1f
+    return cycle * 0.78f
+}
+
+// ── small helpers ───────────────────────────────────────────────────────────
+
+private val ROUND = StrokeCap.Round
+
+private fun lerp(from: Float, to: Float, t: Float) = from + (to - from) * t
+
+private fun Float.easeOutQuad() = 1f - (1f - this).pow(2)
+private fun Float.easeInQuad() = this * this
+private fun Float.easeOutQuart() = 1f - (1f - this).pow(4)
+private fun Float.easeInOutQuad() =
+    if (this < 0.5f) 2f * this * this else 1f - (-2f * this + 2f).pow(2) / 2f
+
+private fun Float.easeOutBack(): Float {
+    val c = 1.70158f
+    val t = this - 1f
+    return 1f + (c + 1f) * t.pow(3) + c * t.pow(2)
+}
+
+private fun MarkSegment.toPath() = Path().apply {
+    moveTo(x0, y0)
+    quadraticTo(cx, cy, x1, y1)
+}
+
+private fun Path.measuredLength(): Float =
+    PathMeasure().let { it.setPath(this, false); it.length }
+
+/** The first [fraction] of this path, or null if there is nothing to draw yet. */
+private fun Path.head(fraction: Float, length: Float): Path? =
+    segment(0f, fraction, length)
+
+private fun Path.segment(from: Float, to: Float, length: Float): Path? {
+    if (to <= from || length <= 0f) return null
+    val out = Path()
+    val measure = PathMeasure()
+    measure.setPath(this, false)
+    measure.getSegment(from * length, to * length, out, true)
+    return out
+}

--- a/android/app/src/main/java/app/myco/ui/intro/MycoMark.kt
+++ b/android/app/src/main/java/app/myco/ui/intro/MycoMark.kt
@@ -1,0 +1,242 @@
+package app.myco.ui.intro
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * Geometry for the Myco mark — the fourfold mycelial mandala from
+ * `docs/myco-logo.png`, grown rather than drawn.
+ *
+ * Only **one quadrant** is generated. [IntroScreen] draws it four times at
+ * 90/180/270°, which is where the logo's symmetry comes from and keeps the
+ * per-frame path count to a quarter of what it looks like.
+ *
+ * This file is deliberately free of Compose graphics types: it emits plain
+ * coordinates so it can be unit-tested on the JVM without Robolectric. The
+ * caller turns [MarkSegment]s into paths once and holds onto them.
+ */
+
+/** The coordinate space the mark is authored in; scaled to the viewport. */
+const val MARK_VIEWPORT = 400f
+const val MARK_CENTER = MARK_VIEWPORT / 2f
+
+/** Where the filaments stop. The ring sits on this radius too, so they end on its line. */
+const val MARK_RING_RADIUS = 176f
+
+/** How far from the centre the innermost filaments start — the spark sits inside this. */
+private const val ROOT_RADIUS = 22f
+
+private const val DEPTH = 5
+private const val ROOT_LENGTH = 44f
+private const val LENGTH_DECAY = 0.84f
+
+/** Trunk headings for one quadrant, in degrees. Four arms → sixteen in the round. */
+private val ARMS = floatArrayOf(-32f, -6f, 20f, 44f)
+
+/**
+ * One filament: a quadratic curve from ([x0], [y0]) to ([x1], [y1]) bent around
+ * ([cx], [cy]).
+ *
+ * The bend is the whole trick — it is what gives the mark its woven look
+ * instead of a bicycle wheel of straight spokes. Successive generations bend
+ * the opposite way.
+ *
+ * [generation] is depth from the trunk, and drives when this segment is drawn.
+ * [parent] is the segment this one grows out of, so growth can propagate along
+ * the structure rather than appearing in disconnected rings.
+ */
+data class MarkSegment(
+    val x0: Float,
+    val y0: Float,
+    val cx: Float,
+    val cy: Float,
+    val x1: Float,
+    val y1: Float,
+    val generation: Int,
+    val strokeWidth: Float,
+    val alpha: Float,
+    /** Trunk segments, drawn in the lighter tint. */
+    val bright: Boolean,
+    /** True for the handful of spines the nutrient pulses run along. */
+    val spine: Boolean,
+    val parent: Int,
+) {
+    /** Distance of this segment's outer end from the centre of the mark. */
+    val endRadius: Float get() = hypot(x1 - MARK_CENTER, y1 - MARK_CENTER)
+}
+
+/** A swollen node where a trunk first forks. Four of them in the round. */
+data class MarkNode(
+    val x: Float,
+    val y: Float,
+    val radius: Float,
+    /** Polar position, so the pupil can push the node ahead of itself. */
+    val distance: Float,
+    val angle: Float,
+    val generation: Int,
+    val parent: Int,
+)
+
+data class MycoMark(
+    val segments: List<MarkSegment>,
+    val nodes: List<MarkNode>,
+) {
+    val generations: Int get() = (segments.maxOfOrNull { it.generation } ?: -1) + 1
+
+    /** Indices of the segments the nutrient pulses travel along. */
+    val spineIndices: List<Int> get() = segments.indices.filter { segments[it].spine }
+}
+
+/**
+ * Grow one quadrant of the mark.
+ *
+ * [seed] fixes the jitter. It must stay fixed across recomposition and
+ * configuration changes or the mark would reshuffle itself mid-animation —
+ * hold the result in `remember`.
+ */
+fun buildMycoMark(seed: Long = 20_260_806L): MycoMark {
+    val random = Random(seed)
+    val segments = mutableListOf<MarkSegment>()
+    val nodes = mutableListOf<MarkNode>()
+
+    fun between(min: Float, max: Float) = min + random.nextFloat() * (max - min)
+
+    fun grow(
+        x: Float,
+        y: Float,
+        angle: Float,
+        length: Float,
+        depth: Int,
+        generation: Int,
+        curl: Float,
+        trunk: Boolean,
+        parent: Int,
+    ) {
+        if (depth <= 0) return
+
+        val x1 = x + cos(angle) * length
+        val y1 = y + sin(angle) * length
+
+        // Control point pushed off the perpendicular. Alternating `curl` down
+        // the chain is what weaves the filaments together.
+        val perpendicular = angle + (Math.PI / 2).toFloat()
+        val bow = length * between(0.26f, 0.42f) * curl
+        val cx = (x + x1) / 2f + cos(perpendicular) * bow
+        val cy = (y + y1) / 2f + sin(perpendicular) * bow
+
+        val index = segments.size
+        segments += MarkSegment(
+            x0 = x, y0 = y, cx = cx, cy = cy, x1 = x1, y1 = y1,
+            generation = generation,
+            strokeWidth = depth * 0.62f + 0.5f,
+            alpha = 0.55f + depth * 0.09f,
+            bright = depth >= DEPTH - 1,
+            // The first two trunk segments of each arm carry the nutrients.
+            spine = trunk && generation < 2,
+            parent = parent,
+        )
+
+        if (trunk && depth == DEPTH - 1) {
+            nodes += MarkNode(
+                x = x1, y = y1, radius = 5.5f,
+                distance = hypot(x1 - MARK_CENTER, y1 - MARK_CENTER),
+                angle = atan2(y1 - MARK_CENTER, x1 - MARK_CENTER),
+                generation = generation + 1,
+                parent = index,
+            )
+        }
+
+        val branches = if (depth > 2) 2 else if (random.nextFloat() < 0.7f) 2 else 1
+        for (i in 0 until branches) {
+            val fan = (i - (branches - 1) / 2f) * between(0.34f, 0.6f)
+            grow(
+                x = x1,
+                y = y1,
+                angle = angle + fan + between(-0.06f, 0.06f),
+                length = length * between(LENGTH_DECAY - 0.06f, LENGTH_DECAY + 0.06f),
+                depth = depth - 1,
+                generation = generation + 1,
+                curl = -curl,
+                trunk = trunk && i == branches / 2,
+                parent = index,
+            )
+        }
+    }
+
+    ARMS.forEachIndexed { i, degrees ->
+        val angle = (degrees * Math.PI / 180.0).toFloat()
+        grow(
+            x = MARK_CENTER + cos(angle) * ROOT_RADIUS,
+            y = MARK_CENTER + sin(angle) * ROOT_RADIUS,
+            angle = angle,
+            length = ROOT_LENGTH,
+            depth = DEPTH,
+            generation = 0,
+            curl = if (i % 2 == 0) -1f else 1f,
+            trunk = true,
+            parent = -1,
+        )
+    }
+
+    return MycoMark(segments, nodes)
+}
+
+/**
+ * The tendril the idle prompt sits on: a small branching sprig that grows
+ * downward out of the mark and carries the words up on it.
+ *
+ * Authored in its own little coordinate space ([TENDRIL_WIDTH] × [TENDRIL_HEIGHT]),
+ * rooted at the top centre.
+ */
+const val TENDRIL_WIDTH = 200f
+const val TENDRIL_HEIGHT = 54f
+
+fun buildTendril(seed: Long = 20_260_807L): MycoMark {
+    val random = Random(seed)
+    val segments = mutableListOf<MarkSegment>()
+
+    fun between(min: Float, max: Float) = min + random.nextFloat() * (max - min)
+
+    fun grow(x: Float, y: Float, angle: Float, length: Float, depth: Int, generation: Int, parent: Int) {
+        if (depth <= 0) return
+
+        val x1 = x + cos(angle) * length
+        val y1 = y + sin(angle) * length
+        val perpendicular = angle + (Math.PI / 2).toFloat()
+        val bow = length * between(0.15f, 0.3f) * if (generation % 2 == 0) -1f else 1f
+        val cx = (x + x1) / 2f + cos(perpendicular) * bow
+        val cy = (y + y1) / 2f + sin(perpendicular) * bow
+
+        val index = segments.size
+        segments += MarkSegment(
+            x0 = x, y0 = y, cx = cx, cy = cy, x1 = x1, y1 = y1,
+            generation = generation,
+            strokeWidth = depth * 0.45f + 0.35f,
+            alpha = 0.35f + depth * 0.14f,
+            bright = false,
+            spine = false,
+            parent = parent,
+        )
+
+        // It runs sideways along the words as it thins out.
+        for (i in 0 until 2) {
+            val fan = (if (i == 0) -1f else 1f) * between(0.5f, 1.15f)
+            grow(x1, y1, angle + fan, length * between(0.62f, 0.82f), depth - 1, generation + 1, index)
+        }
+    }
+
+    grow(
+        x = TENDRIL_WIDTH / 2f,
+        y = 0f,
+        angle = (Math.PI / 2).toFloat(),   // straight down, out of the mark
+        length = 17f,
+        depth = 4,
+        generation = 0,
+        parent = -1,
+    )
+
+    return MycoMark(segments, emptyList())
+}

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -94,6 +94,7 @@ fun SettingsScreen(
     bleExhausted: Boolean = false,
     initialExitProxy: String = "",
     onExitProxyChange: (String) -> Unit = {},
+    onReplayIntro: () -> Unit = {},
 ) {
     var page by remember { mutableStateOf(SettingsPage.Root) }
 
@@ -124,6 +125,7 @@ fun SettingsScreen(
             onOfflineOnlyToggle = onOfflineOnlyToggle,
             initialExitProxy = initialExitProxy,
             onExitProxyChange = onExitProxyChange,
+            onReplayIntro = onReplayIntro,
             onBack = { page = SettingsPage.Root },
         )
     }
@@ -437,6 +439,7 @@ private fun DeveloperSettings(
     onOfflineOnlyToggle: (Boolean) -> Unit,
     initialExitProxy: String,
     onExitProxyChange: (String) -> Unit,
+    onReplayIntro: () -> Unit,
     onBack: () -> Unit,
 ) {
     SettingsColumn {
@@ -482,6 +485,37 @@ private fun DeveloperSettings(
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Button(onClick = { onExitProxyChange(field.trim()) }) { Text("Apply") }
                     TextButton(onClick = { field = ""; onExitProxyChange("") }) { Text("Turn off") }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(8.dp))
+        GroupLabel("INTRO")
+        SectionCard {
+            var replayed by rememberSaveable { mutableStateOf(false) }
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    "The intro plays in full on first launch; after that it is only the " +
+                        "dive. This puts it back to first-launch state, without clearing " +
+                        "app data.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Button(onClick = { onReplayIntro(); replayed = true }) { Text("Play again") }
+                    if (replayed) {
+                        Text(
+                            "Plays in full next launch.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/app/myco/ui/theme/Theme.kt
+++ b/android/app/src/main/java/app/myco/ui/theme/Theme.kt
@@ -35,6 +35,24 @@ val ScreenBg = Color(0xFFFFFFFF)
 
 /** Bright emerald retained as the primary brand accent on AMOLED black. */
 val AmoledAccent = Color(0xFF34D399)
+
+// --- Intro mark -------------------------------------------------------------
+//
+// A third deliberate exception to theme-following, alongside the QR card and
+// the amber warning states. The intro is the mark from docs/myco-logo.png,
+// sampled off it, and it is identical in both themes: it runs before any app
+// chrome and owns the whole screen, so there is nothing for it to sit against
+// and no light-mode variant to render. Cyan filaments on near-black are the
+// asset, not a colour choice.
+/** The ground the mark grows out of. */
+val MarkGround = Color(0xFF03090C)
+/** Filament stroke. */
+val MarkFilament = Color(0xFF22D3EE)
+/** Trunk filaments and the prompt, one step lighter. */
+val MarkBright = Color(0xFFA5F3FC)
+/** The nodes, the spark, and the pupil's edge. */
+val MarkNodeColor = Color(0xFF67E8F9)
+
 private val LightWarning = Color(0xFFB45309)
 private val LightWarningContainer = Color(0xFFFFF7ED)
 private val LightOnWarningContainer = Color(0xFF9A3412)

--- a/android/app/src/test/java/app/myco/ui/intro/MycoMarkTest.kt
+++ b/android/app/src/test/java/app/myco/ui/intro/MycoMarkTest.kt
@@ -1,0 +1,124 @@
+package app.myco.ui.intro
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import kotlin.math.hypot
+import org.junit.Test
+
+class MycoMarkTest {
+
+    @Test
+    fun `same seed grows the same mark`() {
+        val a = buildMycoMark(seed = 7)
+        val b = buildMycoMark(seed = 7)
+
+        // The mark must not reshuffle across recomposition or a rotation, so
+        // the generator has to be a pure function of its seed.
+        assertEquals(a.segments, b.segments)
+        assertEquals(a.nodes, b.nodes)
+    }
+
+    @Test
+    fun `different seeds grow different marks`() {
+        assertTrue(buildMycoMark(seed = 7).segments != buildMycoMark(seed = 8).segments)
+    }
+
+    @Test
+    fun `the mark grows out to the ring and is trimmed by it`() {
+        val mark = buildMycoMark()
+        val outside = mark.segments.count { it.endRadius > MARK_RING_RADIUS }
+        val furthest = mark.segments.maxOf { it.endRadius }
+
+        // Branch lengths are jittered, so the outermost filaments land either
+        // side of the ring and the draw clips the ones that overshoot. That
+        // clip is load-bearing — without it the mark frays outward instead of
+        // ending on a line — so this asserts it has work to do…
+        assertTrue("nothing reaches the ring; the clip is doing nothing", outside > 0)
+        // …and that the overshoot stays a trim rather than a large hidden
+        // halo we would be paying to generate and stroke every frame.
+        assertTrue(
+            "filaments run to $furthest, well past the ring at $MARK_RING_RADIUS",
+            furthest < MARK_RING_RADIUS * 1.4f,
+        )
+        // The mark should fill its disc, not hug the middle.
+        assertTrue("mark only reaches $furthest", furthest > MARK_RING_RADIUS * 0.85f)
+    }
+
+    @Test
+    fun `a segment is always generated after the one it grows from`() {
+        // Growth propagates along the chain, so a parent must already exist —
+        // and already be drawing — by the time its children are scheduled.
+        val mark = buildMycoMark()
+
+        mark.segments.forEachIndexed { index, segment ->
+            assertTrue(
+                "segment $index has parent ${segment.parent}",
+                segment.parent < index,
+            )
+        }
+    }
+
+    @Test
+    fun `generations are contiguous and start at the trunk`() {
+        val mark = buildMycoMark()
+        val byGeneration = mark.segments.groupBy { it.generation }
+
+        assertEquals(4, byGeneration.getValue(0).size)     // one trunk per arm
+        for (generation in 0 until mark.generations) {
+            assertTrue("generation $generation is empty", byGeneration.containsKey(generation))
+        }
+        // Each generation branches, so it is never smaller than the last.
+        for (generation in 1 until mark.generations) {
+            assertTrue(
+                "generation $generation is smaller than ${generation - 1}",
+                byGeneration.getValue(generation).size >= byGeneration.getValue(generation - 1).size,
+            )
+        }
+    }
+
+    @Test
+    fun `child segments start where their parent ended`() {
+        // Any drift here would show as filaments floating free of the branch
+        // that feeds them, which is exactly what the growth is meant to avoid.
+        val mark = buildMycoMark()
+
+        mark.segments.filter { it.parent >= 0 }.forEach { segment ->
+            val parent = mark.segments[segment.parent]
+            assertEquals(parent.x1, segment.x0, 0.001f)
+            assertEquals(parent.y1, segment.y0, 0.001f)
+        }
+    }
+
+    @Test
+    fun `one node per arm, out where the trunk first forks`() {
+        val mark = buildMycoMark()
+
+        assertEquals(4, mark.nodes.size)
+        mark.nodes.forEach { node ->
+            assertTrue("node at ${node.distance} is inside the spark", node.distance > 40f)
+            assertTrue("node at ${node.distance} is past the ring", node.distance < MARK_RING_RADIUS)
+            // Polar position has to agree with the cartesian one, or the pupil
+            // would shunt the node off its own filament as it pushes it out.
+            assertEquals(node.distance, hypot(node.x - MARK_CENTER, node.y - MARK_CENTER), 0.01f)
+        }
+    }
+
+    @Test
+    fun `nutrients have spines to run along`() {
+        val mark = buildMycoMark()
+        val spines = mark.spineIndices
+
+        assertTrue("no spines to pulse along", spines.isNotEmpty())
+        spines.forEach { assertTrue(mark.segments[it].generation < 2) }
+    }
+
+    @Test
+    fun `the tendril hangs below its root`() {
+        val tendril = buildTendril()
+
+        assertTrue(tendril.segments.isNotEmpty())
+        // It grows downward out of the mark, so nothing may end above the root.
+        tendril.segments.forEach { assertTrue(it.y1 > 0f) }
+        assertTrue(tendril.segments.all { it.y1 <= TENDRIL_HEIGHT * 1.5f })
+    }
+}


### PR DESCRIPTION
A first-run intro for the Android app.

A spark appears, mycelial filaments grow out of it into the Myco mark, and the
ring closes around them; the mark then breathes while it waits. Tapping
anywhere opens a pupil in the middle of it, which contracts and dilates the way
a real one does before the camera falls into it and the app is there.

## What's here

**The mark is generated, not an asset.** `ui/intro/MycoMark.kt` grows one
quadrant of branching filaments; `IntroScreen` draws it four times at
90/180/270°. That's where the logo's fourfold symmetry comes from, and it keeps
the per-frame path count to a quarter of what it looks like. The geometry file
deliberately has no Compose graphics types in it, so it unit-tests on the JVM
without Robolectric.

**The pupil is a hole, not a black disc.** Ground and mark composite in one
off-screen layer and a single `BlendMode.Clear` punches through both, so what
you see in the pupil is the app itself, live. Until the dive starts the hole is
frosted — a wash of the ground over it, with `Modifier.blur` on the app
underneath by the same amount — so you can tell something is back there long
before you can read it. `Modifier.blur` no-ops below API 31, where the wash
carries it alone.

**The intro is an overlay, not a nav destination.** The app is composed and laid
out underneath it from the first frame. A destination would have had nothing
behind it to reveal, and would have hitched on exactly the frame the eye is on.

**First launch only.** Afterwards `IntroMode.Returning` joins the same timeline
part-way and runs it faster — about two seconds, start to app — so this stays
out of the way of someone who just wants to open the app. Settings → Advanced → Developer
settings has a control to put it back to first-launch state.

## Notes for review

- **Colours.** The mark is fixed cyan on near-black in both themes: a third
  deliberate exception alongside the QR card and the amber warning states. It
  runs before any app chrome and owns the whole screen, so it has nothing to sit
  against and no light-mode variant to render. The values live as `Mark*`
  constants in `Theme.kt` next to the peer-state ones, and CONVENTIONS.md
  records the exception.
- **Cost.** Roughly 450 stroked paths a frame during the growth, from ~113
  generated segments drawn four times. Bloom is a wide translucent stroke under
  a narrow bright one rather than a blur filter — cheaper, and it survives
  hardware layers. Smooth on both devices below; if it ever isn't, baking the
  settled mark to an `ImageBitmap` after growth is the obvious next lever.
- **Timeline.** One clock in seconds off `withFrameNanos`, with every beat a
  window on it. The constants block near the bottom of `IntroScreen.kt` is the
  whole schedule — moving a number there moves only that beat.
- **Not ported from the web prototype:** system-bar handling is untouched, so
  the status bar sits over the intro rather than the intro going under it.
  Worth a follow-up.

## Tests

`MycoMarkTest` covers the geometry: same seed grows the same mark (it must not
reshuffle across recomposition or a rotation), children start exactly where
their parent ended, generations are contiguous and branch outward, nodes agree
between their polar and cartesian positions, and the mark reaches the ring
without running far past it. `./gradlew :app:testDebugUnitTest` — 11 pass.

The animation itself is only meaningful on-device, so:

## Manual test

Galaxy A52s (Android 14) and DC-1 (Android 13), debug build:

- Fresh install: mark grows, settles, breathes, and waits indefinitely.
- Tap anywhere: pupil opens, reacts to the light, dives through to the apps
  drawer. The app is visible through the pupil the whole way, frosted at first.
- Tapping mid-growth skips straight to the dive.
- Relaunch: short path, straight into the dive, app in about two seconds.
- Settings → Advanced → Developer settings → INTRO → "Play again": next
  launch plays in full again.