### PR TITLE
Deep links: myco://app/<host>/<path>, and an app that arrives before it opens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ node_modules/
 # Standalone nsite app, developed as its own git repo
 /myco-bitchat/
 /myco-ics/
+/myco-dumplings/
 
 .env
 # Standalone mesh exit-node daemon (developed in-tree, not shipped)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -78,6 +78,12 @@ None yet. Field TODOs are tracked separately in `reference/FIX-TODOS.md`.
 - **Vendor divergence:** convergence and churn recovery must be demonstrated on at least three vendors (Samsung + Xiaomi + Pixel); Pixel alone is not representative.
 - **fips rebase risk:** 19 commits sit 232 commits behind a heavily refactored master; some themes likely dissolve entirely. Fallback is targeted fixes on `feat/platform-peer-queue`.
 
+## Quick Tasks Completed
+
+| ID | Task | Date | Branch | Summary |
+|----|------|------|--------|---------|
+| 260809-nyq | Myco deep linking (`myco://app/<host>/<path>`) + deferred open, and the myco-dumplings test nsite | 2026-08-09 | `feat/deep-links` | `.planning/quick/260809-nyq-myco-deep-linking-myco-app-host-path-def/SUMMARY.md` |
+
 ## Deferred Items
 
 | Category | Item | Status | Deferred At |

--- a/.planning/quick/260809-nyq-myco-deep-linking-myco-app-host-path-def/PLAN.md
+++ b/.planning/quick/260809-nyq-myco-deep-linking-myco-app-host-path-def/PLAN.md
@@ -1,0 +1,103 @@
+---
+id: 260809-nyq
+slug: myco-deep-linking-myco-app-host-path-def
+date: 2026-08-09
+mode: quick
+branch: feat/deep-links
+---
+
+# Myco deep linking (`myco://app/<host>/<path>`) + deferred open + myco-dumplings
+
+## Goal
+
+A `myco://app/<host>/<deep-path>` link opens that nsite at that path. If the nsite
+isn't installed yet, Myco retrieves it and — however long that takes, across process
+death and reboots — the *first* open of that nsite lands on the deep path.
+
+## Locked decisions
+
+1. **SPA fallback in the gateway** (not hash routing). Real paths, one small
+   `nsite-deck` change that stays upstream-generic.
+2. **Deep links carry no invite/pairing/holder info.** `myco://app/<host>/<path>` and
+   nothing else. Retrieval works holder-less: `Content::open_site` already tries every
+   Circle peer, then the public IP fallback, when `holder = None`
+   (`myco-core/src/content.rs:585-610`).
+3. The invite payload (`/invite/cordn1<bech32>`) is **opaque to Myco** — app-defined,
+   forwarded verbatim to the nsite.
+
+## Tasks
+
+### T1 — Gateway SPA fallback (`nsite-deck/src/gateway.rs`)
+
+On a manifest miss, precedence is: `/404.html` → `/index.html` (SPA shell, **200**) →
+gateway 404 page.
+
+The `/index.html` fallback applies **only to navigation-style requests** — those where
+`normalize_path` produced a `…/index.html` (root, trailing slash, or extensionless last
+segment). A miss on `/assets/app.js` still 404s, so a broken asset does not silently
+render the app shell with a 200.
+
+Unit tests: extensionless deep path → shell 200; missing asset → 404; `/404.html`
+present → keeps 404 precedence; no `/index.html` → gateway 404.
+
+### T2 — `MycoLink` parser (`android/.../share/MycoLink.kt`, new)
+
+Parse `myco://app/<host>/<deep-path…>` → `AppLink(host, path)`.
+- `path` keeps its leading slash, plus any query/fragment; `/` when absent.
+- Rejects anything with pairing/invite query params — this form is deliberately
+  credential-free.
+- Rejects a bare `myco://app/<host>` with no tail? No — that is a valid "just open it"
+  link, `path = "/"`.
+Unit-testable pure Kotlin (no Android types beyond `Uri`; use string parsing so it is
+testable off-device).
+
+### T3 — `PendingDeepLinks` store (`android/.../share/PendingDeepLinks.kt`, new)
+
+SharedPreferences-backed `{host → {path, ts}}` JSON map.
+- `put(host, path)` / `take(host)` (read-and-clear) / `peek(host)` / `sweep()`.
+- Entries expire after 30 days; `sweep()` drops them.
+- Survives process death and reboot — this is the whole point of the feature.
+
+### T4 — `NsiteActivity`: deep path + already-open navigation
+
+- New `EXTRA_PATH`; `loadUrl("http://$host.localhost$path")`.
+- Data URI stays host-only (`myco://app/<host>`) so `documentLaunchMode=intoExisting`
+  still re-surfaces the same Recents card.
+- Add `onNewIntent`: an already-open nsite navigates to the new path instead of showing
+  the stale page.
+
+### T5 — `MainActivity`: routing + reconciler
+
+- `handleScannedText`: explicit `MycoLink` branch **before** the raw-link fallback.
+- Ready now → launch with the path immediately.
+- Not ready → `PendingDeepLinks.put`, dispatch `OpenNsite{link: host, holder: null}`,
+  toast "Getting <app>…".
+- `reconcilePendingLinks()` on `onResume`: for each pending entry, if the site is
+  `ready` → launch with the path and clear; if `unreachable` → re-dispatch `OpenNsite`
+  (retry, do not give up on the first failure — a holder peer may only now be in range).
+- `launchNsite()` consumes a pending path too, so a user tapping the app in the drawer
+  themselves also lands on the deep link.
+
+### T6 — `myco-dumplings` nsite (new, `/myco-dumplings`)
+
+Vite + React + TS, same shape as `myco-ics` (no applesauce — no relay use).
+- Offline-first bookmarks in `localStorage`: URL + label.
+- Share → `myco://app/<own-host>/invite/cordn1<bech32(payload)>` + QR + copy.
+- Route `/invite/:payload` → decode → "<who> shared <title> — add to bookmarks?" →
+  accept/dismiss. Uses real path routing (depends on T1).
+- bech32 hrp `cordn`, payload = compact JSON `{u,t,f}`.
+- Own bech32 + tiny router implementation; no runtime deps beyond React + a QR encoder.
+
+### T7 — Docs
+
+`docs/design/deep-links.md`: the URL grammar, why it carries no secrets, the deferred
+open state machine, and the gateway fallback rule.
+
+## Verification
+
+- `cargo test -p nsite-deck`
+- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`
+- `npm run typecheck && npm run build` in `myco-dumplings`
+- Android: `./gradlew assembleDebug`
+- Manual: `adb shell am start -a android.intent.action.VIEW -d "myco://app/<host>/invite/cordn1…"`
+  against both an installed and a not-yet-installed nsite.

--- a/.planning/quick/260809-nyq-myco-deep-linking-myco-app-host-path-def/SUMMARY.md
+++ b/.planning/quick/260809-nyq-myco-deep-linking-myco-app-host-path-def/SUMMARY.md
@@ -1,0 +1,83 @@
+---
+id: 260809-nyq
+status: complete
+date: 2026-08-09
+branch: feat/deep-links
+commits:
+  - fc29538312b672eeacfc903c5de94857271d0d71  # gateway SPA fallback
+  - de9db3670fc98bb291e742fe51a0e24db8e088e3  # android deep links + deferred open
+  - 0bbc70dd1364e90ec154c7218542d0aa453859ad  # docs + gitignore
+  - 73f568527e1c8f22c41c41a73c6c735440f3fcc4  # myco-dumplings (its own repo)
+---
+
+# Myco deep linking + myco-dumplings — done
+
+`myco://app/<host>/<path>` opens an app at a place inside it. If the app isn't
+installed, Myco retrieves it and the path is spent on its **first** open — however
+long that takes, across process death and reboots.
+
+## What landed
+
+| Scope | Where |
+|-------|-------|
+| Gateway SPA fallback | `nsite-deck/src/gateway.rs` — `resolve_hash`, 5 new tests |
+| Link parser | `android/…/share/MycoLink.kt` + 9 JVM unit tests |
+| Pending-link store | `android/…/share/PendingDeepLinks.kt` |
+| Deep path + already-open nav | `android/…/NsiteActivity.kt` (`EXTRA_PATH`, `onNewIntent`) |
+| Routing + reconciler | `android/…/MainActivity.kt` |
+| Test app | `myco-dumplings/` (standalone repo) |
+| Design doc | `docs/design/deep-links.md` |
+
+## Decisions taken during execution
+
+1. **The SPA fallback is limited to navigation-style paths.** The task said "on
+   manifest miss, fall back to `/index.html`". Applied literally, a missing
+   `/assets/app.js` would answer HTML with a 200 — a broken asset turned silent. The
+   fallback now applies only where `normalize_path` produced a `…/index.html` (root,
+   trailing slash, extensionless segment). Assets keep their 404.
+
+2. **Query params are forwarded, not rejected.** The plan said to reject links with
+   pairing/invite query params. Myco defines no query params at all, so there is
+   nothing to reject — the rule is enforced by Myco never *reading* the query, and by
+   attaching no holder/secret when it builds a link. The query rides along for the app.
+
+3. **A foreground watcher was added alongside the resume reconciler.** Resume alone
+   would miss the common case: tap a link, wait five seconds while a peer in the room
+   serves the app, with Myco open the whole time. The watcher is bounded (3 min) and
+   de-duplicated; the reconciler remains the durable half.
+
+4. **`myco-dumplings` is its own git repo**, gitignored here like `myco-ics` and
+   `myco-bitchat` (user's call, mid-execution — an earlier in-tree commit was rewound).
+   Initial commit `73f5685` inside `myco-dumplings/`.
+
+5. **Dumplings builds with `base: "/"`**, unlike the other nsites' `"./"`. Relative
+   asset URLs resolve against the current route, so from `/invite/x` they 404. Any
+   nsite wanting real routes needs this; documented in both READMEs.
+
+## Verified
+
+- `cargo test -p nsite-deck` — 22 pass (5 new)
+- `cargo fmt --all --check` clean; `cargo clippy -p nsite-deck --all-targets` clean
+- `./gradlew :app:testDebugUnitTest` — `MycoLinkTest` 9/9
+- `./gradlew :app:assembleDebug` — APK built
+- `npm run build` in `myco-dumplings` — clean typecheck + build
+- bech32 round-trip checked directly: long payload, uppercase accepted, mixed case
+  rejected, tampered checksum rejected, wrong hrp rejected
+
+## Not verified
+
+On-device. The end-to-end claim — scan on a phone without the app, wait, land on the
+invite — has not been run against hardware:
+
+```sh
+adb shell am start -a android.intent.action.VIEW -d "myco://app/<host>/invite/cordn1…"
+```
+
+Needs Dumplings deployed to a real nsite host (`npm run deploy`) and two phones.
+
+## Out of scope, still open
+
+**Myco itself not installed.** `myco://` has no handler, so the tap does nothing. Needs
+an `https://` App Link landing page plus clipboard hand-off (sideload/zapstore
+distribution rules out the Play Install Referrer). Rationale for deferring in
+`docs/design/deep-links.md` §5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   screen once the download actually finishes. Not while it is still
   transferring, because an icon for an app that never arrived is worse than no
   icon; and only once per app, so declining is respected.
+- A link can now point at a place *inside* an app, not just at the app:
+  `myco://app/<host>/<path>`. Follow one for an app you don't have and Myco
+  fetches it from whoever nearby is carrying it, then opens it on the spot the
+  link named — five seconds later if a peer is in the room, or after a reboot
+  next week if nobody was. Opening the app yourself from the Apps grid spends
+  the link just the same, so the first time you see that app is the time you
+  land where you were sent. Deep links deliberately carry no pairing secret:
+  they travel through channels nobody controls, so anything inside one is
+  public and replayable. Pairing keeps its own face-to-face carrier.
+- Apps can serve their own routes. A path an app's manifest doesn't list now
+  gets the app's shell instead of a 404, so client-side routing works —
+  bounded to navigation-style paths, because answering a missing script with a
+  page would turn a broken asset into a silent one. An app that ships its own
+  `404.html` still owns that answer.
+- Dumplings joins bitchat and ICS in Discover's suggested apps — save a link,
+  hand it to whoever is next to you, and it arrives as something they can
+  choose to keep.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Full design docs are in **[docs/](docs/README.md)**:
 - [Architecture](docs/design/architecture.md)
 - [The nsite layer](docs/design/nsite-layer.md) · [Propagation](docs/design/propagation.md) · [BLE interop](docs/design/ble-interop.md)
 - [Identity & pairing](docs/design/identity-pairing.md) · [Security](docs/design/security.md)
+- [Deep links](docs/design/deep-links.md) — linking to a place inside an app, and what happens when that app isn't installed yet
 - [Roadmap](docs/roadmap.md)
 
 ## Status

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -52,7 +52,9 @@ import app.myco.core.NativeActions
 import app.myco.nfc.NfcReader
 import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
+import app.myco.share.MycoLink
 import app.myco.share.NsiteShare
+import app.myco.share.PendingDeepLinks
 import app.myco.ui.MycoApp
 import app.myco.ui.intro.IntroMode
 import app.myco.ui.intro.IntroScreen
@@ -73,6 +75,9 @@ class MainActivity : ComponentActivity() {
     private lateinit var core: AppCoreClient
     private val prefs by lazy { getSharedPreferences("myco_prefs", MODE_PRIVATE) }
     private val nfcAdapter by lazy { NfcAdapter.getDefaultAdapter(this) }
+
+    /** Hosts with a live [watchPendingLink] coroutine, so resumes don't stack them. */
+    private val pendingWatchers = mutableSetOf<String>()
 
     private val permLauncher = registerForActivityResult(RequestMultiplePermissions()) {
         // BLE is enabled by default / remembered; (re)start it once perms land.
@@ -297,6 +302,9 @@ class MainActivity : ComponentActivity() {
         core.state().ownNpub.takeIf { it.isNotEmpty() }?.let {
             core.dispatch(NativeActions.setDeviceName(DeviceName.current(this, it)))
         }
+        // Deep links followed before the app existed (possibly in a previous process)
+        // get their chance every time Myco comes back to the foreground.
+        reconcilePendingLinks()
     }
 
     override fun onPause() {
@@ -421,18 +429,28 @@ class MainActivity : ComponentActivity() {
 
     // --- nsite launching ---
 
-    /** The intent that opens an nsite as its own fullscreen task (one per host). */
-    private fun nsiteIntent(hostLabel: String, title: String): Intent =
+    /** The intent that opens an nsite as its own fullscreen task (one per host),
+     *  at [path] inside it (the root unless a deep link said otherwise). */
+    private fun nsiteIntent(hostLabel: String, title: String, path: String = "/"): Intent =
         Intent(this, NsiteActivity::class.java).apply {
             action = Intent.ACTION_VIEW
+            // Host-only, so a deep link re-surfaces the app's existing Recents card
+            // instead of opening a second one per route.
             data = NsiteActivity.documentUri(hostLabel)
             putExtra(NsiteActivity.EXTRA_HOST, hostLabel)
             putExtra(NsiteActivity.EXTRA_TITLE, title)
+            putExtra(NsiteActivity.EXTRA_PATH, path)
             addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
         }
 
-    private fun launchNsite(hostLabel: String, title: String) {
-        startActivity(nsiteIntent(hostLabel, title))
+    /**
+     * Open an nsite. With no explicit [path], any deep link still waiting on this app
+     * is spent here — so tapping it yourself in the Apps grid lands on the link you
+     * followed days ago just as surely as Myco opening it for you would have.
+     */
+    private fun launchNsite(hostLabel: String, title: String, path: String? = null) {
+        val target = path ?: PendingDeepLinks.take(this, hostLabel) ?: "/"
+        startActivity(nsiteIntent(hostLabel, title, target))
     }
 
     /** Pin an nsite to the home screen as an app-like shortcut (favicon + title). */
@@ -504,6 +522,10 @@ class MainActivity : ComponentActivity() {
             openSharedNsite(info)
             return
         }
+        MycoLink.parseAppLink(text)?.let { link ->
+            openAppLink(link)
+            return
+        }
         // Fall back to treating it as a pasteable nsite link.
         core.dispatch(NativeActions.openNsite(text))
         Toast.makeText(this, "Opening app...", Toast.LENGTH_SHORT).show()
@@ -513,6 +535,94 @@ class MainActivity : ComponentActivity() {
         val data = intent?.data ?: return
         if (data.scheme != NsiteShare.SCHEME) return
         handleScannedText(data.toString())
+    }
+
+    /**
+     * Follow a `myco://app/<host>/<path>` deep link.
+     *
+     * Installed already → open it, there, now. Not installed → start retrieving it and
+     * **remember the path**: the app may arrive in five seconds or next week, and
+     * either way its first open belongs to the link that asked for it. Nothing about
+     * the wait is shown as a modal — the app appears in the Apps grid with its
+     * download ring, same as any other incoming app.
+     *
+     * No holder is passed because the link carries none by design (see [MycoLink]);
+     * `open_site` falls through every Circle peer and then the public source anyway.
+     */
+    private fun openAppLink(link: MycoLink.AppLink) {
+        val site = core.state().sites.firstOrNull { it.host == link.host }
+        if (site != null && site.state == "ready") {
+            launchNsite(link.host, site.title, link.path)
+            PendingDeepLinks.remove(this, link.host)
+            return
+        }
+        PendingDeepLinks.put(this, link.host, link.path)
+        core.dispatch(NativeActions.openNsite(link.host))
+        Toast.makeText(this, "Getting the app — it opens when it lands", Toast.LENGTH_LONG).show()
+        watchPendingLink(link.host)
+    }
+
+    /**
+     * Open the apps whose deep links have been waiting, and retry the ones that
+     * haven't arrived.
+     *
+     * Runs on every resume, which is what makes the wait survivable: the watcher
+     * coroutine started at tap time dies with the process, but this doesn't — a link
+     * followed before a reboot still opens the first time Myco comes back up with the
+     * app in hand. An `unreachable` site is re-dispatched rather than dropped: it means
+     * nobody in range had it *then*, and someone who does may have walked in since.
+     */
+    private fun reconcilePendingLinks() {
+        val hosts = PendingDeepLinks.hosts(this)
+        if (hosts.isEmpty()) return
+        lifecycleScope.launch {
+            val sites = withContext(Dispatchers.IO) { core.state() }.sites
+            for (host in hosts) {
+                val path = PendingDeepLinks.peek(this@MainActivity, host) ?: continue
+                val site = sites.firstOrNull { it.host == host }
+                when (site?.state) {
+                    "ready" -> {
+                        PendingDeepLinks.remove(this@MainActivity, host)
+                        launchNsite(host, site.title, path)
+                    }
+                    // Still coming — the watcher below opens it the moment it lands.
+                    "syncing" -> watchPendingLink(host)
+                    // Never started, or nobody had it last time. Ask again.
+                    else -> {
+                        core.dispatch(NativeActions.openNsite(host))
+                        watchPendingLink(host)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Watch one pending app while Myco is open, so a sync that finishes in the next few
+     * seconds — the common case, a peer right there in the room — opens the link
+     * immediately instead of waiting for the next resume. Bounded and de-duplicated;
+     * the durable half of the promise is [reconcilePendingLinks].
+     */
+    private fun watchPendingLink(hostLabel: String) {
+        if (!pendingWatchers.add(hostLabel)) return
+        lifecycleScope.launch {
+            try {
+                val deadline = SystemClock.elapsedRealtime() + PENDING_WATCH_MS
+                while (SystemClock.elapsedRealtime() < deadline) {
+                    delay(PENDING_WATCH_POLL_MS)
+                    val path = PendingDeepLinks.peek(this@MainActivity, hostLabel) ?: return@launch
+                    val site = withContext(Dispatchers.IO) { core.state() }
+                        .sites.firstOrNull { it.host == hostLabel }
+                    if (site != null && site.state == "ready") {
+                        PendingDeepLinks.remove(this@MainActivity, hostLabel)
+                        launchNsite(hostLabel, site.title, path)
+                        return@launch
+                    }
+                }
+            } finally {
+                pendingWatchers.remove(hostLabel)
+            }
+        }
     }
 
     /**
@@ -627,6 +737,11 @@ class MainActivity : ComponentActivity() {
          *  giving up on offering it — a sync that has not landed by now failed. */
         private const val HOME_OFFER_TIMEOUT_MS = 3 * 60 * 1000L
         private const val HOME_OFFER_POLL_MS = 1500L
+
+        /** How long a foreground watcher waits for a deep-linked app to land before
+         *  handing the wait back to the durable store (opened on a later resume). */
+        private const val PENDING_WATCH_MS = 3 * 60 * 1000L
+        private const val PENDING_WATCH_POLL_MS = 1000L
         const val PREF_EXIT_PROXY = "exit_proxy"
         /** Set once the intro has played all the way through. */
         const val PREF_INTRO_SEEN = "intro_seen"

--- a/android/app/src/main/java/app/myco/NsiteActivity.kt
+++ b/android/app/src/main/java/app/myco/NsiteActivity.kt
@@ -41,6 +41,10 @@ class NsiteActivity : ComponentActivity() {
     private lateinit var webView: WebView
     private lateinit var root: FrameLayout
 
+    /** The nsite this task belongs to; a re-delivered intent for anything else is
+     *  not ours to render (the task is keyed by host — see [documentUri]). */
+    private var hostLabel: String = ""
+
     /**
      * Whether the loaded page opted into drawing behind the status bar, by setting
      * `viewport-fit=cover` on its viewport meta tag.
@@ -70,7 +74,7 @@ class NsiteActivity : ComponentActivity() {
         enableEdgeToEdge()
         client = MycoCore.client(this)
 
-        val hostLabel = intent.getStringExtra(EXTRA_HOST).orEmpty()
+        hostLabel = intent.getStringExtra(EXTRA_HOST).orEmpty()
         if (hostLabel.isEmpty()) {
             finish()
             return
@@ -150,7 +154,30 @@ class NsiteActivity : ComponentActivity() {
         // `*.localhost` as loopback + a secure context, so the nsite's
         // `ws://localhost:4870` to the embedded relay isn't blocked by Private/
         // Local Network Access (a `.nsite` page is classed "public" → blocked).
-        webView.loadUrl("http://$hostLabel.localhost/")
+        webView.loadUrl(pageUrl(intent))
+    }
+
+    /**
+     * A deep link into an nsite that is **already open**.
+     *
+     * The task is keyed by host, so a second `myco://app/<host>/…` re-surfaces this
+     * task rather than starting a new one — and without this the user would be handed
+     * back whatever page they left behind instead of the one they just tapped.
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        // The task is per-host; an intent for a different nsite isn't ours to render.
+        val host = intent.getStringExtra(EXTRA_HOST).orEmpty()
+        if (host.isNotEmpty() && !host.equals(hostLabel, ignoreCase = true)) return
+        if (this::webView.isInitialized) webView.loadUrl(pageUrl(intent))
+    }
+
+    /** The gateway URL this intent asks for: the nsite root, or its deep path. */
+    private fun pageUrl(intent: Intent): String {
+        val path = intent.getStringExtra(EXTRA_PATH).orEmpty().ifEmpty { "/" }
+        val rooted = if (path.startsWith("/")) path else "/$path"
+        return "http://$hostLabel.localhost$rooted"
     }
 
     override fun onDestroy() {
@@ -225,7 +252,16 @@ class NsiteActivity : ComponentActivity() {
         const val EXTRA_HOST = "app.myco.extra.HOST"
         const val EXTRA_TITLE = "app.myco.extra.TITLE"
 
-        /** A per-host document URI so re-opening the same nsite re-surfaces its task. */
+        /** Where inside the nsite to land — a deep link's path. Root when absent. */
+        const val EXTRA_PATH = "app.myco.extra.PATH"
+
+        /**
+         * A per-host document URI so re-opening the same nsite re-surfaces its task.
+         *
+         * Host-only **on purpose**: the deep path travels in [EXTRA_PATH], not here.
+         * Folding it into the document URI would make every route a distinct document,
+         * so each route would spawn its own Recents card for the same app.
+         */
         fun documentUri(hostLabel: String): Uri = Uri.parse("myco://app/$hostLabel")
 
         /** Read the page's declared theme-color, else the computed body/html background. */

--- a/android/app/src/main/java/app/myco/share/MycoLink.kt
+++ b/android/app/src/main/java/app/myco/share/MycoLink.kt
@@ -1,0 +1,84 @@
+package app.myco.share
+
+/**
+ * The **app deep link**: `myco://app/<host>/<deep-path…>`.
+ *
+ * One link that names an app and a place inside it — `myco://app/<host>/dumpling/dmpl1…`
+ * is "open this app, at this route". Myco resolves the `<host>` half; everything after
+ * it is opaque and handed to the nsite verbatim.
+ *
+ * **It carries no secrets.** No holder npub, no pairing secret, no token that
+ * Myco interprets. A deep link travels through channels nobody controls — a chat
+ * message, a printed QR, a URL bar, someone's screenshot — so anything in it is public
+ * and replayable, which is the opposite of what a one-time pairing secret needs to be.
+ * Pairing has its own carrier: the scanned/tapped `myco://pair/…` and `myco://share/…`
+ * payloads in [NsiteShare], exchanged face to face.
+ *
+ * Losing the holder hint costs nothing: `Content::open_site` with `holder = None`
+ * already tries every Circle peer in turn and then the public fallback, so a link with
+ * no sharer attached still retrieves the app from whoever nearby happens to have it.
+ *
+ * Deliberately plain string parsing (no `android.net.Uri`), so it is a pure function
+ * the JVM unit tests can exercise without an emulator.
+ */
+object MycoLink {
+    const val APP_PREFIX = "myco://app/"
+
+    /** An app deep link: which nsite, and where inside it to land. */
+    data class AppLink(
+        /** The `<host>` label — an `npub1…` root, or `<pubkeyB36><dTag>`. */
+        val host: String,
+        /** The in-app path, leading slash included, query/fragment intact. `/` if none. */
+        val path: String,
+    )
+
+    /**
+     * Parse `myco://app/<host>[/<path>][?query][#fragment]`, or null if [uri] is not an
+     * app deep link (a `myco://pair/…`, a `myco://share/…`, a pasted nsite link, junk).
+     *
+     * A bare `myco://app/<host>` is valid and means "just open it" — `path = "/"`.
+     */
+    fun parseAppLink(uri: String): AppLink? {
+        val trimmed = uri.trim()
+        if (!trimmed.startsWith(APP_PREFIX, ignoreCase = true)) return null
+        val rest = trimmed.substring(APP_PREFIX.length)
+        if (rest.isEmpty()) return null
+
+        // The host label ends at the path, query, or fragment — whichever comes first.
+        val end = rest.indexOfFirst { it == '/' || it == '?' || it == '#' }
+        // Lowercased: a QR in alphanumeric mode carries an uppercased URI, and the
+        // label is case-insensitive (it is a DNS label). The path is left verbatim —
+        // its payload is the app's to interpret, and bech32 must not be case-mixed.
+        val host = (if (end < 0) rest else rest.substring(0, end)).lowercase()
+        if (!isHostLabel(host)) return null
+
+        val tail = if (end < 0) "" else rest.substring(end)
+        if (tail.any { it.isWhitespace() || it.code < 0x20 || it == '\\' }) return null
+        val path = when {
+            tail.isEmpty() -> "/"
+            // A link that jumps straight to a query/fragment still needs a path root.
+            tail.startsWith("/") -> tail
+            else -> "/$tail"
+        }
+        return AppLink(host, path)
+    }
+
+    /** Build the deep link for [host] at [path] (the share side of [parseAppLink]). */
+    fun buildAppLink(host: String, path: String): String {
+        val p = if (path.startsWith("/")) path else "/$path"
+        return "$APP_PREFIX$host${if (p == "/") "" else p}"
+    }
+
+    /**
+     * A plausible `<host>` label. Not a full resolve — the core does that, and this
+     * side has no secp256k1 — just the shape the label must have to be usable at all:
+     * it becomes a DNS label (`<host>.localhost`) for the WebView, so it is limited to
+     * what a DNS label may hold.
+     */
+    private fun isHostLabel(host: String): Boolean =
+        host.isNotEmpty() &&
+            host.length <= 63 &&
+            host.all { it in 'a'..'z' || it in '0'..'9' || it == '-' } &&
+            !host.startsWith("-") &&
+            !host.endsWith("-")
+}

--- a/android/app/src/main/java/app/myco/share/PendingDeepLinks.kt
+++ b/android/app/src/main/java/app/myco/share/PendingDeepLinks.kt
@@ -1,0 +1,85 @@
+package app.myco.share
+
+import android.content.Context
+import org.json.JSONObject
+
+/**
+ * Deep links waiting for their app to finish arriving.
+ *
+ * Tapping `myco://app/<host>/dumpling/…` for an app you don't have yet starts a mesh
+ * retrieval that may take seconds — or days, if nobody carrying that app has been near
+ * you since. The link has to outlive all of it: the sync, the app being swiped away,
+ * the process being killed, the phone being rebooted. So the pending path lives in
+ * SharedPreferences, not in memory, and is consumed on the app's **first** open —
+ * whether Myco opens it automatically the moment it turns ready, or the user taps it in
+ * the Apps grid themselves a week later.
+ *
+ * Stored as one JSON object, `{ "<host>": { "path": …, "ts": … } }`, under a single key:
+ * a handful of entries at most, and one write per change beats a key per host.
+ */
+object PendingDeepLinks {
+    private const val KEY = "pending_deep_links"
+
+    /** How long a pending link is worth honouring. Past this, the moment has passed:
+     *  landing someone on a month-old link is more confusing than opening the app. */
+    private const val TTL_MS = 30L * 24 * 60 * 60 * 1000
+
+    private const val FIELD_PATH = "path"
+    private const val FIELD_TS = "ts"
+
+    private fun prefs(ctx: Context) = ctx.getSharedPreferences("myco_prefs", Context.MODE_PRIVATE)
+
+    private fun read(ctx: Context): JSONObject =
+        runCatching { JSONObject(prefs(ctx).getString(KEY, "{}").orEmpty()) }.getOrElse { JSONObject() }
+
+    private fun write(ctx: Context, obj: JSONObject) {
+        prefs(ctx).edit().putString(KEY, obj.toString()).apply()
+    }
+
+    /** Remember that [host] should open at [path] once it is installed. Last link wins:
+     *  someone who sends a second link means the second one. */
+    fun put(ctx: Context, host: String, path: String, now: Long = System.currentTimeMillis()) {
+        if (host.isEmpty()) return
+        val obj = read(ctx)
+        obj.put(host, JSONObject().put(FIELD_PATH, path).put(FIELD_TS, now))
+        write(ctx, obj)
+    }
+
+    /** The path pending for [host], without consuming it. Null if none or expired. */
+    fun peek(ctx: Context, host: String, now: Long = System.currentTimeMillis()): String? {
+        val entry = read(ctx).optJSONObject(host) ?: return null
+        if (now - entry.optLong(FIELD_TS) > TTL_MS) return null
+        return entry.optString(FIELD_PATH).takeIf { it.isNotEmpty() }
+    }
+
+    /** The path pending for [host], clearing it — it is spent on this one open. */
+    fun take(ctx: Context, host: String, now: Long = System.currentTimeMillis()): String? {
+        val path = peek(ctx, host, now)
+        remove(ctx, host)
+        return path
+    }
+
+    fun remove(ctx: Context, host: String) {
+        val obj = read(ctx)
+        if (!obj.has(host)) return
+        obj.remove(host)
+        write(ctx, obj)
+    }
+
+    /** Every host with a live pending link, expired entries swept as a side effect. */
+    fun hosts(ctx: Context, now: Long = System.currentTimeMillis()): Set<String> {
+        val obj = read(ctx)
+        val live = mutableSetOf<String>()
+        var expired = false
+        for (host in obj.keys()) {
+            val entry = obj.optJSONObject(host)
+            if (entry != null && now - entry.optLong(FIELD_TS) <= TTL_MS) live += host else expired = true
+        }
+        if (expired) {
+            val kept = JSONObject()
+            for (host in live) kept.put(host, obj.get(host))
+            write(ctx, kept)
+        }
+        return live
+    }
+}

--- a/android/app/src/main/java/app/myco/ui/screens/DiscoverScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DiscoverScreen.kt
@@ -222,4 +222,5 @@ private data class SuggestedApp(val title: String, val host: String)
 private val SUGGESTED_APPS = listOf(
     SuggestedApp("bitchat", "4ofb5evx6765n3syphyhlocydo8q7fyipswzgpkx59u7p1yiivbitchat"),
     SuggestedApp("ICS", "4ofb5evx6765n3syphyhlocydo8q7fyipswzgpkx59u7p1yiivics"),
+    SuggestedApp("Dumplings", "4ofb5evx6765n3syphyhlocydo8q7fyipswzgpkx59u7p1yiivdumplings"),
 )

--- a/android/app/src/test/java/app/myco/share/MycoLinkTest.kt
+++ b/android/app/src/test/java/app/myco/share/MycoLinkTest.kt
@@ -1,0 +1,76 @@
+package app.myco.share
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MycoLinkTest {
+
+    private val host = "5rnyv42gd5hia53curyrl58o9vnouebwyt4gxdice14ialcs4vcahmls"
+
+    @Test
+    fun `parses an app link with a deep path`() {
+        val link = MycoLink.parseAppLink("myco://app/$host/dumpling/dmpl1qqqsyqcyq5rqwzqf")
+        assertEquals(host, link?.host)
+        assertEquals("/dumpling/dmpl1qqqsyqcyq5rqwzqf", link?.path)
+    }
+
+    @Test
+    fun `a bare app link opens the app at its root`() {
+        assertEquals("/", MycoLink.parseAppLink("myco://app/$host")?.path)
+        assertEquals("/", MycoLink.parseAppLink("myco://app/$host/")?.path)
+    }
+
+    @Test
+    fun `keeps the query and fragment for the app to read`() {
+        val link = MycoLink.parseAppLink("myco://app/$host/dumpling/abc?ref=qr#top")
+        assertEquals("/dumpling/abc?ref=qr#top", link?.path)
+    }
+
+    @Test
+    fun `a query with no path still lands on the root`() {
+        assertEquals("/?ref=qr", MycoLink.parseAppLink("myco://app/$host?ref=qr")?.path)
+    }
+
+    @Test
+    fun `lowercases the host so an uppercased QR still resolves`() {
+        // QR alphanumeric mode can only carry uppercase.
+        val link = MycoLink.parseAppLink("MYCO://APP/${host.uppercase()}/Invite/Abc")
+        assertEquals(host, link?.host)
+        // The path's case is the app's business, so it is left verbatim.
+        assertEquals("/Invite/Abc", link?.path)
+    }
+
+    @Test
+    fun `rejects the other myco schemes and junk`() {
+        assertNull(MycoLink.parseAppLink("myco://pair/eyJ2IjoxfQ"))
+        assertNull(MycoLink.parseAppLink("myco://share/eyJ2IjoxfQ"))
+        assertNull(MycoLink.parseAppLink("https://example.com/app/$host"))
+        assertNull(MycoLink.parseAppLink("myco://app/"))
+        assertNull(MycoLink.parseAppLink(""))
+    }
+
+    @Test
+    fun `rejects a host that is not a usable label`() {
+        // It becomes `<host>.localhost` in the WebView, so it must be a DNS label.
+        assertNull(MycoLink.parseAppLink("myco://app/has_underscore/x"))
+        assertNull(MycoLink.parseAppLink("myco://app/-leading/x"))
+        assertNull(MycoLink.parseAppLink("myco://app/trailing-/x"))
+        assertNull(MycoLink.parseAppLink("myco://app/${"a".repeat(64)}/x"))
+    }
+
+    @Test
+    fun `rejects a path carrying control characters`() {
+        assertNull(MycoLink.parseAppLink("myco://app/$host/in\nvite"))
+        assertNull(MycoLink.parseAppLink("myco://app/$host/in vite"))
+        assertNull(MycoLink.parseAppLink("myco://app/$host/in\\vite"))
+    }
+
+    @Test
+    fun `builds links that parse back`() {
+        val built = MycoLink.buildAppLink(host, "/dumpling/dmpl1abc")
+        assertEquals("myco://app/$host/dumpling/dmpl1abc", built)
+        assertEquals("/dumpling/dmpl1abc", MycoLink.parseAppLink(built)?.path)
+        assertEquals("myco://app/$host", MycoLink.buildAppLink(host, "/"))
+    }
+}

--- a/docs/design/deep-links.md
+++ b/docs/design/deep-links.md
@@ -1,0 +1,128 @@
+# Deep links
+
+A link that names an app **and a place inside it**, and works whether or not the
+receiving phone has that app yet.
+
+```
+myco://app/<host>/<path>
+
+myco://app/5rnyv42gd5hia53curyrl58o9vnouebwyt4gxdice14ialcs4vcahmls/dumpling/dmpl1…
+         └────────────────────── host ──────────────────────┘└──── path ────┘
+```
+
+- `<host>` is the ordinary nsite label — an `npub1…` root, or `<pubkeyB36><dTag>`.
+  Myco resolves it, and retrieves the app if it is missing.
+- Everything after it is **opaque to Myco** and handed to the nsite verbatim, query
+  and fragment included. `/dumpling/dmpl1…` means nothing here; it means whatever the
+  app says it means.
+- A bare `myco://app/<host>` is valid: "just open it".
+
+Parsed by `MycoLink.parseAppLink` (`android/…/share/MycoLink.kt`), which is a pure
+function with JVM unit tests. The host is lowercased (a QR in alphanumeric mode is
+uppercase-only) and must be a usable DNS label, because it becomes `<host>.localhost`
+in the WebView. The path is left exactly as written.
+
+## §1 It carries no secrets
+
+Deliberately: **no holder npub, no pairing secret, no token Myco interprets.**
+
+A deep link goes places nobody controls — a chat message, a printed QR on a wall, a
+URL bar, a screenshot in someone's camera roll. Anything inside it is public, durable
+and replayable, which is the exact opposite of what a one-time pairing secret needs to
+be. Pairing keeps its own carrier: the scanned or tapped `myco://pair/…` and
+`myco://share/…` payloads (`docs/design/identity-pairing.md`), exchanged face to face,
+one-shot, and short-lived.
+
+Dropping the holder hint costs a retry and nothing else. `Content::open_site` with
+`holder = None` already walks every Circle peer in turn and then the public IP source
+(`myco-core/src/content.rs`), so a link with no sharer attached still finds the app
+through whoever nearby happens to have it.
+
+## §2 The deferred open
+
+The hard requirement: **the first open of a deep-linked app lands on the deep link** —
+no matter how long "first" takes.
+
+```
+tap myco://app/<host>/dumpling/…
+        │
+        ├── app ready ──────────────► open it, at that path. done.
+        │
+        └── not ready
+              │  remember {host → path} in SharedPreferences
+              │  dispatch OpenNsite{link: host, holder: null}
+              │
+              ├── foreground watcher (3 min, 1s poll) ──► ready ──► open at path
+              ├── every MainActivity.onResume ──────────► ready ──► open at path
+              │                                     └─► unreachable ──► retry OpenNsite
+              └── user taps the app in the Apps grid ──► launchNsite spends the path
+```
+
+Three consumers, one store (`PendingDeepLinks`), and the path is spent by whichever
+gets there first:
+
+- **The watcher** covers the common case — a peer is right there in the room and the
+  sync finishes in seconds while Myco is still open.
+- **The resume reconciler** is the durable half. The watcher dies with the process;
+  this doesn't. A link followed before a reboot opens the first time Myco comes back up
+  with the app in hand. It also **re-dispatches** an `unreachable` app rather than
+  writing it off: nobody in range had it *then*, and someone who does may have walked
+  in since.
+- **`launchNsite`** consumes a pending path too, so someone who opens the app from the
+  Apps grid themselves still lands on the link they followed days ago.
+
+Entries expire after 30 days. Past that the moment has passed, and landing someone on a
+month-old link is more confusing than opening the app.
+
+## §3 Recents, and an app that is already open
+
+The nsite task is keyed by a **host-only** document URI (`myco://app/<host>`), and the
+path travels in an intent extra. Folding the path into the document URI would make
+every route a separate document, so each route would get its own Recents card for the
+same app.
+
+The flip side is that a deep link into an already-open nsite re-surfaces the existing
+task, so `NsiteActivity.onNewIntent` navigates the WebView to the new path — otherwise
+the user would be handed back the page they left instead of the one they just tapped.
+
+## §4 What the gateway had to give up
+
+`/dumpling/dmpl1…` is not a file any manifest lists. The gateway now resolves a miss as:
+
+1. the site's own `/404.html`, if it ships one — it owns that answer;
+2. `/index.html` with a **200** — the app shell, so a client-side route reaches the
+   router;
+3. otherwise the gateway's 404 page.
+
+Step 2 applies **only to navigation-style requests**: those where `normalize_path`
+produced a `…/index.html` (root, trailing slash, or an extensionless last segment). A
+missing `/assets/app.js` still 404s. Answering a script request with HTML and a 200 is
+the classic SPA-fallback footgun — it turns a broken asset into a silent one.
+
+Two consequences for anyone writing an nsite with real routes:
+
+- **Route segments must not contain a dot.** A dot makes the segment look like an asset,
+  and it 404s instead of reaching the router. (Bech32 payloads have none — one reason
+  Dumplings encodes its payloads that way.)
+- **Build with `base: "/"`, not `"./"`.** From `/dumpling/x`, a relative
+  `./assets/index.js` resolves to `/dumpling/assets/index.js`, which does not exist.
+
+## §5 What is not covered
+
+If **Myco itself** is not installed, `myco://` has no handler and the tap does nothing.
+Solving that needs an `https://` App Link landing page plus a deferred-deep-link
+mechanism (clipboard hand-off, since sideload and zapstore distribution rule out the
+Play Install Referrer). Deferred: while distribution is sideload-first, the person
+sending the link is standing next to the person receiving it.
+
+## §6 See it work
+
+`myco-dumplings/` exists for exactly this: a bookmark app whose only real feature is
+sharing a link as `myco://app/<host>/dumpling/dmpl1…`.
+
+```sh
+adb shell am start -a android.intent.action.VIEW -d "myco://app/<host>/dumpling/dmpl1…"
+```
+
+Run it twice: once against a phone that has the app, once against one that has never
+seen it.

--- a/nsite-deck/src/gateway.rs
+++ b/nsite-deck/src/gateway.rs
@@ -8,7 +8,7 @@
 //! served once **all** its referenced blobs are present; until then the gateway
 //! returns a small loading page (HTTP 503) so a half-synced site never renders.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::content_type;
 use crate::host::{self, SiteAddr};
@@ -117,13 +117,9 @@ pub async fn serve(
 
     let normalized = normalize_path(path);
 
-    // Map path -> sha256, falling back to /404.html, then a gateway 404.
-    let (hash, status) = match manifest.hash_for(&normalized) {
-        Some(h) => (h.to_string(), 200u16),
-        None => match manifest.hash_for("/404.html") {
-            Some(h) => (h.to_string(), 404),
-            None => return GatewayResponse::html(404, gateway_404_page(&normalized)),
-        },
+    let (hash, status) = match resolve_hash(&manifest.paths, &normalized) {
+        Some((h, status)) => (h.to_string(), status),
+        None => return GatewayResponse::html(404, gateway_404_page(&normalized)),
     };
 
     match blobs.get(&hash).await {
@@ -141,6 +137,37 @@ pub async fn serve(
         Ok(None) => GatewayResponse::html(503, loading_page("Loading…")),
         Err(e) => GatewayResponse::html(500, format!("<h1>500</h1><pre>{e}</pre>")),
     }
+}
+
+/// Map an already-[`normalize_path`]d request path to `(sha256, http status)`.
+///
+/// Precedence on a miss:
+/// 1. `/404.html` — an nsite that ships its own not-found page owns that answer.
+/// 2. `/index.html` — the **SPA fallback**: the app shell, served with **200**, so a
+///    client-side route (`/dumpling/<payload>`, a deep link's landing path) reaches the
+///    router that knows what to do with it instead of dying on the doormat.
+/// 3. Nothing — the caller renders the gateway's own 404.
+///
+/// The shell fallback is deliberately limited to **navigation-style** requests: those
+/// where [`normalize_path`] produced a `…/index.html` (root, trailing slash, or an
+/// extensionless last segment). A missing `/assets/app.js` must keep 404ing — serving
+/// it HTML with a 200 turns a broken asset into a silent, much harder bug.
+fn resolve_hash<'a>(
+    paths: &'a BTreeMap<String, String>,
+    normalized: &str,
+) -> Option<(&'a str, u16)> {
+    if let Some(h) = paths.get(normalized) {
+        return Some((h.as_str(), 200));
+    }
+    if let Some(h) = paths.get("/404.html") {
+        return Some((h.as_str(), 404));
+    }
+    if normalized.ends_with("/index.html") {
+        if let Some(h) = paths.get("/index.html") {
+            return Some((h.as_str(), 200));
+        }
+    }
+    None
 }
 
 /// Normalize a request path to a manifest path: index.html fallback for the
@@ -286,6 +313,62 @@ mod tests {
         assert_eq!(normalize_path("/style.css"), "/style.css");
         assert_eq!(normalize_path("index.html"), "/index.html");
         assert_eq!(normalize_path("/a/b.js?v=2"), "/a/b.js");
+    }
+
+    /// A manifest's path map, built from `(path, hash)` pairs.
+    fn paths(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+        entries
+            .iter()
+            .map(|(p, h)| (p.to_string(), h.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn serves_an_exact_path_before_any_fallback() {
+        let p = paths(&[("/style.css", "css"), ("/index.html", "shell")]);
+        assert_eq!(resolve_hash(&p, "/style.css"), Some(("css", 200)));
+        assert_eq!(resolve_hash(&p, "/index.html"), Some(("shell", 200)));
+    }
+
+    #[test]
+    fn falls_back_to_the_app_shell_for_an_unknown_route() {
+        // `/dumpling/dmpl1abc` normalizes to `…/index.html` — a client-side route.
+        let p = paths(&[("/index.html", "shell")]);
+        assert_eq!(
+            resolve_hash(&p, &normalize_path("/dumpling/dmpl1abc")),
+            Some(("shell", 200)),
+            "a deep-link route reaches the router, not a 404",
+        );
+        assert_eq!(resolve_hash(&p, &normalize_path("/")), Some(("shell", 200)));
+        assert_eq!(
+            resolve_hash(&p, &normalize_path("/deep/nested/route")),
+            Some(("shell", 200)),
+        );
+    }
+
+    #[test]
+    fn a_missing_asset_still_404s() {
+        // Serving the shell for a missing script would turn a broken asset into a
+        // silent bug: 200 OK, HTML where JS was expected.
+        let p = paths(&[("/index.html", "shell")]);
+        assert_eq!(resolve_hash(&p, &normalize_path("/assets/app.js")), None);
+        assert_eq!(resolve_hash(&p, &normalize_path("/favicon.ico")), None);
+    }
+
+    #[test]
+    fn a_sites_own_404_page_wins_over_the_shell() {
+        let p = paths(&[("/index.html", "shell"), ("/404.html", "notfound")]);
+        assert_eq!(
+            resolve_hash(&p, &normalize_path("/nope")),
+            Some(("notfound", 404)),
+            "an nsite that ships a 404 page owns that answer",
+        );
+    }
+
+    #[test]
+    fn no_shell_means_the_gateway_404s() {
+        let p = paths(&[("/style.css", "css")]);
+        assert_eq!(resolve_hash(&p, &normalize_path("/anything")), None);
     }
 
     #[test]


### PR DESCRIPTION
A link can now point at a place **inside** an app, not just at the app:

```
myco://app/<host>/<path>
```

Follow one for an app you don't have and Myco fetches it from whoever nearby is carrying it, then opens it on the spot the link named. However long that takes — five seconds if a peer is in the room, or after a reboot next week if nobody was — the app's **first** open lands on the link.

No issue to close; this came out of wanting a shareable "here, look at this thing in this app" link.

## What's in the diff

**The gateway learns client-side routes** (`nsite-deck/src/gateway.rs`). A deep path is not a file any manifest lists, so the gateway used to 404 before the app's router ran. A miss now resolves as: the site's own `/404.html` → `/index.html` with a 200 → the gateway 404 page.

The shell fallback is deliberately narrowed to **navigation-style** requests — those where `normalize_path` produced a `…/index.html` (root, trailing slash, extensionless last segment). A missing `/assets/app.js` still 404s. Serving HTML with a 200 for a script request is the classic SPA-fallback footgun: it turns a broken asset into a silent one. The path resolution moved into a pure `resolve_hash(paths, normalized)` so it is testable without constructing a signed manifest event; five new unit tests cover shell-hit, asset-miss, `404.html` precedence, and no-shell.

**The link itself** (`share/MycoLink.kt`) is a pure function with 9 JVM unit tests. The host is lowercased (a QR in alphanumeric mode can only carry uppercase) and validated as a DNS label, because it becomes `<host>.localhost` in the WebView; the path is passed through verbatim, query and fragment included, and rejected if it carries control characters.

**It carries no secrets, on purpose** — no holder npub, no pairing secret, no token Myco interprets. A deep link travels through channels nobody controls (a chat message, a printed QR, a screenshot), so anything inside it is public, durable and replayable, which is the opposite of what a one-time pairing secret needs. Pairing keeps its own face-to-face carrier (`myco://pair/…`, `myco://share/…`). Dropping the holder hint costs only a retry: `Content::open_site` with `holder = None` already walks every Circle peer and then the public source.

**The deferred open** (`share/PendingDeepLinks.kt` + `MainActivity`) is the part that needed care. The pending `{host → path}` lives in SharedPreferences, and three consumers race to spend it:

- a bounded foreground watcher (3 min, 1 s poll) for the common case where a peer is right there;
- a reconciler on every `MainActivity.onResume`, which is the durable half — the watcher dies with the process, this doesn't — and which **re-dispatches** an `unreachable` app rather than writing it off, since nobody in range had it *then* and someone who does may have walked in since;
- `launchNsite`, so a user who opens the app from the Apps grid themselves also lands where they were sent.

Entries expire after 30 days.

**Recents keying** (`NsiteActivity`): the task document URI stays host-only, with the path in an intent extra, so a deep link re-surfaces the app's existing card instead of opening one card per route. The flip side is that an already-open nsite would otherwise show the page the user left, so `onNewIntent` navigates the WebView to the new path.

## Cross-cutting

**No new dependencies** — Rust or Android.

**Security surface.** One new untrusted-input parser (`MycoLink`). It is total: every failure path returns `null`, no `!!`, no exceptions, nothing on the main thread beyond a SharedPreferences read. The parsed path reaches only `loadUrl("http://<host>.localhost$path")`, where the host is already fixed, so a hostile path cannot redirect the WebView off-origin; the `.localhost` intercept in `NsiteActivity` is unchanged. `PendingDeepLinks` stores no secrets. The scheme filter and the `NsiteActivity` export status are untouched — `NsiteActivity` remains `exported="false"`.

**Threading.** `core.state()` in the reconciler and watcher is read on `Dispatchers.IO` inside `lifecycleScope`, matching the existing `offerHomeScreenWhenReady` pattern; the watcher set is de-duplicated so resumes don't stack coroutines, and each watcher clears its entry in a `finally`.

**Docs.** New `docs/design/deep-links.md` (grammar, the no-secrets rationale, the deferred-open state machine, the gateway rule, and what is explicitly *not* covered), linked from the README, with a `CHANGELOG.md` entry under `[Unreleased]`.

**Discover** gains a third suggested app, Dumplings — a link-sharing nsite that exists to exercise this path end to end (save a link, hand it to whoever is next to you, they choose whether to keep it). Like `myco-ics` and `myco-bitchat` it is developed as its own repo and is gitignored here, so its source is not in this diff — the entry is just a host label, same shape as the two beside it.

## Testing

- `cargo fmt --check`, `cargo build`, `cargo test` — clean; `nsite-deck` 22 pass, 5 new.
- `cargo clippy --all-targets` — no new warnings. The remaining ones are pre-existing (verified: identical count with this branch's changes stashed) and in files this PR doesn't touch.
- `./gradlew testDebugUnitTest` — `MycoLinkTest` 9/9; `./gradlew assembleDebug` clean.
- Installed on a Pixel 7 Pro (Android 17) and a Galaxy A52s (Android 14).

**Not yet verified on device:** the end-to-end claim — follow a link on a phone that does *not* have the app, wait for the mesh fetch, land on the path. That needs two phones and Dumplings published, and I want to be straight that I have not run it yet rather than imply I have. The pieces it is built from are individually exercised (parser and gateway by unit tests; the ready-poll shape is the same one `offerHomeScreenWhenReady` already ships).

## Known gap, deliberately out of scope

If **Myco itself** isn't installed, `myco://` has no handler and the tap does nothing. Closing that needs an `https://` App Link landing page plus a deferred-deep-link hand-off (clipboard — sideload and zapstore distribution rule out the Play Install Referrer), which is a domain-and-hosting change rather than a code one. Reasoning is written down in `docs/design/deep-links.md` §5.

Relatedly, and worth knowing before anyone reports it as a bug: custom schemes are not auto-linkified by Android's `Linkify`, so a `myco://` link pasted into most chat apps renders as plain text. QR, NFC, and the in-app scanner are the channels that work today. The `https://` App Link above is also the fix for that.
