### PR TITLE
Rebuild on current FIPS, and make the radios actually hold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,13 @@ on:
 
 env:
   # `fips` is a gitignored local path dep (reference/fips). A fresh checkout has no
-  # reference/ at all, so clone the fork branch carrying the mobile features
-  # (platform-pushed peer queue + Wi-Fi Aware transport-preference roaming).
+  # reference/ at all, so clone the branch carrying the mobile seams: Android
+  # BLE as a backend behind the existing `BleIo` trait, per-instance transport
+  # addressing (the LAN and Wi-Fi Aware lanes need one UDP socket each), and the
+  # app-owned TUN/UDP/radio seams. Built on current fips master; each commit is
+  # shaped to be cherry-picked upstream on its own.
   FIPS_REPO: https://github.com/jmcorgan/fips.git
-  FIPS_REF: feat/platform-peer-queue
+  FIPS_REF: integration/platform
   NDK_VERSION: 26.1.10909125
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   FIPS_REPO: https://github.com/jmcorgan/fips.git
-  FIPS_REF: feat/platform-peer-queue   # fips fork branch carrying the mobile + Wi-Fi Aware features
+  FIPS_REF: integration/platform   # fips branch carrying the mobile seams (Android BLE, per-instance transports)
   NDK_VERSION: 26.1.10909125
 
 jobs:

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -260,11 +260,19 @@ reaches past the colour scheme will be caught there.
 
 ## Build environment
 
-- **`reference/fips` must be checked out on `feat/platform-peer-queue`.** It is a
-  gitignored path dependency, and `master` does not export the symbols myco-core
-  needs (`fips::discovery::platform`, a public `ControlReadHandle`) — the Android
-  build fails to compile against it. `release.yml` clones the same ref from
-  `jmcorgan/fips`. Phase 4 is what removes this constraint.
+- **`reference/fips` must be checked out on `integration/platform`.** It is a
+  gitignored path dependency. That branch sits on current fips master and adds
+  the mobile seams myco-core needs: Android BLE behind the existing `BleIo`
+  backend trait, per-instance transport addressing (the LAN and Wi-Fi Aware
+  lanes take one UDP socket each), and the app-owned TUN/UDP/radio seams.
+  `ci.yml` and `release.yml` clone the same ref from `jmcorgan/fips`.
+
+  The old `feat/platform-peer-queue` branch is gone from the build. What
+  myco-core used to reach for there — `fips::discovery::platform`, a public
+  `ControlReadHandle`, `ble::attempts`, `ble::android_io` — no longer exists in
+  any form. Peer state and peer commands now go over the node's own control
+  socket, and each commit on `integration/platform` is shaped to be
+  cherry-picked upstream on its own rather than living as a fork.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Wi-Fi Aware carries mesh traffic for the first time. The fast lane had been
+  negotiating a data path with nearby phones for months and never moving a
+  byte over it: the mesh node had one UDP socket, and the LAN lane pinned it to
+  the Wi-Fi network, after which nothing addressed to an Aware link could be
+  routed. Aware now has its own socket, pinned to its own network, and two
+  phones in a room peer over it directly — no access point, no router, no
+  internet. On the bench it becomes the busiest link between them, ahead of
+  Bluetooth and ahead of the LAN.
+- A lost Aware link comes back in seconds rather than minutes. It used to wait
+  for the next discovery sweep; it now asks for the path again as soon as it
+  drops, backing off if the peer has genuinely gone.
+- Settings says so when Bluetooth scanning is deaf because location services
+  are off. Some phones refuse to report nearby devices without location even
+  when an app asks not to use it for location, and the symptom is an empty peer
+  list with nothing to explain it — on one tablet, hours of it. The warning
+  appears only once scanning has actually been silent for a while, so a phone
+  that scans perfectly well with location off is never nagged, and tapping it
+  goes straight to the setting.
+- Each peer on the Dev tab now shows which radio carried it, as an icon down
+  the left edge: the Bluetooth rune, the Wi-Fi Aware arcs, or a globe for
+  anything routed. A peer with no link yet shows nothing rather than a guess.
+- Peer rows carry how long the session has been up beside how long ago it was
+  heard from. Those answer different questions, and only the second was
+  visible: a link re-establishing every few seconds looks perfectly healthy if
+  all you can see is that it was heard from a moment ago.
+
+### Changed
+
+- The mesh node is rebuilt on current FIPS. The version Myco had been building
+  against had drifted a long way behind, and the gap included fixes to path
+  MTU, framing, peer identity and the control plane. Everything Myco needs from
+  the node is now carried as focused changes on top of that current base rather
+  than as a private fork: Bluetooth as a first-class transport on Android,
+  per-instance transport addressing, an app-owned socket seam, and two
+  control-plane bug fixes. Peer state, peer discovery and `.fips` name
+  resolution all moved onto interfaces the node already ships.
+- Dev tab peer rows are legibly expandable — a caret says a row opens before
+  you tap it — and the screen now leads with your own identity, then peers,
+  then the radio self-check, which is the order you read them in.
+
+### Fixed
+
+- Bluetooth works again after being switched off and on. Turning the radio off
+  and back on — or leaving and returning from airplane mode — left the app
+  permanently unable to see any Bluetooth peer until it was force-stopped,
+  because nothing was watching the adapter. The lane is now rebuilt when the
+  radio returns, including the case where the app started with Bluetooth
+  already off.
+- Failed Bluetooth dials no longer accumulate until nothing can connect. Every
+  attempt that timed out abandoned a socket holding a connection slot, and once
+  enough had leaked every later attempt hung for its full timeout and failed —
+  recoverable only by force-stopping the app, which is exactly the workaround
+  this behaviour had been trained into people for months.
+- A phone could advertise a Bluetooth port nothing was listening on, which made
+  it permanently impossible to dial while looking perfectly healthy from the
+  outside. It now advertises the port it actually bound, and re-advertises when
+  that changes.
+- An unreachable peer is no longer redialled every thirty seconds forever. One
+  dead address could absorb most of the connection attempts and block every
+  other peer queued behind it; attempts now back off per address.
+- Turning the mesh off and on left the previous node running. Two nodes then
+  shared one radio, and the one answering questions about peers was not the one
+  doing the work — so the app could report no peers while a connection was live.
+- The Dev tab reported Bluetooth scanning and advertising as `unknown` on a
+  radio that was plainly working, and kept saying `active` after the radio had
+  been shut down.
+- Scan reports no longer flood the log. A busy room produced thousands of
+  lines and pushed anything useful out of the buffer within seconds; a phone
+  whose scanner returns nothing at all now says so once per window instead of
+  saying nothing.
+
 ## [0.5.0] - 2026-08-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,7 @@ dependencies = [
  "hex",
  "hkdf",
  "libc",
+ "libm",
  "mdns-sd",
  "nostr",
  "nostr-sdk",
@@ -1211,9 +1212,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1909,9 +1910,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -2053,9 +2054,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mdns-sd"
-version = "0.19.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18148fee27e99e76dbf6e137f27727113d31f766e578d1b93a93c3615fca7081"
+checksum = "86dbb9f00c8c367f75ed3a775d3eb31d0375a72f58275ef64a1bc53c255a2ce2"
 dependencies = [
  "fastrand",
  "flume",
@@ -3570,13 +3571,13 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket-pktinfo"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+checksum = "612942246d0cc239cfd83af1dfd39be47f649208a3524e5e9da651910128e0ac"
 dependencies = [
  "libc",
  "socket2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,6 +1202,7 @@ dependencies = [
  "tun",
  "windows-service",
  "wintun",
+ "zeroize",
 ]
 
 [[package]]
@@ -5058,6 +5059,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -221,18 +221,68 @@ class MainActivity : ComponentActivity() {
 
     // --- mesh adapter (app-owned TUN) ---
 
+    /**
+     * The mesh master switch. Takes the node **and the BLE radio** with it.
+     *
+     * The radio has to follow, and this is the one place it does. The BLE
+     * byte-bridge hands its scan and accept receivers to whichever transport
+     * asks first, and never gets them back — so a node rebuilt underneath a
+     * surviving radio comes up with a scanner that receives nothing and an
+     * acceptor that accepts nothing: BLE looks alive (advertising, the radio
+     * still scanning) while no advert ever reaches the new node. Rebuilding the
+     * radio alongside the node gives the new transport a fresh bridge to take.
+     *
+     * This does not contradict [BleService]'s rule that starting a radio must
+     * never bounce the node — that is about the *radio* toggle. Here the node is
+     * going down regardless; the radio is following it, not driving it.
+     */
     private fun setMeshEnabled(enabled: Boolean) {
         prefs.edit().putBoolean(PREF_MESH, enabled).apply()
+        val bleOn = prefs.getBoolean(PREF_BLE, true)
         if (enabled) {
             // Node follows the master switch (radio toggles only gate radios).
             core.dispatch(NativeActions.startNode())
+            startBleWhenNodeUp()
             // Android requires user consent before any app can run a VPN.
             val consent = VpnService.prepare(this)
             android.util.Log.i("MycoVpn", "setMeshEnabled(true): consent needed=${consent != null}")
             if (consent != null) vpnConsentLauncher.launch(consent) else startMeshNow()
         } else {
             MycoVpnService.stop(this)
+            // Stop the node first: its drain wants to get a shutdown Disconnect
+            // out over whatever links are still up, including BLE.
             core.dispatch(NativeActions.stopNode())
+            if (bleOn) BleService.stop(this)
+        }
+    }
+
+    /**
+     * Start the BLE radio, but not before the node is actually running.
+     *
+     * The order is load-bearing. The byte-bridge's scan and accept receivers are
+     * single-take: whichever transport resolves the bridge first keeps them for
+     * good. Creating the radio while the previous node is still draining hands
+     * the fresh bridge to the *dying* transport, and the node that replaces it
+     * comes up deaf — advertising normally, scanning normally, and receiving
+     * nothing. Waiting for `nodeRunning` means the new transport is the one that
+     * takes them.
+     *
+     * Same retry budget as [startMeshNow], and the same reasoning: a stop that
+     * has to drain first can hold the start back for a couple of seconds.
+     */
+    private fun startBleWhenNodeUp(attempt: Int = 0) {
+        if (!prefs.getBoolean(PREF_BLE, true)) return
+        if (!bleCorePermsGranted()) {
+            requestBlePermissionsIfNeeded()
+            return
+        }
+        // Out of retries: start anyway rather than leaving BLE off entirely. A
+        // bridge that arrives late is picked up in place — the running scanner
+        // re-resolves the slot and takes the new receivers.
+        if (core.state().nodeRunning || attempt >= MESH_START_RETRIES) {
+            BleService.start(this)
+        } else {
+            window.decorView.postDelayed({ startBleWhenNodeUp(attempt + 1) }, MESH_START_RETRY_MS)
         }
     }
 

--- a/android/app/src/main/java/app/myco/ap/ApRadio.kt
+++ b/android/app/src/main/java/app/myco/ap/ApRadio.kt
@@ -12,12 +12,11 @@ import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
-import android.os.ParcelFileDescriptor
 import android.util.Log
 import androidx.annotation.RequiresApi
 import app.myco.core.MycoCore
 import app.myco.core.NativeCore
-import java.io.FileDescriptor
+import app.myco.core.UdpSocketPin
 import java.net.Inet4Address
 import java.net.Inet6Address
 import java.net.InetAddress
@@ -36,11 +35,13 @@ import kotlinx.coroutines.flow.asStateFlow
  *     LAN discovery publishes (`reference/fips` `src/discovery/lan`), whose
  *     TXT carries the node's `npub`;
  *  3. on resolve, push `(npub, addr)` into the core's platform peer queue
- *     ([NativeCore.awarePeerFound], transport `"udp"`, lane `"udp"`) — the
- *     same seam the Wi-Fi Aware radio uses, labelled with this lane's own
- *     name rather than masquerading as Aware. The node dials the UDP
- *     transport bound `:4871` and Noise IK authenticates; the pushed npub is
- *     only a routing hint.
+ *     ([NativeCore.awarePeerFound], lane `"udp"`) — the same seam the Wi-Fi
+ *     Aware radio uses, labelled with this lane's own name rather than
+ *     masquerading as Aware. The core turns that label into the qualified
+ *     transport `"udp/lan"`, so the node dials the LAN lane's own UDP socket
+ *     (bound `:4871`, pinned below to this Wi-Fi [Network]) and never the
+ *     Aware one; Noise IK authenticates, and the pushed npub is only a
+ *     routing hint.
  *
  * The browse is deliberately **not** gated on the literal `!FIPS` SSID: on
  * API 33+ the SSID is redacted unless the app holds location permission, so a
@@ -59,10 +60,10 @@ import kotlinx.coroutines.flow.asStateFlow
  * The `!FIPS` AP never passes internet validation (it's local-only), so on a
  * phone with active mobile data the OS can route the handshake's replies to
  * a competing validated default network instead of back over this Wi-Fi —
- * the send succeeds locally but nothing ever comes back. [`bindUdpSocket`]
- * pins the core's UDP transport socket (fd surfaced via
- * [NativeCore.nextUdpTransportFd]) to this specific [Network] with
- * `Network.bindSocket` so replies aren't lost that way.
+ * the send succeeds locally but nothing ever comes back. [UdpSocketPin] pins
+ * this lane's own UDP transport socket to this specific [Network] so replies
+ * aren't lost that way — and, because that mark is exclusive, so that pinning
+ * it here cannot cost the Wi-Fi Aware lane its own reachability.
  */
 class ApRadio private constructor(private val context: Context) {
     private val connectivity =
@@ -104,11 +105,11 @@ class ApRadio private constructor(private val context: Context) {
     private var browseListener: NsdManager.DiscoveryListener? = null
     private var ssid: String? = null
 
-    /** The core's UDP transport socket fd, once learned (see [bindUdpSocket]).
-     *  Confined to [handler]; re-learned each time the node (re)starts.
-     *  [udpPfd] owns the dup and is kept alive so [udpFd] stays valid. */
-    private var udpPfd: ParcelFileDescriptor? = null
-    private var udpFd: FileDescriptor? = null
+    /** Pins this lane's UDP transport socket to the current Wi-Fi [Network] —
+     *  see [UdpSocketPin] for why each lane needs a socket of its own. Asks
+     *  for [LANE] by name, so it can only ever receive the LAN lane's socket,
+     *  never Wi-Fi Aware's. */
+    private val udpPin = UdpSocketPin(LANE, handler, TAG)
 
     /** Own npub, to skip a self-advert (defensive — the app never publishes
      *  mDNS, only browses). Resolved lazily; the core is up by first resolve. */
@@ -124,7 +125,7 @@ class ApRadio private constructor(private val context: Context) {
 
         override fun onAvailable(network: Network) {
             if (wifiNets.add(network) && wifiNets.size == 1) startBrowse()
-            bindUdpSocket(network)
+            udpPin.bindTo(network)
             publishWifi()
         }
 
@@ -134,6 +135,7 @@ class ApRadio private constructor(private val context: Context) {
         }
 
         override fun onLost(network: Network) {
+            udpPin.clearTarget(network)
             if (wifiNets.remove(network) && wifiNets.isEmpty()) {
                 ssid = null
                 stopBrowse()
@@ -157,43 +159,10 @@ class ApRadio private constructor(private val context: Context) {
         connectivity.registerNetworkCallback(request, callback, handler)
         Log.i(TAG, "AP lane armed (browsing $SERVICE_TYPE while Wi-Fi is up)")
 
-        // Learn the core's UDP transport fd as soon as the node opens it (only
-        // once mesh is toggled on — see runtime.rs's start_node). A dedicated
-        // thread since the native call blocks; loops forever so a later
-        // mesh off→on cycle (a fresh transport, fresh fd) is picked up too.
-        Thread({
-            while (true) {
-                val fd = NativeCore.nextUdpTransportFd(FD_POLL_TIMEOUT_MS)
-                if (fd >= 0) handler.post { onUdpFd(fd) }
-            }
-        }, "myco-ap-udpfd").apply { isDaemon = true; start() }
-    }
-
-    /** A fresh UDP transport fd arrived (node just started, or restarted).
-     *  `fromFd` dups it, so fips keeps full ownership of the original — the
-     *  dup refers to the same socket, and `bindSocket`'s mark applies to the
-     *  socket, not the fd. The [ParcelFileDescriptor] is held (not closed) for
-     *  as long as we may need to re-bind on a network change. */
-    private fun onUdpFd(fd: Int) {
-        val pfd = runCatching { ParcelFileDescriptor.fromFd(fd) }.getOrElse {
-            Log.w(TAG, "could not dup UDP transport fd $fd", it)
-            return
-        }
-        udpPfd?.let { old -> runCatching { old.close() } }
-        udpPfd = pfd
-        udpFd = pfd.fileDescriptor
-        wifiNets.firstOrNull()?.let { bindUdpSocket(it) }
-    }
-
-    /** Pin the core's UDP transport socket to `network` via `Network.bindSocket`
-     *  — see the class doc's "why" — so replies to a peer on this ap-lane
-     *  network aren't lost to a competing validated default network. A no-op
-     *  until [onUdpFd] has learned the fd (mesh not started yet). */
-    private fun bindUdpSocket(network: Network) {
-        val fd = udpFd ?: return // node not started yet; onUdpFd binds when it is
-        runCatching { network.bindSocket(fd) }
-            .onSuccess { Log.i(TAG, "bound core UDP socket to $network") }
-            .onFailure { Log.w(TAG, "bindSocket to Wi-Fi network failed", it) }
+        // Learn this lane's UDP transport socket as soon as the node opens it
+        // (only once mesh is toggled on — see runtime.rs's start_node) and pin
+        // it to the Wi-Fi network the browse is running over.
+        udpPin.start()
     }
 
     // --- mDNS browse ---
@@ -479,10 +448,11 @@ class ApRadio private constructor(private val context: Context) {
         /** TXT key carrying the advertising node's npub. */
         private const val TXT_NPUB = "npub"
 
-        /** The lane label pushed to [NativeCore.awarePeerFound]/[NativeCore.awarePeerLost]
-         *  — distinguishes this radio from [app.myco.aware.AwareRadio], which shares
-         *  the same JNI seam and pushes "aware" even though both ride fips's UDP
-         *  transport underneath. */
+        /** The lane label pushed to [NativeCore.awarePeerFound]/[NativeCore.awarePeerLost],
+         *  and asked of [NativeCore.nextUdpTransportFd] — distinguishes this radio from
+         *  [app.myco.aware.AwareRadio], which shares the same JNI seams and pushes
+         *  "aware". Both ride UDP, but each lane is its own transport instance with
+         *  its own socket, and this label is what selects between them. */
         private const val LANE = "udp"
 
         /** Candidate-rotation interval (see [rotate]).
@@ -500,11 +470,6 @@ class ApRadio private constructor(private val context: Context) {
          *  nothing is connected, and an established session is worth far more
          *  than shaving seconds off finding one. */
         private const val REPUSH_MS = 35_000L
-
-        /** Blocking wait per poll for the core's UDP transport fd. Short so a
-         *  mesh off→on cycle's fresh fd is picked up promptly, and so the
-         *  native side's install path never stalls long behind this call. */
-        private const val FD_POLL_TIMEOUT_MS = 1_000
 
         private val _wifi = MutableStateFlow(WifiApView())
         private val _nodes = MutableStateFlow<List<LanFipsNode>>(emptyList())

--- a/android/app/src/main/java/app/myco/aware/AwareRadio.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareRadio.kt
@@ -8,6 +8,7 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.net.wifi.aware.AttachCallback
+import android.net.wifi.aware.DiscoverySession
 import android.net.wifi.aware.DiscoverySessionCallback
 import android.net.wifi.aware.PeerHandle
 import android.net.wifi.aware.PublishConfig
@@ -21,6 +22,7 @@ import android.net.wifi.aware.WifiAwareSession
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
+import android.os.SystemClock
 import android.util.Log
 import app.myco.core.NativeCore
 import app.myco.core.UdpSocketPin
@@ -47,27 +49,31 @@ import kotlinx.coroutines.flow.asStateFlow
  *
  * Flow, per peer:
  *  1. publish + subscribe the Myco service (symmetric, no group owner).
- *  2. on a subscribe match, exchange device npubs over Aware `sendMessage`
+ *  2. on a subscribe match, exchange identities over Aware `sendMessage`
  *     (the analog of BLE's in-band pubkey exchange — no identity is in the
- *     advert itself).
+ *     advert itself). The payload is `"<npub>|<port>"`.
  *  3. the smaller-npub side requests the NDP (the cross-probe tiebreaker,
  *     applied before spending a scarce data-path slot; the core backstops it).
  *  4. read the peer's scoped link-local IPv6 from [WifiAwareNetworkInfo] and
  *     push `awarePeerFound(npub, "[fe80::x%ifindex]:port")`.
  *
- * The listener port is a fixed app constant carried in the state
- * ([app.myco.core.AppState.wifiAwarePort]); both peers bind it, so there is no
- * PSM-style discovery problem and no need for `setPort()` on a secured NDP.
- * It is **not** the LAN lane's port — the two lanes bind different ports as
- * well as different sockets — so two phones must run matching builds to peer
- * over Aware at all. See `runtime.rs`'s `AWARE_UDP_PORT`.
+ * The listener port is **per peer**, not a global constant. Each side binds
+ * its own ([app.myco.core.AppState.wifiAwarePort], `runtime.rs`'s
+ * `AWARE_UDP_PORT`) and advertises it in the identity exchange, and we dial
+ * each peer at the port *it* named. Dialling our own port instead is what
+ * broke interop the moment this lane moved off the LAN port: a peer on an
+ * older build still listens on [LEGACY_UDP_PORT], so the dial lands on a dead
+ * port, the handshake never completes, and Android tears the idle NDP down
+ * ~35s later — forever. An identity payload with no port is exactly that peer,
+ * and is dialled at [LEGACY_UDP_PORT]; there is no flag day.
  * The NDP is left **open** (no PSK) — fips authenticates with Noise IK.
  */
 class AwareRadio(
     private val context: Context,
     /** This device's npub, sent in the pubkey exchange and used for the tiebreaker. */
     private val ownNpub: String,
-    /** The fixed UDP port both peers bind. */
+    /** This device's Aware UDP port — bound locally and advertised to peers in
+     *  the identity exchange. Peers are dialled at *their* advertised port. */
     private val port: Int,
 ) {
     private val manager: WifiAwareManager? =
@@ -88,11 +94,31 @@ class AwareRadio(
     private var publishSession: PublishDiscoverySession? = null
     private var subscribeSession: SubscribeDiscoverySession? = null
 
-    /** Peers we have exchanged npubs with, keyed by the (session-scoped) handle. */
-    private val peerNpubs = ConcurrentHashMap<PeerHandle, String>()
+    /** Peers we have exchanged identities with, keyed by the (session-scoped) handle. */
+    private val peerIdentities = ConcurrentHashMap<PeerHandle, AwarePeer>()
 
-    /** Live NDP requests, keyed by peer npub, so we can tear them down on stop. */
+    /** Live NDP requests, keyed by peer npub, so we can tear them down on stop.
+     *  Also the "one outstanding request per peer" lock: entries go in with
+     *  [ConcurrentHashMap.putIfAbsent], so a rediscovery and a retry landing at
+     *  the same moment (on different threads) cannot both request. */
     private val ndpCallbacks = ConcurrentHashMap<String, ConnectivityManager.NetworkCallback>()
+
+    /** What a peer's NDP would be re-requested against: the discovery session
+     *  and handle it was last seen on, plus the port it advertised. Kept after
+     *  the NDP drops so recovery does not have to wait for rediscovery. */
+    private val ndpTargets = ConcurrentHashMap<String, NdpTarget>()
+
+    /** Peers whose NDP is established right now. The chipset has exactly one
+     *  `aware_data` interface, so a live NDP to one peer is the usual reason a
+     *  request for another is refused outright — and that is knowable here,
+     *  before spending a request, in a way [logResources] is not: it reports
+     *  seven of eight "data paths" free while the one interface is held. */
+    private val liveNdps: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /** Per-peer NDP retry state. Mutated only on [handler]; the map is
+     *  concurrent because [ConnectivityManager.NetworkCallback]s (which arrive
+     *  on the framework's own thread) hop onto [handler] to touch it. */
+    private val retries = ConcurrentHashMap<String, NdpRetry>()
 
     @Volatile
     private var running = false
@@ -194,7 +220,11 @@ class AwareRadio(
     private fun closeSessions() {
         for ((_, cb) in ndpCallbacks) runCatching { connectivity.unregisterNetworkCallback(cb) }
         ndpCallbacks.clear()
-        peerNpubs.clear()
+        for ((_, st) in retries) st.pending?.let { handler.removeCallbacks(it) }
+        retries.clear()
+        liveNdps.clear()
+        ndpTargets.clear()
+        peerIdentities.clear()
         _links.value = emptyList()
         runCatching { publishSession?.close() }
         runCatching { subscribeSession?.close() }
@@ -246,12 +276,12 @@ class AwareRadio(
             // request the data path on the publish session. Exactly one side is
             // responder and one is initiator — an NDP needs both, complementary.
             override fun onMessageReceived(peer: PeerHandle, message: ByteArray) {
-                val peerNpub = parseNpub(message) ?: return
-                peerNpubs[peer] = peerNpub
-                publishSession?.sendMessage(peer, MSG_ID_NPUB, ownNpub.toByteArray())
-                if (ownNpub > peerNpub) {
-                    Log.i(TAG, "publish: responder for ${short(peerNpub)}; requesting NDP")
-                    requestDataPath(publishSession, peer, peerNpub)
+                val remote = parsePeer(message) ?: return
+                peerIdentities[peer] = remote
+                publishSession?.sendMessage(peer, MSG_ID_NPUB, identityPayload())
+                if (ownNpub > remote.npub) {
+                    Log.i(TAG, "publish: responder for ${short(remote.npub)}; requesting NDP")
+                    requestDataPath(publishSession, peer, remote)
                 }
             }
         }, handler)
@@ -281,26 +311,61 @@ class AwareRadio(
                 serviceSpecificInfo: ByteArray?,
                 matchFilter: MutableList<ByteArray>?,
             ) {
-                Log.i(TAG, "discovered a peer; sending our npub")
-                subscribeSession?.sendMessage(peer, MSG_ID_NPUB, ownNpub.toByteArray())
+                Log.i(TAG, "discovered a peer; sending our identity")
+                subscribeSession?.sendMessage(peer, MSG_ID_NPUB, identityPayload())
             }
 
             // The publisher replied with its npub. If WE are the initiator for
             // this pair (smaller npub), request the NDP on the subscribe
             // session; the peer's publish side requests as responder.
             override fun onMessageReceived(peer: PeerHandle, message: ByteArray) {
-                val peerNpub = parseNpub(message) ?: return
-                peerNpubs[peer] = peerNpub
-                if (ownNpub < peerNpub) {
-                    Log.i(TAG, "subscribe: initiator for ${short(peerNpub)}; requesting NDP")
-                    requestDataPath(subscribeSession, peer, peerNpub)
+                val remote = parsePeer(message) ?: return
+                peerIdentities[peer] = remote
+                if (ownNpub < remote.npub) {
+                    Log.i(TAG, "subscribe: initiator for ${short(remote.npub)}; requesting NDP")
+                    requestDataPath(subscribeSession, peer, remote)
                 }
             }
         }, handler)
     }
 
-    private fun parseNpub(message: ByteArray): String? =
-        message.toString(Charsets.UTF_8).takeIf { it.startsWith("npub1") }
+    /** This device's identity as it goes on the wire: `"<npub>|<port>"`. */
+    private fun identityPayload(): ByteArray = "$ownNpub$FIELD_SEP$port".toByteArray()
+
+    /**
+     * Parse an identity payload into the peer's npub and the UDP port to dial
+     * it at. The wire format is `"<npub>|<port>"` in UTF-8 — one delimiter, and
+     * unambiguous because an npub is fixed-shape bech32 (`npub1` + 58 chars
+     * from an alphabet that excludes `|`).
+     *
+     * A bare npub with no delimiter is a peer on a build from before the Aware
+     * lane got its own socket, which listens on the LAN lane's
+     * [LEGACY_UDP_PORT] — parse it as such rather than rejecting it, so old and
+     * new builds still peer.
+     *
+     * Anything else is ignored: a payload we cannot parse is never dialled at a
+     * guessed port, because an NDP to a peer we cannot reach holds the
+     * chipset's only data-path slot for ~35s and starves peers we can.
+     */
+    private fun parsePeer(message: ByteArray): AwarePeer? {
+        val text = message.toString(Charsets.UTF_8)
+        val sep = text.indexOf(FIELD_SEP)
+        val npub = if (sep < 0) text else text.substring(0, sep)
+        if (!NPUB_RE.matches(npub)) {
+            Log.w(TAG, "ignoring malformed identity payload (${message.size} bytes)")
+            return null
+        }
+        if (sep < 0) {
+            Log.i(TAG, "${short(npub)} advertised no port (legacy build); dialling $LEGACY_UDP_PORT")
+            return AwarePeer(npub, LEGACY_UDP_PORT)
+        }
+        val peerPort = text.substring(sep + 1).toIntOrNull()
+        if (peerPort == null || peerPort !in 1..65535) {
+            Log.w(TAG, "ignoring identity from ${short(npub)}: bad port field")
+            return null
+        }
+        return AwarePeer(npub, peerPort)
+    }
 
     /**
      * Request an open NDP toward `peer` on the given discovery `session`. Both
@@ -310,10 +375,26 @@ class AwareRadio(
      * and push `awarePeerFound`; FIPS's cross-connection resolution dedups the
      * two resulting UDP links to one Noise session.
      */
-    private fun requestDataPath(session: android.net.wifi.aware.DiscoverySession?, peer: PeerHandle, peerNpub: String) {
-        val sess = session ?: return
-        if (ndpCallbacks.containsKey(peerNpub)) return
-        Log.i(TAG, "requesting NDP to ${short(peerNpub)} (${logResources()})")
+    private fun requestDataPath(
+        session: DiscoverySession?,
+        peer: PeerHandle,
+        remote: AwarePeer,
+        isRetry: Boolean = false,
+    ): Boolean {
+        val sess = session ?: return false
+        val peerNpub = remote.npub
+        // Remember what to re-request against if this NDP later drops, and
+        // drop any queued retry: this request supersedes it.
+        ndpTargets[peerNpub] = NdpTarget(sess, peer, remote.port)
+        if (isRetry) cancelPendingRetry(peerNpub) else clearRetry(peerNpub)
+        // Don't spend a request that cannot be provisioned: the interface is
+        // already carrying someone else's NDP. Queue instead — see
+        // [deferNdpRetry], which does not touch the retry budget.
+        dataPathBlockedBy(peerNpub)?.let { why ->
+            Log.i(TAG, "not requesting NDP to ${short(peerNpub)}: $why (${logResources()})")
+            deferNdpRetry(peerNpub)
+            return false
+        }
         // Open (unencrypted) NDP: no security setter. Noise IK is the trust
         // layer; a PSK here would be a redundant credential under it.
         val specifier = WifiAwareNetworkSpecifier.Builder(sess, peer).build()
@@ -322,11 +403,18 @@ class AwareRadio(
             .setNetworkSpecifier(specifier)
             .build()
 
+        // When the request went out, so [ConnectivityManager.NetworkCallback.onUnavailable]
+        // can tell an instant refusal from a negotiation that ran its timeout.
+        var requestedAt = SystemClock.elapsedRealtime()
+
         val callback = object : ConnectivityManager.NetworkCallback() {
             override fun onCapabilitiesChanged(network: Network, caps: NetworkCapabilities) {
                 val info = caps.transportInfo as? WifiAwareNetworkInfo ?: return
-                val addr = formatPeerAddr(info.peerIpv6Addr) ?: return
+                val addr = formatPeerAddr(info.peerIpv6Addr, remote.port) ?: return
                 Log.i(TAG, "Aware NDP up to ${short(peerNpub)} at $addr")
+                liveNdps.add(peerNpub)
+                // The link is good: hand the peer a fresh retry budget.
+                if (retries.containsKey(peerNpub)) handler.post { clearRetry(peerNpub) }
                 // Pin BEFORE announcing the peer: the core dials as soon as it
                 // is told, and a dial from an unpinned (or wrong-network)
                 // socket is what used to time out. This callback repeats for
@@ -343,11 +431,16 @@ class AwareRadio(
                 NativeCore.awarePeerFound(peerNpub, addr, LANE)
             }
 
+            // An NDP is otherwise only requested on *rediscovery*, so a peer
+            // whose data path drops sits dark until the discovery cycle comes
+            // round again — minutes. Re-request it ourselves; see
+            // [scheduleNdpRetry] for the backoff and the give-up rule.
             override fun onLost(network: Network) {
                 Log.i(TAG, "Aware NDP lost to ${short(peerNpub)}")
                 udpPin.clearTarget(network)
                 NativeCore.awarePeerLost(peerNpub, LANE)
                 releaseNdp(peerNpub)
+                handler.post { scheduleNdpRetry(peerNpub, "NDP lost") }
             }
 
             // Fired when the request can't be provisioned within the timeout
@@ -355,22 +448,194 @@ class AwareRadio(
             // in use. Releasing the request frees the slot (an un-timed-out
             // request would hold it indefinitely), and dropping the map entry
             // lets a later rediscovery retry.
+            // Two very different failures arrive here, and telling them apart
+            // is what keeps the retry budget honest. A refusal comes back in
+            // milliseconds: the framework had no `aware_data` interface to give
+            // (`WifiAwareDataPathStMgr: NdpInfos[] - no interfaces available!`)
+            // and the peer had no say in it — so it is deferred, not counted.
+            // A genuine failure to negotiate takes the full [NDP_TIMEOUT_MS]
+            // and does say something about the peer, so it costs a retry.
             override fun onUnavailable() {
-                Log.w(TAG, "Aware NDP request unavailable for ${short(peerNpub)} — slots full? (${logResources()})")
+                val elapsed = SystemClock.elapsedRealtime() - requestedAt
                 releaseNdp(peerNpub)
+                if (elapsed < NDP_REFUSAL_MS) {
+                    Log.w(
+                        TAG,
+                        "NDP to ${short(peerNpub)} refused outright after ${elapsed}ms — " +
+                            "no data-path interface free (${logResources()})",
+                    )
+                    handler.post { deferNdpRetry(peerNpub, refundAttempt = true) }
+                } else {
+                    Log.w(TAG, "Aware NDP request to ${short(peerNpub)} gave up after ${elapsed}ms (${logResources()})")
+                    handler.post { scheduleNdpRetry(peerNpub, "request unavailable") }
+                }
             }
         }
-        ndpCallbacks[peerNpub] = callback
+        // The one-outstanding-request lock. onLost arrives on the framework's
+        // thread and rediscovery on ours, so the check and the claim have to be
+        // one operation or both paths can request the same peer at once —
+        // two requests for one peer against a chipset with one data-path slot.
+        if (ndpCallbacks.putIfAbsent(peerNpub, callback) != null) {
+            Log.d(TAG, "NDP request to ${short(peerNpub)} already outstanding; not re-requesting")
+            return false
+        }
+        Log.i(TAG, "requesting NDP to ${short(peerNpub)} (dial port ${remote.port}, ${logResources()})")
         setLink(peerNpub, addr = null, up = false)
+        requestedAt = SystemClock.elapsedRealtime()
         // Timed request: on failure to provision within NDP_TIMEOUT_MS the
         // framework calls onUnavailable and releases it, so a stuck negotiation
         // never leaks a data-path slot (the root cause of "works fresh, dies
         // after a few restarts" — slots pile up and never free).
         connectivity.requestNetwork(request, callback, NDP_TIMEOUT_MS)
+        return true
+    }
+
+    /**
+     * Queue a re-request of `peerNpub`'s NDP after a loss or a failed request.
+     *
+     * The policy, and each clause earns its place:
+     *  - **Backoff**, [NDP_RETRY_BASE_MS] doubling to [NDP_RETRY_MAX_MS]: an
+     *    immediate unconditional retry against a peer that has walked out of
+     *    the room thrashes the radio for as long as it is gone.
+     *  - **Give up** after [MAX_NDP_RETRIES] attempts and fall back to waiting
+     *    for rediscovery — which is the correct signal that the peer is back.
+     *  - **One outstanding request per peer**: guarded here (a queued retry and
+     *    a live request both bar a new one) and again, atomically, in
+     *    [requestDataPath]. A success resets the budget.
+     *  - **One data-path interface**: see [deferNdpRetry], which queues a try
+     *    that could not have worked without charging it to the budget.
+     *
+     * Handler thread only.
+     */
+    private fun scheduleNdpRetry(peerNpub: String, why: String) {
+        if (!running) return
+        if (ndpTargets[peerNpub] == null) return
+        if (ndpCallbacks.containsKey(peerNpub)) return
+        val state = retries.getOrPut(peerNpub) { NdpRetry() }
+        if (state.pending != null) return
+        if (state.attempts >= MAX_NDP_RETRIES) {
+            Log.w(
+                TAG,
+                "giving up on ${short(peerNpub)} after $MAX_NDP_RETRIES NDP retries ($why); " +
+                    "waiting for rediscovery",
+            )
+            clearRetry(peerNpub)
+            return
+        }
+        val delay = backoffMs(state.attempts)
+        Log.i(
+            TAG,
+            "re-requesting NDP to ${short(peerNpub)} in ${delay}ms " +
+                "($why, attempt ${state.attempts + 1}/$MAX_NDP_RETRIES)",
+        )
+        queueRetry(peerNpub, state, delay)
+    }
+
+    /** Fire a queued retry. The attempt is only spent if a request actually
+     *  went out — [requestDataPath] defers instead when the data-path
+     *  interface is held, which is nothing to do with this peer. Handler
+     *  thread only. */
+    private fun attemptNdpRetry(peerNpub: String) {
+        val state = retries[peerNpub] ?: return
+        state.pending = null
+        if (!running) return
+        val target = ndpTargets[peerNpub] ?: return
+        if (ndpCallbacks.containsKey(peerNpub)) return
+        val issued = requestDataPath(
+            target.session,
+            target.peer,
+            AwarePeer(peerNpub, target.port),
+            isRetry = true,
+        )
+        if (issued) state.attempts += 1
+    }
+
+    /**
+     * Queue another try *without* spending a retry, because the last one could
+     * not have succeeded: the chipset's single `aware_data` interface was
+     * carrying another peer's NDP. Counting these as retries would let one
+     * unreachable peer eat the budget of a reachable one. Bounded all the same
+     * by [MAX_NDP_SLOT_DEFERRALS], so an interface held for good does not leave
+     * us polling forever. Handler thread only.
+     */
+    private fun deferNdpRetry(peerNpub: String, refundAttempt: Boolean = false) {
+        if (!running) return
+        if (ndpTargets[peerNpub] == null) return
+        if (ndpCallbacks.containsKey(peerNpub)) return
+        val state = retries.getOrPut(peerNpub) { NdpRetry() }
+        if (state.pending != null) return
+        // A request that was refused outright still went through
+        // [attemptNdpRetry], which counted it. It never reached the peer, so
+        // give it back — otherwise a held interface silently drains the budget
+        // meant for real attempts, and the counters stop meaning anything.
+        if (refundAttempt) state.attempts = (state.attempts - 1).coerceAtLeast(0)
+        state.deferrals += 1
+        if (state.deferrals > MAX_NDP_SLOT_DEFERRALS) {
+            Log.w(
+                TAG,
+                "data-path interface still held after $MAX_NDP_SLOT_DEFERRALS deferrals; " +
+                    "leaving ${short(peerNpub)} to rediscovery",
+            )
+            clearRetry(peerNpub)
+            return
+        }
+        val delay = backoffMs(state.deferrals - 1)
+        Log.i(
+            TAG,
+            "deferring NDP to ${short(peerNpub)} by ${delay}ms " +
+                "(deferral ${state.deferrals}/$MAX_NDP_SLOT_DEFERRALS, " +
+                "retries still ${state.attempts}/$MAX_NDP_RETRIES)",
+        )
+        queueRetry(peerNpub, state, delay)
+    }
+
+    private fun queueRetry(peerNpub: String, state: NdpRetry, delay: Long) {
+        val runnable = Runnable { attemptNdpRetry(peerNpub) }
+        state.pending = runnable
+        handler.postDelayed(runnable, delay)
+    }
+
+    /** [NDP_RETRY_BASE_MS] doubled per attempt, capped at [NDP_RETRY_MAX_MS]. */
+    private fun backoffMs(attempts: Int): Long =
+        (NDP_RETRY_BASE_MS shl attempts.coerceAtMost(8)).coerceAtMost(NDP_RETRY_MAX_MS)
+
+    /** Cancel a queued retry but keep the peer's counters (the request that
+     *  replaces it is part of the same escalating chain). */
+    private fun cancelPendingRetry(peerNpub: String) {
+        retries[peerNpub]?.let { st ->
+            st.pending?.let { handler.removeCallbacks(it) }
+            st.pending = null
+        }
+    }
+
+    /** Forget a peer's retry state entirely: it either connected or is out of
+     *  budget, and either way the next request starts from scratch. */
+    private fun clearRetry(peerNpub: String) {
+        retries.remove(peerNpub)?.pending?.let { handler.removeCallbacks(it) }
+    }
+
+    /**
+     * Why a request for `peerNpub` would be refused out of hand, or null if it
+     * has a chance. The Pixel's chipset has exactly one `aware_data`
+     * interface, so an NDP live to any *other* peer is a refusal we can see
+     * coming — and [android.net.wifi.aware.AwareResources] will not tell us:
+     * it reported `dataPaths=7` free throughout a run of instant refusals.
+     * Hence our own [liveNdps] first, with the framework's count as a backstop.
+     */
+    private fun dataPathBlockedBy(peerNpub: String): String? {
+        liveNdps.firstOrNull { it != peerNpub }?.let {
+            return "data-path interface held by ${short(it)}"
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val r = manager?.availableAwareResources
+            if (r != null && r.availableDataPathsCount <= 0) return "no data paths free"
+        }
+        return null
     }
 
     /** Unregister and forget a peer's NDP request, freeing its data-path slot. */
     private fun releaseNdp(peerNpub: String) {
+        liveNdps.remove(peerNpub)
         ndpCallbacks.remove(peerNpub)?.let {
             runCatching { connectivity.unregisterNetworkCallback(it) }
         }
@@ -386,13 +651,15 @@ class AwareRadio(
     }
 
     /**
-     * Format the peer's link-local IPv6 as `"[fe80::x%ifindex]:port"` with a
+     * Format the peer's link-local IPv6 as `"[fe80::x%ifindex]:peerPort"` — the
+ * port the *peer* advertised, not ours, so a peer on a different build is
+ * dialled where it actually listens — with a
      * **numeric** scope — the only form fips-core's address parser accepts
      * (interface-name scopes do not parse). The [Inet6Address] handed back by
      * [WifiAwareNetworkInfo] is already scoped to the local `aware_dataN`
      * interface, so its `scopeId` is the ifindex we need.
      */
-    private fun formatPeerAddr(ipv6: Inet6Address?): String? {
+    private fun formatPeerAddr(ipv6: Inet6Address?, peerPort: Int): String? {
         if (ipv6 == null) return null
         val scopeId = ipv6.scopeId
         if (scopeId == 0) {
@@ -402,7 +669,7 @@ class AwareRadio(
         // hostAddress may render as "fe80::x%aware_data0" or "fe80::x%3";
         // strip any scope suffix and re-append the numeric ifindex.
         val bare = ipv6.hostAddress?.substringBefore('%') ?: return null
-        return "[$bare%$scopeId]:$port"
+        return "[$bare%$scopeId]:$peerPort"
     }
 
     private fun short(npub: String): String =
@@ -459,13 +726,75 @@ class AwareRadio(
          *  lane's socket rather than the LAN lane's. */
         private const val LANE = "aware"
 
-        /** Message id for the npub-exchange `sendMessage`. */
+        /** Message id for the identity-exchange `sendMessage`. */
         private const val MSG_ID_NPUB = 1
+
+        /** Separator between npub and port in the identity payload. Not in the
+         *  bech32 alphabet, so it cannot occur inside an npub. */
+        private const val FIELD_SEP = '|'
+
+        /** Shape of a valid npub: bech32, `npub1` + 58 chars of the bech32
+         *  alphabet (no `1`, `b`, `i`, `o`). Anything else is not dialled. */
+        private val NPUB_RE = Regex("^npub1[023456789acdefghjklmnpqrstuvwxyz]{58}$")
+
+        /** Where a peer that advertises no port listens: builds from before the
+         *  Aware lane got its own socket shared the LAN lane's port. */
+        private const val LEGACY_UDP_PORT = 4871
 
         /** NDP request timeout: if the data path isn't provisioned within this,
          *  onUnavailable fires and the request (and its slot) is released. */
         private const val NDP_TIMEOUT_MS = 20_000
+
+        /** First NDP retry delay after a loss; doubles per attempt. */
+        private const val NDP_RETRY_BASE_MS = 2_000L
+
+        /** Ceiling on the retry backoff, and the deferral poll interval. */
+        private const val NDP_RETRY_MAX_MS = 30_000L
+
+        /** Retries before falling back to waiting for rediscovery. With the
+         *  backoff above that is 2+4+8+16+30s ≈ 1 minute of trying. */
+        private const val MAX_NDP_RETRIES = 5
+
+        /** An `onUnavailable` faster than this is the framework refusing the
+         *  request outright (no `aware_data` interface), not a negotiation that
+         *  ran out of time — the two are told apart by nothing else. */
+        private const val NDP_REFUSAL_MS = 2_000L
+
+        /** How many times a try may be deferred for want of a data-path
+         *  interface before the peer is left to rediscovery. Deferrals use the
+         *  same escalating backoff as retries, so this is ~2.5 minutes — long
+         *  enough to outlast the ~40s Android takes to reclaim the interface
+         *  behind a dropped NDP, short enough not to poll a dead room. */
+        private const val MAX_NDP_SLOT_DEFERRALS = 8
     }
+}
+
+/** A peer's identity as advertised over Aware: who it is, and the UDP port it
+ *  listens on. The port is per peer — see [AwareRadio.parsePeer]. */
+private data class AwarePeer(val npub: String, val port: Int)
+
+/** Everything needed to re-request a peer's NDP without waiting for it to be
+ *  rediscovered: the discovery session and handle it was last seen on, and the
+ *  port it advertised. */
+private class NdpTarget(
+    val session: DiscoverySession,
+    val peer: PeerHandle,
+    val port: Int,
+)
+
+/** A peer's NDP retry budget. Mutated only on the radio's handler thread;
+ *  [pending] is volatile because teardown cancels it from another one. */
+private class NdpRetry {
+    /** Retries actually issued since the last successful NDP. */
+    var attempts: Int = 0
+
+    /** Retries skipped because the chipset's data-path interface was held.
+     *  Counted separately: the peer did nothing wrong, so these must not eat
+     *  the retry budget — but they are bounded too. */
+    var deferrals: Int = 0
+
+    @Volatile
+    var pending: Runnable? = null
 }
 
 /** One Wi-Fi Aware NDP as the radio sees it: requested (no addr yet) or up

--- a/android/app/src/main/java/app/myco/aware/AwareRadio.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareRadio.kt
@@ -23,6 +23,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.util.Log
 import app.myco.core.NativeCore
+import app.myco.core.UdpSocketPin
 import java.net.Inet6Address
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,8 +34,16 @@ import kotlinx.coroutines.flow.asStateFlow
  * The Wi-Fi Aware (NAN) bulk-lane radio. Control-plane only: it discovers
  * peers, brings up a data path (NDP), and pushes "peer reachable / lost" into
  * the core ([NativeCore.awarePeerFound]/[NativeCore.awarePeerLost]). The bytes
- * ride the ordinary fips UDP transport over the `aware_dataN` interface — this
- * class never touches a payload byte. See docs/design/wifi-aware-interop.md.
+ * ride a fips UDP transport over the `aware_dataN` interface — this class never
+ * touches a payload byte. See docs/design/wifi-aware-interop.md.
+ *
+ * That transport is **this lane's own** UDP socket, and this class pins it to
+ * the NDP's [Network] ([udpPin]). Both halves matter. An NDP is a network of
+ * its own with its own routing table, so a socket marked with any other
+ * network — infrastructure Wi-Fi, as the AP lane marks it — cannot reach an
+ * Aware peer at all: the address is well-formed, the send reports success, and
+ * nothing arrives. That was the whole of the "Aware discovers everything and
+ * peers with nothing" fault. See [UdpSocketPin].
  *
  * Flow, per peer:
  *  1. publish + subscribe the Myco service (symmetric, no group owner).
@@ -49,6 +58,9 @@ import kotlinx.coroutines.flow.asStateFlow
  * The listener port is a fixed app constant carried in the state
  * ([app.myco.core.AppState.wifiAwarePort]); both peers bind it, so there is no
  * PSM-style discovery problem and no need for `setPort()` on a secured NDP.
+ * It is **not** the LAN lane's port — the two lanes bind different ports as
+ * well as different sockets — so two phones must run matching builds to peer
+ * over Aware at all. See `runtime.rs`'s `AWARE_UDP_PORT`.
  * The NDP is left **open** (no PSK) — fips authenticates with Noise IK.
  */
 class AwareRadio(
@@ -65,6 +77,12 @@ class AwareRadio(
 
     private val thread = HandlerThread("myco-aware").apply { start() }
     private val handler = Handler(thread.looper)
+
+    /** Pins this lane's UDP transport socket to the NDP [Network] — see the
+     *  class doc, and [UdpSocketPin] for why the lane needs a socket of its
+     *  own. Asks for [LANE] by name, so it can only ever receive the Aware
+     *  lane's socket, never the AP lane's. */
+    private val udpPin = UdpSocketPin(LANE, handler, TAG)
 
     private var session: WifiAwareSession? = null
     private var publishSession: PublishDiscoverySession? = null
@@ -99,6 +117,7 @@ class AwareRadio(
             return
         }
         running = true
+        udpPin.start()
         registerAvailability(mgr)
         if (mgr.isAvailable) {
             attach(mgr)
@@ -191,6 +210,11 @@ class AwareRadio(
         availabilityReceiver?.let { runCatching { context.unregisterReceiver(it) } }
         availabilityReceiver = null
         closeSessions()
+        // On the handler thread, where the pin's state lives. Releases our dup
+        // of the socket; the core's own descriptor, and its binding, are
+        // untouched — a stale mark on a network that has gone away is harmless,
+        // and the next NDP re-pins.
+        handler.post { udpPin.stop() }
     }
 
     fun shutdown() {
@@ -303,12 +327,25 @@ class AwareRadio(
                 val info = caps.transportInfo as? WifiAwareNetworkInfo ?: return
                 val addr = formatPeerAddr(info.peerIpv6Addr) ?: return
                 Log.i(TAG, "Aware NDP up to ${short(peerNpub)} at $addr")
+                // Pin BEFORE announcing the peer: the core dials as soon as it
+                // is told, and a dial from an unpinned (or wrong-network)
+                // socket is what used to time out. This callback repeats for
+                // the life of the NDP, so the re-pin is idempotent and cheap.
+                //
+                // One socket, one mark: with several concurrent NDPs the most
+                // recent one wins. Each NDP is a separate Network, so a single
+                // socket cannot serve them all — the pair this milestone has to
+                // get right is two phones, and a fan-out (a socket per NDP)
+                // would need a transport instance per peer, which fips has no
+                // way to configure at runtime.
+                udpPin.bindTo(network)
                 setLink(peerNpub, addr, up = true)
                 NativeCore.awarePeerFound(peerNpub, addr, LANE)
             }
 
             override fun onLost(network: Network) {
                 Log.i(TAG, "Aware NDP lost to ${short(peerNpub)}")
+                udpPin.clearTarget(network)
                 NativeCore.awarePeerLost(peerNpub, LANE)
                 releaseNdp(peerNpub)
             }
@@ -413,9 +450,13 @@ class AwareRadio(
         /** The Myco Wi-Fi Aware service name (the analog of the FIPS service UUID). */
         private const val SERVICE_NAME = "myco.fips.v1"
 
-        /** The lane label pushed to [NativeCore.awarePeerFound]/[NativeCore.awarePeerLost]
-         *  — distinguishes this radio from [app.myco.ap.ApRadio], which pushes "udp"
-         *  through the same seam even though both ride fips's UDP transport. */
+        /** The lane label pushed to [NativeCore.awarePeerFound]/[NativeCore.awarePeerLost],
+         *  and asked of [NativeCore.nextUdpTransportFd] — distinguishes this radio from
+         *  [app.myco.ap.ApRadio], which pushes "udp" through the same seams. Both ride
+         *  UDP, but each lane is its own transport instance with its own socket, and
+         *  this label is what selects between them. The core turns it into the
+         *  qualified transport `"udp/aware"`, which is what makes fips dial this
+         *  lane's socket rather than the LAN lane's. */
         private const val LANE = "aware"
 
         /** Message id for the npub-exchange `sendMessage`. */

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -26,6 +26,7 @@ import java.io.IOException
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
 /**
@@ -57,6 +58,11 @@ class BleRadio(context: Context) {
     private var bridgeHandle: Long = 0
     private val io = Executors.newCachedThreadPool()
     private val channels = ConcurrentHashMap<Long, BluetoothSocket>()
+    // Dials parked inside BluetoothSocket.connect(), by device MAC. Android's
+    // connect blocks well past the core's probe timeout, so without this the
+    // core's re-dials stack up: several sockets per device, each holding an LE
+    // connect slot, none of them closed. See [connect].
+    private val dialing = ConcurrentHashMap<String, BluetoothSocket>()
     // A parallel GATT per channel, used only to request a low connection interval
     // (L2CAP CoC exposes no priority API). Bumps mesh throughput ~2-4x.
     private val gatts = ConcurrentHashMap<Long, GattPrio>()
@@ -139,28 +145,121 @@ class BleRadio(context: Context) {
         }
     }
 
-    /** Dial a peer; deliver the result (and, on success, start the channel). */
+    /**
+     * Dial a peer; deliver the result (and, on success, start the channel).
+     *
+     * Every exit closes the socket unless the core adopted it. A
+     * [BluetoothSocket] whose `connect()` threw is *not* self-closing, and an
+     * abandoned one keeps its slot in the BT stack's LE connect table: leak
+     * enough of them and every later dial hangs for its full timeout and then
+     * fails, with nothing in the app's own state to explain it. Only killing
+     * the process gets them back.
+     *
+     * The dial is also bounded twice over, because `connect()` blocks for far
+     * longer than the core is willing to wait — the core gives up at its
+     * probe timeout and re-dials while this thread is still parked inside
+     * Android:
+     *
+     * - one in-flight dial per device ([dialing]): a fresh dial to the same
+     *   MAC closes the previous socket, which unblocks it promptly;
+     * - [DIAL_WATCHDOG_MS] as a backstop, for the peer the core discovers
+     *   once and never probes again.
+     *
+     * So the socket is closed on every exit that is not an adoption — a
+     * `connect()` that threw, a success the core declined to take, the
+     * watchdog, and [shutdown] — and the core is answered on every exit
+     * including the two that never reach a socket at all (already stopped,
+     * and a thread pool that refuses the work).
+     */
     fun connect(connectId: Long, addr: String, psm: Int) {
-        if (stopped) return
-        runCatching {
-        io.execute {
-            val mac = addr.substringAfter('/', addr)
-            try {
-                val device = adapter?.getRemoteDevice(mac)
-                    ?: throw IOException("no adapter / bad addr $addr")
-                val sock = device.createInsecureL2capChannel(psm)
-                sock.connect()
-                val chId = NativeCore.bleDeliverConnectResult(
-                    bridgeHandle, connectId, true, addr, sendMtu(sock), recvMtu(sock),
-                )
-                if (chId > 0) startChannel(chId, sock) else closeQuietly(sock)
-            } catch (e: Exception) {
-                Log.w(TAG, "connect $addr psm $psm failed: ${e.message}")
-                NativeCore.bleDeliverConnectResult(bridgeHandle, connectId, false, addr, 0, 0)
-            }
+        // Every return from here answers the core, one way or another. A dial
+        // that is silently dropped costs the probe loop its full 10s timeout
+        // waiting for an attempt that was never made.
+        if (stopped) {
+            failDial(connectId, addr)
+            return
         }
+        val submitted = runCatching { io.execute { dial(connectId, addr, psm) } }
+        if (submitted.isFailure) {
+            // The pool was shut down underneath this call, so the dial will
+            // never run.
+            failDial(connectId, addr)
         }
     }
+
+    /** Tell the core a dial did not produce a channel. Safe at any point,
+     *  including after [shutdown]: the bridge handle outlives the radio (see
+     *  [BleService.stopBle]), and an answer for a dial the core already gave up
+     *  on is discarded there rather than allocating anything. */
+    private fun failDial(connectId: Long, addr: String) {
+        runCatching {
+            NativeCore.bleDeliverConnectResult(bridgeHandle, connectId, false, addr, 0, 0)
+        }
+    }
+
+    /** The dial itself, on an [io] thread. See [connect] for why it is bounded. */
+    private fun dial(connectId: Long, addr: String, psm: Int) {
+        val mac = addr.substringAfter('/', addr)
+        var sock: BluetoothSocket? = null
+        var adopted = false
+        var watchdog: ScheduledFuture<*>? = null
+        try {
+            val device = adapter?.getRemoteDevice(mac)
+                ?: throw IOException("no adapter / bad addr $addr")
+            val s = device.createInsecureL2capChannel(psm)
+            sock = s
+            // Supersede any dial to this device still parked in connect():
+            // the core only re-dials once it has given up on the last one,
+            // so the old socket is dead weight holding an LE connect slot.
+            dialing.put(mac, s)?.let { closeQuietly(it) }
+            // Re-checked here, and in this order. [shutdown] sets `stopped`
+            // and only then drains [dialing], so registering before checking
+            // is what makes the race unloseable: either the drain sees our
+            // socket and closes it, or we see `stopped` and close it
+            // ourselves. Checking first and registering after would let a
+            // dial slip between the two and outlive the radio, parked in the
+            // BT stack where `shutdownNow` cannot reach it.
+            if (stopped) throw IOException("radio stopped")
+            watchdog = armDialWatchdog(mac, s)
+            s.connect()
+            val chId = NativeCore.bleDeliverConnectResult(
+                bridgeHandle, connectId, true, addr, sendMtu(s), recvMtu(s),
+            )
+            // Adopted *before* the channel is started, not after: from this
+            // point the socket belongs to [channels]. A throw out of
+            // startChannel must not close it underneath the core, nor report
+            // this dial failed after it has already been reported succeeded.
+            if (chId > 0) {
+                adopted = true
+                startChannel(chId, s)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "connect $addr psm $psm failed: ${e.message}")
+            if (!adopted) failDial(connectId, addr)
+        } finally {
+            // Nothing left to watch: dropping it keeps a resolved dial's socket
+            // out of the shared scheduler's queue for the next 15s.
+            watchdog?.cancel(false)
+            // Only clear the entry if it is still ours — a superseding dial
+            // owns it now, and closing its socket would kill a live attempt.
+            sock?.let { dialing.remove(mac, it) }
+            if (!adopted) sock?.let { closeQuietly(it) }
+        }
+    }
+
+    /** Close a dial still unresolved after [DIAL_WATCHDOG_MS], so a connect
+     *  Android never answers cannot hold an LE connect slot indefinitely.
+     *  Closing makes the parked `connect()` throw, and the dial's own `finally`
+     *  does the rest. */
+    private fun armDialWatchdog(mac: String, sock: BluetoothSocket): ScheduledFuture<*>? =
+        runCatching {
+            retryExec.schedule({
+                if (dialing.remove(mac, sock)) {
+                    Log.w(TAG, "dial $mac still unresolved after ${DIAL_WATCHDOG_MS}ms — closing")
+                    closeQuietly(sock)
+                }
+            }, DIAL_WATCHDOG_MS, TimeUnit.MILLISECONDS)
+        }.getOrNull()
 
     fun startAdvertising(psm: Int) {
         if (stopped) return
@@ -356,6 +455,11 @@ class BleRadio(context: Context) {
         stopAdvertising()
         runCatching { serverSocket?.close() }
         serverSocket = null
+        // Dials parked in connect() outlive the radio otherwise: the thread
+        // pool is shut down below, but shutdownNow cannot interrupt a thread
+        // blocked in the BT stack. Closing the socket is what releases it.
+        dialing.values.toList().forEach { closeQuietly(it) }
+        dialing.clear()
         channels.keys.toList().forEach { closeChannel(it) }
         gatts.keys.toList().forEach { dropGatt(it) }
         io.shutdownNow()
@@ -585,6 +689,11 @@ class BleRadio(context: Context) {
         // read() fits one SDU and next_send never truncates an outbound packet.
         private const val MAX_PACKET = 8192
         private const val SEND_TIMEOUT_MS = 1000
+
+        /** Backstop for a dial Android never resolves. Comfortably above the
+         *  core's probe timeout (10s) so a dial that is merely slow is left
+         *  alone, and well below the ~30s+ this has been seen to block for. */
+        private const val DIAL_WATCHDOG_MS = 15_000L
 
         /** Background scan: batched delivery window (controller-offloaded). */
         private const val BACKGROUND_BATCH_MS = 5000L

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * The Android BLE radio. Kotlin owns the radio; the Rust core (fips `AndroidIo`)
@@ -102,6 +103,19 @@ class BleRadio(context: Context) {
     // SCAN_FAILED_SCANNING_TOO_FREQUENTLY) used to be logged and abandoned, which
     // permanently killed peer discovery until the mesh was toggled. We re-arm it.
     private var scanRetries = 0
+
+    // Scan-report accounting, summarised on a timer instead of logged per
+    // result. Per-result logging emitted several lines a second on a busy
+    // radio and rotated every other MycoBleRadio line out of the buffer within
+    // seconds. The timer fires whether or not anything was seen, because a
+    // scanner producing *nothing* is as much of a symptom as one producing
+    // adverts with no PSM — a device in that state is inbound-only, and under
+    // a log-only-when-there-is-something scheme it would look healthy.
+    private val scanWithPsm = AtomicInteger()
+    private val scanWithoutPsm = AtomicInteger()
+    private val scanPsmAddrs = ConcurrentHashMap.newKeySet<String>()
+    private val scanNoPsmAddrs = ConcurrentHashMap.newKeySet<String>()
+    @Volatile private var scanSummaryTask: ScheduledFuture<*>? = null
 
     // Background mode (set from the service via ProcessLifecycleOwner): while the
     // app is not visible, discovery drops from LOW_LATENCY (~100% RX duty) to
@@ -381,6 +395,14 @@ class BleRadio(context: Context) {
             sc.startScan(filters, settings, cb)
             Log.i(TAG, "scanning for FIPS peers (${if (backgroundMode) "low-power" else "low-latency"})")
             if (bridgeHandle != 0L) NativeCore.bleDeliverScanningState(bridgeHandle, true)
+            scanSummaryTask = runCatching {
+                retryExec.scheduleWithFixedDelay(
+                    { if (!stopped) runCatching { logScanSummary() } },
+                    SCAN_SUMMARY_SECS,
+                    SCAN_SUMMARY_SECS,
+                    TimeUnit.SECONDS,
+                )
+            }.getOrNull()
         } catch (e: Exception) {
             Log.e(TAG, "startScanning failed", e)
             scheduleScanRetry(-1)
@@ -404,10 +426,44 @@ class BleRadio(context: Context) {
         // core fall back to the legacy default PSM (0x0085) and dial the
         // wrong L2CAP port, which the peer rejects every time.
         if (psm > 0) {
+            scanWithPsm.incrementAndGet()
+            scanPsmAddrs.add(addr)
             NativeCore.bleDeliverScan(bridgeHandle, addr, psm, result.rssi)
         } else {
-            Log.d(TAG, "scan $addr: PSM not in advert yet (awaiting scan response)")
+            // Counted, not logged: this fires several times a second per peer
+            // while a scan response is outstanding. [logScanSummary] reports
+            // the addresses that never produced one, which is the real signal.
+            scanWithoutPsm.incrementAndGet()
+            scanNoPsmAddrs.add(addr)
         }
+    }
+
+    /** Summarise the last window of scan reports; scheduled from [startScanning]. */
+    private fun logScanSummary() {
+        val withPsm = scanWithPsm.getAndSet(0)
+        val withoutPsm = scanWithoutPsm.getAndSet(0)
+        val silent = scanNoPsmAddrs.minus(scanPsmAddrs)
+        scanPsmAddrs.clear()
+        scanNoPsmAddrs.clear()
+        val secs = SCAN_SUMMARY_SECS
+        if (withPsm == 0 && withoutPsm == 0) {
+            // Loud on purpose. A radio that advertises and listens but scans
+            // nothing is inbound-only: it can never learn a peer's PSM, so
+            // every dial it makes falls back to the configured default and
+            // fails. That is invisible unless it is said out loud.
+            Log.w(TAG, "scan summary: 0 adverts in ${secs}s — scanner produced nothing")
+            return
+        }
+        val tail = if (silent.isEmpty()) {
+            ""
+        } else {
+            ", no PSM from ${silent.size}: ${silent.joinToString(" ")}"
+        }
+        Log.i(
+            TAG,
+            "scan summary: ${withPsm + withoutPsm} adverts in ${secs}s " +
+                "($withPsm with psm, $withoutPsm awaiting scan response$tail)",
+        )
     }
 
     /** Re-arm scanning after a failure, so a transient throttle/error doesn't
@@ -440,6 +496,10 @@ class BleRadio(context: Context) {
     fun stopScanning() {
         scanCallback?.let { runCatching { scanner?.stopScan(it) } }
         scanCallback = null
+        // No scan, nothing to summarise — otherwise the timer would report
+        // "0 adverts" against a scanner nobody asked to be running.
+        scanSummaryTask?.cancel(false)
+        scanSummaryTask = null
         if (bridgeHandle != 0L) NativeCore.bleDeliverScanningState(bridgeHandle, false)
     }
 
@@ -694,6 +754,11 @@ class BleRadio(context: Context) {
          *  core's probe timeout (10s) so a dial that is merely slow is left
          *  alone, and well below the ~30s+ this has been seen to block for. */
         private const val DIAL_WATCHDOG_MS = 15_000L
+
+        /** How often the scanner reports what it has seen. Long enough that the
+         *  summary costs one line a window instead of several a second, short
+         *  enough that a scanner going silent shows up while you are watching. */
+        private const val SCAN_SUMMARY_SECS = 30L
 
         /** Background scan: batched delivery window (controller-offloaded). */
         private const val BACKGROUND_BATCH_MS = 5000L

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -395,6 +395,12 @@ class BleRadio(context: Context) {
             sc.startScan(filters, settings, cb)
             Log.i(TAG, "scanning for FIPS peers (${if (backgroundMode) "low-power" else "low-latency"})")
             if (bridgeHandle != 0L) NativeCore.bleDeliverScanningState(bridgeHandle, true)
+            // A scanner that has only just started has not been silent yet, so
+            // the streak restarts here — this is what keeps the warning off
+            // screen in the first moments after the mesh is switched on. The
+            // *verdict* ([BleHealth.scannerConfirmedSilent]) deliberately does
+            // not restart with it: see that field.
+            BleHealth.emptyScanWindows = 0
             scanSummaryTask = runCatching {
                 retryExec.scheduleWithFixedDelay(
                     { if (!stopped) runCatching { logScanSummary() } },
@@ -451,9 +457,18 @@ class BleRadio(context: Context) {
             // nothing is inbound-only: it can never learn a peer's PSM, so
             // every dial it makes falls back to the configured default and
             // fails. That is invisible unless it is said out loud.
-            Log.w(TAG, "scan summary: 0 adverts in ${secs}s — scanner produced nothing")
+            val empty = BleHealth.emptyScanWindows + 1
+            BleHealth.emptyScanWindows = empty
+            if (empty >= SILENT_WINDOWS_BEFORE_ALARM) BleHealth.scannerConfirmedSilent = true
+            Log.w(TAG, "scan summary: 0 adverts in ${secs}s — scanner produced nothing (window $empty)")
             return
         }
+        // One advert of any kind proves the scanner is delivering, so both the
+        // streak and the verdict are over. This is the *only* place the
+        // verdict is cleared: nothing short of a real advert counts as the
+        // radio having recovered.
+        BleHealth.emptyScanWindows = 0
+        BleHealth.scannerConfirmedSilent = false
         val tail = if (silent.isEmpty()) {
             ""
         } else {
@@ -500,6 +515,10 @@ class BleRadio(context: Context) {
         // "0 adverts" against a scanner nobody asked to be running.
         scanSummaryTask?.cancel(false)
         scanSummaryTask = null
+        // Silence only means something while we are listening. A stopped
+        // scanner has heard nothing by definition, and leaving the streak
+        // standing would accuse the phone of a fault while the mesh is off.
+        BleHealth.emptyScanWindows = 0
         if (bridgeHandle != 0L) NativeCore.bleDeliverScanningState(bridgeHandle, false)
     }
 
@@ -511,6 +530,11 @@ class BleRadio(context: Context) {
     /** Tear everything down (called when the service stops). */
     fun shutdown() {
         stopped = true
+        // The radio is being destroyed — on a mesh toggle a fresh one is built
+        // in its place, and it must start with no verdict against it. This is
+        // the one thing other than a real advert that clears the latch, and it
+        // is not a shortcut: there is no scanner left to be deaf.
+        BleHealth.scannerConfirmedSilent = false
         stopScanning()
         stopAdvertising()
         runCatching { serverSocket?.close() }
@@ -760,6 +784,12 @@ class BleRadio(context: Context) {
          *  enough that a scanner going silent shows up while you are watching. */
         private const val SCAN_SUMMARY_SECS = 30L
 
+        /** Consecutive empty [SCAN_SUMMARY_SECS] windows before the radio is
+         *  called deaf ([BleHealth.scannerConfirmedSilent]). Two, not one: a
+         *  full minute of listening, so a scanner merely slow to deliver its
+         *  first result is never accused. */
+        private const val SILENT_WINDOWS_BEFORE_ALARM = 2
+
         /** Background scan: batched delivery window (controller-offloaded). */
         private const val BACKGROUND_BATCH_MS = 5000L
 
@@ -803,4 +833,36 @@ object BleHealth {
      *  Cleared automatically once advertising succeeds on a retry. */
     @Volatile
     var advertiserExhausted: Boolean = false
+
+    /**
+     * How many consecutive scan-summary windows have produced **no advert at
+     * all** — the count behind `scan summary: 0 adverts in 30s`. Restarts at
+     * zero every time the scanner starts, which is what keeps a freshly
+     * enabled mesh from being accused before it has had time to hear anything.
+     */
+    @Volatile
+    var emptyScanWindows: Int = 0
+
+    /**
+     * **The verdict**: this radio has been listening and heard nothing for
+     * long enough that it is not merely quiet, it is deaf.
+     *
+     * This is the observable half of the vendor-stack bug that cost a day of
+     * diagnosis: a device whose scan callback never fires is inbound-only — it
+     * advertises, accepts connections, and can never learn a peer's PSM, so it
+     * never dials anyone. `startScan` reports success throughout. Only the
+     * absence of results says so.
+     *
+     * Kept separate from [emptyScanWindows] because the streak is far too
+     * fragile to drive a warning off directly. The scanner re-arms on every
+     * fore/background flip, and tapping the warning to open location settings
+     * is itself such a flip — so the streak-only version hid the warning the
+     * moment the user acted on it, then stayed hidden for another minute with
+     * nothing fixed. A conclusion once reached is held until something
+     * disproves it, and the only thing that disproves it is a real advert (see
+     * [BleRadio.logScanSummary]) or the radio ceasing to exist (see
+     * [BleRadio.shutdown]).
+     */
+    @Volatile
+    var scannerConfirmedSilent: Boolean = false
 }

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -88,6 +89,26 @@ class BleRadio(context: Context) {
     private var stopped = false
 
     private var serverSocket: BluetoothServerSocket? = null
+
+    /**
+     * The PSM this radio's L2CAP listener is actually bound to, or 0 if it has
+     * none. Written only by [listen] and cleared by [shutdown], so it can never
+     * name a socket that is gone.
+     *
+     * Read by [BleService] to tell a recovered lane from one that came back up
+     * scanning but undialable — a radio with no listener advertises nothing a
+     * peer can connect to, which is invisible from the outside.
+     */
+    @Volatile
+    var listenPsm: Int = 0
+        private set
+
+    // Say it once, not once per operation and not once per retry: with the
+    // adapter off, `bluetoothLeScanner` / `bluetoothLeAdvertiser` are null and
+    // `listenUsingInsecureL2capChannel` throws — three separate ways to fail,
+    // all meaning the same single thing. Per-radio, so the replacement radio
+    // built when Bluetooth returns starts with a clean slate.
+    private val adapterOffLogged = AtomicBoolean(false)
     private var advertiser: BluetoothLeAdvertiser? = null
     private var advertiseCallback: AdvertiseCallback? = null
     private var scanner: BluetoothLeScanner? = null
@@ -145,17 +166,47 @@ class BleRadio(context: Context) {
     /** Open an insecure L2CAP listener; return the OS-assigned PSM (0 on failure). */
     fun listen(): Int {
         if (stopped) return 0
-        val a = adapter ?: return 0
+        val a = adapter ?: run {
+            Log.e(TAG, "listen: no Bluetooth adapter on this device")
+            return 0
+        }
+        if (!a.isEnabled) {
+            reportAdapterOff("listen")
+            return 0
+        }
         return try {
             val ss = a.listenUsingInsecureL2capChannel()
             serverSocket = ss
             val psm = ss.psm
+            listenPsm = psm
             io.execute { acceptLoop(ss) }
             Log.i(TAG, "L2CAP listening on PSM $psm")
             psm
         } catch (e: Exception) {
             Log.e(TAG, "listen failed", e)
             0
+        }
+    }
+
+    /**
+     * Report — once per radio — that Bluetooth itself is off, so the lane
+     * cannot open.
+     *
+     * This is the line whose absence hid the off/on bug: `startScanning` used
+     * to return on a null `bluetoothLeScanner` without a word, so a process
+     * that started with Bluetooth disabled looked identical to a healthy one
+     * (`bluetooth_on=1`, transport `up`) while having never scanned once.
+     * Recovery is [BleService]'s job — it watches the adapter — so this only
+     * has to be audible, not actionable.
+     */
+    private fun reportAdapterOff(op: String) {
+        if (adapterOffLogged.compareAndSet(false, true)) {
+            Log.w(
+                TAG,
+                "$op: Bluetooth is off — this radio has no listener, no advert and " +
+                    "no scan; the lane stays down until the adapter comes back " +
+                    "(BleService rebuilds it then)",
+            )
         }
     }
 
@@ -281,7 +332,12 @@ class BleRadio(context: Context) {
         // Stop-before-start hygiene: never orphan a prior advertiser set on a
         // re-advertise (retry / radio restart), which itself burns a slot.
         stopAdvertising()
-        val adv = adapter?.bluetoothLeAdvertiser ?: return
+        // Null whenever the adapter is not ON. Returning silently here is how a
+        // radio ends up believing it advertises when it does not.
+        val adv = adapter?.bluetoothLeAdvertiser ?: run {
+            reportAdapterOff("startAdvertising")
+            return
+        }
         advertiser = adv
         val settings = AdvertiseSettings.Builder()
             .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_BALANCED)
@@ -356,7 +412,12 @@ class BleRadio(context: Context) {
         // Stop-before-start hygiene: a re-arm (retry / radio restart) must not
         // orphan a prior scan callback.
         stopScanning()
-        val sc = adapter?.bluetoothLeScanner ?: return
+        // Null whenever the adapter is not ON — the silent return that made a
+        // Bluetooth off/on cycle leave this process permanently deaf.
+        val sc = adapter?.bluetoothLeScanner ?: run {
+            reportAdapterOff("startScanning")
+            return
+        }
         scanner = sc
         val filters = listOf(ScanFilter.Builder().setServiceUuid(FIPS_PARCEL_UUID).build())
         val settings = ScanSettings.Builder()
@@ -539,6 +600,9 @@ class BleRadio(context: Context) {
         stopAdvertising()
         runCatching { serverSocket?.close() }
         serverSocket = null
+        // The socket is gone, so the PSM must not outlive it: a stale non-zero
+        // value here would tell [BleService] a dead radio was healthy.
+        listenPsm = 0
         // Dials parked in connect() outlive the radio otherwise: the thread
         // pool is shut down below, but shutdownNow cannot interrupt a thread
         // blocked in the BT stack. Closing the socket is what releases it.

--- a/android/app/src/main/java/app/myco/ble/BleService.kt
+++ b/android/app/src/main/java/app/myco/ble/BleService.kt
@@ -4,11 +4,17 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ServiceInfo
 import android.os.Build
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -29,10 +35,34 @@ import app.myco.core.NativeCore
  *
  * The node + radio are process-singletons ([MycoCore]); the developer UI reads
  * the same node's state.
+ *
+ * It also owns the **Bluetooth adapter watch**. The radio can only be built
+ * against an adapter that is ON, so the service follows the adapter for the
+ * radio's whole life: parking the lane when Bluetooth goes away and rebuilding
+ * it when Bluetooth comes back. See [applyAdapterState].
  */
 class BleService : Service() {
     private var radio: BleRadio? = null
     private var bridgeHandle: Long = 0
+
+    /** True once [startBle] has run and not been undone, so [onDestroy] knows
+     *  whether there is anything left to tear down — including in the parked
+     *  case, where the radio is already gone but the notification is not. */
+    private var running = false
+
+    /**
+     * The lane is down because **Bluetooth is off**, as opposed to down because
+     * nobody asked for it. Only a parked lane is rebuilt on `STATE_ON`, so a
+     * duplicate or spurious settle cannot bounce a healthy radio and drop its
+     * peers.
+     */
+    private var parked = false
+
+    /** Consecutive rebuilds that came up without an L2CAP listener. */
+    private var rebuilds = 0
+
+    private var adapterWatch: BroadcastReceiver? = null
+    private val handler = Handler(Looper.getMainLooper())
 
     // App-visibility observer: while no activity is visible (home button, screen
     // off), drop BLE discovery from LOW_LATENCY to a duty-cycled LOW_POWER scan —
@@ -50,6 +80,24 @@ class BleService : Service() {
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        // Registered here, exactly once per service instance, and for the whole
+        // of it: the watch has to outlive the radio, because the case it exists
+        // for is precisely the one where there is no working radio to hang it
+        // off. Unregistered in [onDestroy].
+        registerAdapterWatch()
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacks(settleAdapterState)
+        handler.removeCallbacks(checkRebuild)
+        adapterWatch?.let { runCatching { unregisterReceiver(it) } }
+        adapterWatch = null
+        if (running) stopBle()
+        super.onDestroy()
+    }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
@@ -96,10 +144,41 @@ class BleService : Service() {
         // Registration replays the current state (onStart fires immediately if the
         // app is already visible), so the radio starts in the right mode.
         ProcessLifecycleOwner.get().lifecycle.addObserver(visibilityObserver)
-        Log.i(TAG, "BLE service started")
+        running = true
+        // A radio built against an adapter that is off has no listener, no
+        // advert and no scan — the core's `listen` returns 0 and both
+        // `bluetoothLeScanner` and `bluetoothLeAdvertiser` are null. Record
+        // that so `STATE_ON` knows there is a lane to recover, which is the
+        // cold-start half of the bug: with Bluetooth already off at launch,
+        // nothing later asked the radio to try again.
+        parked = !adapterOn()
+        if (parked) {
+            Log.w(TAG, "BLE service started with Bluetooth off — lane parked, waiting for the adapter")
+            showNotification(TEXT_WAITING)
+        } else {
+            Log.i(TAG, "BLE service started")
+        }
     }
 
+    /** Stop the lane **and** the service's foreground status: the radio is not
+     *  coming back without another [startBle]. */
     private fun stopBle() {
+        teardown(keepAlive = false)
+        running = false
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        Log.i(TAG, "BLE service stopped")
+    }
+
+    /**
+     * Drop the radio and retract it from the core.
+     *
+     * [keepAlive] keeps the service in the foreground — used when parking for a
+     * Bluetooth outage, where the service must survive to see the adapter come
+     * back. Dropping foreground status there would leave the recovery watch on
+     * a plain background service, which the OS is free to kill; the outage would
+     * then be permanent again, just for a different reason.
+     */
+    private fun teardown(keepAlive: Boolean) {
         ProcessLifecycleOwner.get().lifecycle.removeObserver(visibilityObserver)
         // Node lifecycle belongs to the mesh "Enable" master switch — never stop
         // the node here. Clearing the BLE flag tells the node's BLE backend to
@@ -122,17 +201,129 @@ class BleService : Service() {
         // fresh bridge on the next start. Freeing here risks a use-after-free; the
         // bridge is small, so leaking it on stop is the safe trade.
         bridgeHandle = 0
-        stopForeground(STOP_FOREGROUND_REMOVE)
-        Log.i(TAG, "BLE service stopped")
+        if (keepAlive) Log.i(TAG, "BLE radio torn down (service stays up)")
     }
 
-    override fun onDestroy() {
-        if (radio != null) stopBle()
-        super.onDestroy()
+    // ---- Bluetooth adapter watch ----
+
+    /**
+     * Follow `BluetoothAdapter.ACTION_STATE_CHANGED` for the life of the
+     * service.
+     *
+     * Without this, turning Bluetooth off and on again left the process
+     * permanently deaf: scanning is only ever started by the core's
+     * `RadioIntent` when a radio is installed, and nothing re-installed one.
+     * The adapter is the only thing that knows it came back.
+     */
+    private fun registerAdapterWatch() {
+        if (adapterWatch != null) return
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (intent?.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
+                val state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
+                // STATE_TURNING_ON / STATE_TURNING_OFF broadcast too, and acting
+                // on them is worse than useless: mid-flight the stack still
+                // rejects `listenUsingInsecureL2capChannel` and still hands out
+                // a null scanner, so a rebuild there fails and leaves the lane
+                // looking rebuilt. Settled states only.
+                if (state != BluetoothAdapter.STATE_ON && state != BluetoothAdapter.STATE_OFF) return
+                Log.i(TAG, "bluetooth adapter ${if (state == BluetoothAdapter.STATE_ON) "ON" else "OFF"}")
+                // Coalesce. Each settled state cancels the pending apply and
+                // re-arms it, so an off/on/off flurry converges on **one**
+                // rebuild-or-park decided against whatever the adapter finally
+                // settled on — never a stack of bounces racing each other for
+                // the core's radio slot. The same delay doubles as the stack's
+                // grace period after STATE_ON, before which an L2CAP listener
+                // often will not bind.
+                handler.removeCallbacks(settleAdapterState)
+                handler.postDelayed(settleAdapterState, ADAPTER_SETTLE_MS)
+            }
+        }
+        adapterWatch = receiver
+        registerReceiver(receiver, IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED))
     }
+
+    private val settleAdapterState = Runnable { applyAdapterState() }
+
+    /**
+     * Bring the lane into line with the adapter.
+     *
+     * Reads the adapter directly rather than the broadcast's `EXTRA_STATE`:
+     * after coalescing, the only state that matters is the one it settled on.
+     *
+     * Recovery is a **full rebuild of the radio**, not a re-issued scan. When
+     * Bluetooth was off, the L2CAP listener never opened either, so the radio
+     * has no PSM — re-issuing only the scan would leave a node that hears
+     * everyone and can be dialled by no one, advertising a PSM nothing listens
+     * on (the failure fixed in 86ce34d). A rebuild goes through the same path
+     * the mesh toggle uses: `bleBridgeClear` empties the core's radio slot,
+     * `bleBridgeNew` installs a fresh one, and the core's `RadioIntent` then
+     * re-applies listen → advertise → scan against it *in that order* — so the
+     * PSM it advertises is by construction the one `listen()` just bound.
+     */
+    private fun applyAdapterState() {
+        if (!running) return
+        if (adapterOn()) {
+            if (!parked) {
+                Log.i(TAG, "bluetooth on and the lane was never parked — nothing to recover")
+                return
+            }
+            rebuilds = 0
+            rebuildLane("bluetooth came back")
+        } else {
+            handler.removeCallbacks(checkRebuild)
+            if (parked && radio == null) return // already parked; nothing to do
+            parked = true
+            Log.w(TAG, "bluetooth off — parking the BLE lane (scanning + advertising now report down)")
+            // Tears the radio down, which pushes scanning=false and
+            // advertising=false into the core's atomics — so the Dev tab stops
+            // claiming a radio that no longer exists is active.
+            teardown(keepAlive = true)
+            showNotification(TEXT_WAITING)
+        }
+    }
+
+    /** Rebuild the radio from scratch and check, once, that it actually came up. */
+    private fun rebuildLane(why: String) {
+        rebuilds++
+        Log.i(TAG, "$why — rebuilding the BLE lane (attempt $rebuilds)")
+        if (radio != null) teardown(keepAlive = true)
+        // startBle re-reads the adapter and sets `parked` (and the notification)
+        // itself, so a rebuild that races Bluetooth going away again lands back
+        // in the parked state rather than claiming success.
+        startBle()
+        handler.removeCallbacks(checkRebuild)
+        handler.postDelayed(checkRebuild, REBUILD_CHECK_MS)
+    }
+
+    /**
+     * Did the rebuild produce a dialable radio?
+     *
+     * A rebuild issued a moment too early gets a scanner but no listener — the
+     * adapter is ON while the stack is still settling — and that is exactly the
+     * half-recovered state this whole change exists to avoid, so it is checked
+     * rather than assumed. [BleRadio.listenPsm] is non-zero only while a real
+     * L2CAP server socket is bound.
+     */
+    private val checkRebuild = Runnable {
+        val psm = radio?.listenPsm ?: 0
+        when {
+            !adapterOn() -> Unit // an OFF overtook us; applyAdapterState owns it
+            psm != 0 -> {
+                Log.i(TAG, "BLE lane recovered: L2CAP listener bound to PSM $psm (advertised by the core)")
+                rebuilds = 0
+            }
+            rebuilds >= MAX_REBUILDS ->
+                Log.e(TAG, "BLE lane still has no L2CAP listener after $rebuilds rebuilds — giving up until the adapter changes again")
+            else -> rebuildLane("no L2CAP listener after rebuild $rebuilds")
+        }
+    }
+
+    private fun adapterOn(): Boolean =
+        (getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter?.isEnabled == true
 
     private fun startForegroundCompat() {
-        val notif = buildNotification()
+        val notif = buildNotification(TEXT_ACTIVE)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             startForeground(NOTIF_ID, notif, ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE)
         } else {
@@ -140,7 +331,15 @@ class BleService : Service() {
         }
     }
 
-    private fun buildNotification(): Notification {
+    /** Re-post the ongoing notification so it says what the lane is actually
+     *  doing — the service stays foreground either way. */
+    private fun showNotification(text: String) {
+        if (!running) return
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        runCatching { nm.notify(NOTIF_ID, buildNotification(text)) }
+    }
+
+    private fun buildNotification(text: String): Notification {
         val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(CHANNEL_ID, "Myco BLE", NotificationManager.IMPORTANCE_LOW)
@@ -154,7 +353,7 @@ class BleService : Service() {
         )
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("Myco")
-            .setContentText("BLE peering active")
+            .setContentText(text)
             .setSmallIcon(R.mipmap.ic_launcher)
             .setOngoing(true)
             .addAction(0, "Stop", stopPi)
@@ -165,6 +364,23 @@ class BleService : Service() {
         private const val TAG = "MycoBleService"
         private const val NOTIF_ID = 1
         private const val CHANNEL_ID = "myco_ble"
+        private const val TEXT_ACTIVE = "BLE peering active"
+        private const val TEXT_WAITING = "Waiting for Bluetooth"
+
+        /** How long a settled adapter state is left to stand before it is acted
+         *  on. Two jobs at once: it collapses an off/on/off flurry into one
+         *  decision, and it gives the Bluetooth stack a moment after `STATE_ON`
+         *  — the adapter reports enabled before an L2CAP listener will reliably
+         *  bind. [checkRebuild] covers the case where it is still too soon. */
+        private const val ADAPTER_SETTLE_MS = 1_500L
+
+        /** How long after a rebuild to confirm the listener actually bound. */
+        private const val REBUILD_CHECK_MS = 5_000L
+
+        /** Rebuild attempts per adapter change before the lane is left alone.
+         *  Bounded so a chipset that will not open a listener at all cannot
+         *  turn recovery into an endless radio-churn loop. */
+        private const val MAX_REBUILDS = 3
         const val ACTION_START = "app.myco.ble.START"
         const val ACTION_STOP = "app.myco.ble.STOP"
 

--- a/android/app/src/main/java/app/myco/ble/BleService.kt
+++ b/android/app/src/main/java/app/myco/ble/BleService.kt
@@ -111,6 +111,12 @@ class BleService : Service() {
         }
         radio?.shutdown()
         radio = null
+        // Retract the dead radio from the core's slot. Without this the core kept
+        // holding it, and the next node rebuild (a mesh toggle) installed the
+        // shut-down radio into the fresh slot — so `listen` and `start_advertising`
+        // ran against closed sockets until `bleBridgeNew` replaced it a second
+        // later. An empty slot parks the backend instead, which is correct.
+        if (bridgeHandle != 0L) runCatching { NativeCore.bleBridgeClear(bridgeHandle) }
         // Intentionally NOT freeing the bridge handle: the radio's I/O threads may
         // still reference it as they wind down, and the rebuilt node will inject a
         // fresh bridge on the next start. Freeing here risks a use-after-free; the

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -105,6 +105,10 @@ data class PeerDiagnostic(
     val alsoReachableVia: List<String> = emptyList(),
     /** 0 when never heard from — renders as an em-dash, never "0s". */
     val lastSeenMs: Long,
+    /** Epoch ms the FMP session authenticated; 0 when there is no session.
+     *  The age from this is the session's, not the current FMP index's — the
+     *  index rotates on every rekey (~120s) while the session survives. */
+    val authenticatedAtMs: Long = 0L,
     val rssi: Int?,
     val psm: Int,
     /** "" | "incoming-waiting" | "outbound-waiting" | "paired". */
@@ -355,6 +359,7 @@ data class AppState(
                                 transport = p.optString("transport"),
                                 alsoReachableVia = alsoReachableVia,
                                 lastSeenMs = p.optLong("lastSeenMs"),
+                                authenticatedAtMs = p.optLong("authenticatedAtMs"),
                                 rssi = if (p.isNull("rssi")) null else p.optInt("rssi"),
                                 psm = p.optInt("psm"),
                                 pairState = p.optString("pairState"),

--- a/android/app/src/main/java/app/myco/core/NativeCore.kt
+++ b/android/app/src/main/java/app/myco/core/NativeCore.kt
@@ -101,13 +101,26 @@ internal object NativeCore {
      *  nothing but mesh names. */
     external fun setUpstreamDns(servers: String)
 
-    /** Raw fd of the node's UDP transport socket, once it has opened. Blocks
-     *  up to `timeoutMs`; returns -1 on timeout. Sent once per node lifetime —
-     *  poll this once at startup, then bind it to whichever local-only
-     *  network (Wi-Fi Aware NDP, the `!FIPS` AP) is carrying a
-     *  platform-pushed peer via `Network.bindSocket`, so handshake replies
-     *  aren't lost to a competing validated default network (e.g. cellular). */
-    external fun nextUdpTransportFd(timeoutMs: Int): Int
+    /** Raw fd of the UDP transport socket carrying `lane` (`"aware"` or
+     *  `"udp"`), if the core has announced one newer than `sinceVersion`.
+     *  Blocks up to `timeoutMs`.
+     *
+     *  The node binds **one socket per lane** and the core labels each fd with
+     *  the lane it belongs to, so a radio can only ever receive its own — never
+     *  the other lane's, which it would then pin to the wrong [android.net.Network]
+     *  and black-hole. Bind what comes back with `Network.bindSocket`: a
+     *  local-only network (a Wi-Fi Aware NDP, the `!FIPS` AP) otherwise loses
+     *  handshake replies to a competing validated default network (e.g.
+     *  cellular), and a socket marked with one network cannot reach the other
+     *  lane's peers at all.
+     *
+     *  Returns `(version shl 32) or fd` — JNI has no tuple, and two calls could
+     *  not be made atomic. Use [UdpSocketAnnouncement.of]. `fd` is -1 when
+     *  nothing newer arrived; otherwise pass the returned version back next
+     *  time. Poll in a slow loop: the latest socket per lane is retained, so a
+     *  radio started after the node still learns it, and a node restart bumps
+     *  the version even if the kernel reuses the fd number. */
+    external fun nextUdpTransportFd(lane: String, sinceVersion: Long, timeoutMs: Int): Long
 
     // --- TUN packet bridge (the app-owned TUN; the VpnService pumps these) ---
     /** Kotlin → Rust: route an IPv6 packet read from the TUN fd into the mesh. */

--- a/android/app/src/main/java/app/myco/core/NativeCore.kt
+++ b/android/app/src/main/java/app/myco/core/NativeCore.kt
@@ -42,6 +42,11 @@ internal object NativeCore {
 
     /** Create the bridge over a BleRadio, inject it into the core, return a handle. */
     external fun bleBridgeNew(appHandle: Long, radio: Any): Long
+
+    /** Retract a shut-down radio from the core's slot, without freeing the
+     *  handle. The core then parks until a live radio is injected, rather than
+     *  driving one whose sockets are already closed. */
+    external fun bleBridgeClear(bridgeHandle: Long)
     external fun bleBridgeFree(bridgeHandle: Long)
 
     /** Kotlin → Rust pushes (non-blocking). */

--- a/android/app/src/main/java/app/myco/core/UdpSocketPin.kt
+++ b/android/app/src/main/java/app/myco/core/UdpSocketPin.kt
@@ -1,0 +1,137 @@
+package app.myco.core
+
+import android.net.Network
+import android.os.Handler
+import android.os.ParcelFileDescriptor
+import android.util.Log
+import java.io.FileDescriptor
+
+/**
+ * Pins one lane's UDP transport socket to one [Network].
+ *
+ * # Why a lane needs this at all
+ *
+ * Android routes by the network a socket is *marked* with, not by destination
+ * address alone. A local-only network — a Wi-Fi Aware NDP, the `!FIPS` AP —
+ * never passes internet validation, so an unmarked socket's replies can be
+ * delivered over, or dropped in favour of, a competing validated default
+ * network (typically cellular): the send succeeds locally and nothing ever
+ * comes back. `Network.bindSocket` fixes that by marking the socket.
+ *
+ * # Why there is one of these per lane
+ *
+ * The mark is exclusive. A socket marked with the Wi-Fi netid cannot reach a
+ * Wi-Fi Aware peer, whose NDP is a separate [Network] with its own routing
+ * table, and vice versa. While both lanes shared a single core socket, whichever
+ * bound last silently disabled the other — which is why Wi-Fi Aware could
+ * discover peers, bring up data paths, and never complete a single handshake.
+ *
+ * The core therefore binds one UDP transport per lane and labels every
+ * descriptor it announces with the lane it belongs to. This class asks for one
+ * lane by name ([NativeCore.nextUdpTransportFd]), so it cannot be handed the
+ * other's socket even if that one is announced first — the announcements are
+ * unordered, since the core builds its transports from a hash map.
+ *
+ * # Lifecycle
+ *
+ * The fd is a *borrow*: the core keeps the socket. [ParcelFileDescriptor.fromFd]
+ * dups it so this class holds a descriptor that stays valid while it may still
+ * need to re-bind on a network change, without ever closing the core's own.
+ *
+ * A poll loop rather than a one-shot read, because a node restart (a mesh
+ * off→on cycle) replaces the socket. The core retains the latest announcement
+ * per lane and versions it, so a radio the user toggles on *after* the node
+ * started still learns the socket, and a replacement is recognised even when
+ * the kernel hands back the same fd number.
+ *
+ * All mutable state is confined to [handler]'s thread.
+ */
+internal class UdpSocketPin(
+    /** Lane name, as understood by [NativeCore.nextUdpTransportFd]. */
+    private val lane: String,
+    /** The owning radio's handler; every state change runs here. */
+    private val handler: Handler,
+    /** The owning radio's log tag, so pin messages sit with its own. */
+    private val tag: String,
+) {
+    private var pfd: ParcelFileDescriptor? = null
+    private var fd: FileDescriptor? = null
+
+    /** The network to pin to, remembered so a later fd (or a later network) can
+     *  be married up with whichever half arrived first. */
+    private var target: Network? = null
+
+    @Volatile
+    private var running = false
+
+    /** Start watching for this lane's socket. Idempotent. */
+    fun start() {
+        if (running) return
+        running = true
+        Thread({
+            var version = 0L
+            while (running) {
+                val packed = NativeCore.nextUdpTransportFd(lane, version, POLL_TIMEOUT_MS)
+                val fd = packed.toInt()
+                if (fd < 0) continue // nothing newer within the timeout
+                version = packed ushr 32
+                handler.post { onFd(fd) }
+            }
+        }, "myco-udpfd-$lane").apply { isDaemon = true; start() }
+    }
+
+    /** Stop watching and release our dup of the socket. The core's own
+     *  descriptor is untouched. Must run on [handler]'s thread. */
+    fun stop() {
+        running = false
+        pfd?.let { runCatching { it.close() } }
+        pfd = null
+        fd = null
+        target = null
+    }
+
+    /**
+     * Pin to `network` — now if the socket is known, otherwise as soon as it is
+     * announced. Passing the same network again re-binds, which is what a
+     * fresh socket for an unchanged network needs. Must run on [handler]'s
+     * thread.
+     */
+    fun bindTo(network: Network) {
+        target = network
+        bind()
+    }
+
+    /** Forget the pin target without unbinding — there is no "unbind", and the
+     *  mark is harmless once the network is gone. Must run on [handler]'s
+     *  thread. */
+    fun clearTarget(network: Network) {
+        if (target == network) target = null
+    }
+
+    private fun onFd(raw: Int) {
+        if (!running) return
+        val dup = runCatching { ParcelFileDescriptor.fromFd(raw) }.getOrElse {
+            Log.w(tag, "could not dup $lane UDP transport fd $raw", it)
+            return
+        }
+        pfd?.let { old -> runCatching { old.close() } }
+        pfd = dup
+        fd = dup.fileDescriptor
+        Log.i(tag, "learned $lane UDP transport fd $raw")
+        bind()
+    }
+
+    private fun bind() {
+        val socket = fd ?: return       // node not started yet; onFd binds when it is
+        val network = target ?: return  // no network to pin to yet
+        runCatching { network.bindSocket(socket) }
+            .onSuccess { Log.i(tag, "pinned $lane UDP socket to $network") }
+            .onFailure { Log.w(tag, "pinning $lane UDP socket to $network failed", it) }
+    }
+
+    private companion object {
+        /** Blocking wait per poll. Short so a mesh off→on cycle's fresh socket
+         *  is picked up promptly and so [stop] is honoured within a second. */
+        const val POLL_TIMEOUT_MS = 1_000
+    }
+}

--- a/android/app/src/main/java/app/myco/ui/RadioWarnings.kt
+++ b/android/app/src/main/java/app/myco/ui/RadioWarnings.kt
@@ -2,13 +2,15 @@ package app.myco.ui
 
 import android.bluetooth.BluetoothManager
 import android.content.Context
+import android.location.LocationManager
 import android.net.VpnService
 import android.net.wifi.WifiManager
 import app.myco.aware.AwareHealth
+import app.myco.ble.BleHealth
 import app.myco.core.AppState
 
 /** What tapping a [RadioWarning] should do. Dispatched in SettingsScreen. */
-enum class RadioAction { FIX_VPN, ENABLE_BLUETOOTH, ENABLE_WIFI, GRANT_AWARE_PERMISSION }
+enum class RadioAction { FIX_VPN, ENABLE_BLUETOOTH, ENABLE_WIFI, GRANT_AWARE_PERMISSION, ENABLE_LOCATION }
 
 /** One actionable radio/VPN misconfiguration to surface to the user. */
 data class RadioWarning(val title: String, val detail: String, val action: RadioAction)
@@ -43,6 +45,13 @@ fun radioWarnings(context: Context, state: AppState, meshEnabled: Boolean): List
                     "turned off — nearby peers can't be found. Tap to turn Bluetooth on.",
                 action = RadioAction.ENABLE_BLUETOOTH,
             )
+        } else if (scanBlindedByLocation(context)) {
+            warnings += RadioWarning(
+                title = "Location is off",
+                detail = "Others can find Myco, but Myco can't find them. Bluetooth " +
+                    "scanning needs location. Tap to turn it on.",
+                action = RadioAction.ENABLE_LOCATION,
+            )
         }
     }
 
@@ -69,3 +78,40 @@ fun radioWarnings(context: Context, state: AppState, meshEnabled: Boolean): List
 
     return warnings
 }
+
+/**
+ * Whether the phone's **location services** master switch is on — a plain
+ * Android fact, read straight off [LocationManager] the same way
+ * [app.myco.aware.AwareRadio.isAvailable] reads Aware's, never routed through
+ * `myco-core`. `isLocationEnabled` is API 28 and this app is minSdk 29, so
+ * there is no legacy provider fallback to keep.
+ *
+ * Myco does not want the user's location and never asks for it: `BLUETOOTH_SCAN`
+ * is declared `neverForLocation` and `ACCESS_FINE_LOCATION` is capped at
+ * API 32. This is read only to explain a scanner that has gone silent — see
+ * [scanBlindedByLocation].
+ */
+fun locationServicesEnabled(context: Context): Boolean =
+    (context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager)?.isLocationEnabled == true
+
+/**
+ * Whether this phone looks like it is in the state that cost a full day of
+ * diagnosis on a DC-1 tablet: **scanning silently returns nothing because
+ * location services are off.**
+ *
+ * On AOSP, `neverForLocation` means the master location switch has nothing to
+ * do with BLE scanning from API 31 up. Some vendor stacks ignore that and gate
+ * scan callbacks on it anyway. The failure is completely silent — permissions
+ * are granted, `startScan` reports success, advertising works and inbound
+ * connections land — the device simply never receives a scan result, so it can
+ * never learn a peer's PSM and never dials anyone.
+ *
+ * The test is therefore the *symptom* plus its likely cause, never the setting
+ * alone: warning on "location is off" would be a false alarm on every
+ * compliant device, which is most of them. [BleHealth.scannerConfirmedSilent]
+ * is the symptom — a full minute of listening that produced not one advert —
+ * and it clears itself the moment a real advert arrives, which is exactly what
+ * happens on this hardware within seconds of location being switched on.
+ */
+private fun scanBlindedByLocation(context: Context): Boolean =
+    BleHealth.scannerConfirmedSilent && !locationServicesEnabled(context)

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -109,16 +110,17 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
                 ?: "Technical details — myco-core state.",
         )
 
-        // D-07: the radio self-check leads, because "no peers" is the actual
-        // field complaint and this card is what answers "is it me or is it
-        // them" without a second screen.
-        RadioSelfCheckCard(devState, awareSupported, awareAvailable)
+        // Who am I, then who can I see, then why. Identity leads because it is
+        // what a second device is compared against; the self-check sits under
+        // the peer list rather than over it, since it is the follow-up question
+        // once the list is empty or short, not the first thing read.
+        IdentityCard(devState)
 
         PeersOverviewCard(devState, firstReadLanded)
 
-        PendingPairingsCard(devState, firstReadLanded)
+        RadioSelfCheckCard(devState, awareSupported, awareAvailable)
 
-        IdentityCard(devState)
+        PendingPairingsCard(devState, firstReadLanded)
 
         SelectionContainer {
             Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
@@ -412,7 +414,16 @@ private fun PeersOverviewCard(state: AppState, firstReadLanded: Boolean) {
                 )
             }
         }
-        for (p in state.peers) {
+        // Ruled between rows, not merely spaced: a two-line row against a
+        // two-line neighbour reads as one four-line block without them, and the
+        // expanded body makes that worse.
+        state.peers.forEachIndexed { i, p ->
+            if (i > 0) {
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.padding(start = 16.dp),
+                )
+            }
             val isOpen = p.key in expanded
             PeerDiagnosticRow(p, isOpen) {
                 if (isOpen) expanded.remove(p.key) else expanded.add(p.key)
@@ -429,10 +440,19 @@ private fun PeersOverviewCard(state: AppState, firstReadLanded: Boolean) {
 }
 
 /**
- * One merged peer diagnostics row: state dot + monospace identity on the
- * left, carrying transport + exact-seconds last-heard counter (D-18) on the
- * right, in monospace. `lastSeenMs == 0L` and an empty transport both render
- * as an em-dash rather than a false "0s"/blank value.
+ * One merged peer diagnostics row, over two lines: state dot + monospace
+ * identity with the expand caret on the first, transport and the two link
+ * clocks on the second.
+ *
+ * "seen" is the exact-seconds last-heard counter (D-18); "up" is the FMP
+ * session age. They answer different questions — a link heard from a second
+ * ago that is only ever a few seconds "up" is re-establishing, which reads as
+ * healthy if only the last-heard value is shown. The session survives rekeys
+ * (`receiver_idx` rotates roughly every 120s), so a long "up" means the link
+ * has held rather than that a handshake went stale.
+ *
+ * `lastSeenMs == 0L`, `authenticatedAtMs == 0L` and an empty transport all
+ * render as an em-dash rather than a false "0s"/blank value.
  */
 @Composable
 private fun PeerDiagnosticRow(peer: PeerDiagnostic, expanded: Boolean, onToggle: () -> Unit) {
@@ -452,8 +472,10 @@ private fun PeerDiagnosticRow(peer: PeerDiagnostic, expanded: Boolean, onToggle:
         peer.name.ifEmpty { peer.npub.ifEmpty { peer.nodeAddrHex.ifEmpty { peer.bleAddr } } }
     }
     Column(modifier = Modifier.fillMaxWidth().clickable(onClick = onToggle)) {
+        // Line 1: who. The caret is the affordance — a row that opens has to
+        // look like one before it is tapped, and the dot alone never said so.
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),
+            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 8.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
         ) {
@@ -469,7 +491,26 @@ private fun PeerDiagnosticRow(peer: PeerDiagnostic, expanded: Boolean, onToggle:
                 )
             }
             Text(
-                "${peer.transport.ifEmpty { "—" }} · ${elapsedExact(peer.lastSeenMs)}",
+                if (expanded) "⌃" else "⌄",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        // Line 2: the link, at a glance. Session age rides here rather than
+        // only in the expanded body — it is the number that separates a link
+        // that keeps re-establishing from one that is simply holding, and that
+        // is worth seeing without opening every row.
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(start = 30.dp, end = 16.dp, top = 1.dp, bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                peer.transport.ifEmpty { "—" },
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                "seen ${elapsedExact(peer.lastSeenMs)} · up ${elapsedExact(peer.authenticatedAtMs)}",
                 style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -498,10 +539,6 @@ private fun PeerForensics(peer: PeerDiagnostic) {
         modifier = Modifier.padding(start = 30.dp, end = 16.dp, bottom = 8.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        // Session age, not index age: the FMP receiver_idx rotates on every
-        // rekey (~120s) while the session survives, so a long value here means
-        // the link has held rather than that a handshake went stale.
-        ForensicLine("session age", elapsedExact(peer.authenticatedAtMs))
         ForensicLine("role", peer.role.ifEmpty { "—" })
         ForensicLine("discovery", if (peer.discoveryMs > 0) "${peer.discoveryMs}ms" else "—")
         ForensicLine("send drops", peer.sendDrops.toString())

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -48,6 +48,7 @@ import app.myco.ui.KeyVal
 import app.myco.ui.ScreenHeader
 import app.myco.ui.SectionCard
 import app.myco.ui.StatusDot
+import app.myco.ui.locationServicesEnabled
 import app.myco.ui.theme.StatusAlone
 import app.myco.ui.theme.StatusConnected
 import app.myco.ui.theme.StatusReachable
@@ -84,11 +85,16 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
     // recording either way, so history is complete when the screen returns.
     var devState by remember { mutableStateOf(state) }
     var firstReadLanded by remember { mutableStateOf(false) }
+    // Re-read on the same tick as the core state rather than once at
+    // composition: this is the row you watch while flipping the setting in
+    // another app, so a value frozen at screen entry would be a lie.
+    var locationOn by remember { mutableStateOf(locationServicesEnabled(context)) }
     val lifecycleOwner = LocalLifecycleOwner.current
     LaunchedEffect(Unit) {
         lifecycleOwner.repeatOnLifecycle(androidx.lifecycle.Lifecycle.State.STARTED) {
             while (true) {
                 devState = withContext(Dispatchers.IO) { client.state() }
+                locationOn = withContext(Dispatchers.IO) { locationServicesEnabled(context) }
                 firstReadLanded = true
                 delay(1000)
             }
@@ -118,7 +124,7 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
 
         PeersOverviewCard(devState, firstReadLanded)
 
-        RadioSelfCheckCard(devState, awareSupported, awareAvailable)
+        RadioSelfCheckCard(devState, awareSupported, awareAvailable, locationOn)
 
         PendingPairingsCard(devState, firstReadLanded)
 
@@ -185,7 +191,7 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
 }
 
 /**
- * **The first card, always** (D-07). Six observed radio facts in a fixed order
+ * **The first card, always** (D-07). Seven observed radio facts in a fixed order
  * that never varies with data, so the person holding the phone can answer "is it
  * me or is it them" before scrolling.
  *
@@ -196,7 +202,12 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
  * and never blocks the screen.
  */
 @Composable
-private fun RadioSelfCheckCard(state: AppState, awareSupported: Boolean, awareAvailable: Boolean) {
+private fun RadioSelfCheckCard(
+    state: AppState,
+    awareSupported: Boolean,
+    awareAvailable: Boolean,
+    locationOn: Boolean,
+) {
     DevCard("RADIO SELF-CHECK") {
         KeyValTri("ble enabled", state.bleEnabled, "on", "off")
         KeyValTri(
@@ -211,6 +222,14 @@ private fun RadioSelfCheckCard(state: AppState, awareSupported: Boolean, awareAv
             "active",
             "idle",
         )
+        // Sits with the BLE rows because that is what it explains. Some vendor
+        // stacks gate BLE scan callbacks on the location master switch even
+        // though Myco declares `neverForLocation` and asks for no location
+        // permission at all; the device then advertises and accepts inbound
+        // connections normally while receiving nothing, which reads as
+        // "ble scanning: active" and an empty peer list. Off here, with the
+        // rows above green, is the whole answer.
+        KeyValTri("location services", locationOn, "on", "off")
         KeyValTri("aware supported", awareSupported, "yes", "no")
         KeyValTri("aware available", awareAvailable, "yes", "no")
         KeyValTri(

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -8,11 +8,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -29,6 +31,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -49,10 +52,13 @@ import app.myco.ui.ScreenHeader
 import app.myco.ui.SectionCard
 import app.myco.ui.StatusDot
 import app.myco.ui.locationServicesEnabled
+import app.myco.R
 import app.myco.ui.theme.StatusAlone
 import app.myco.ui.theme.StatusConnected
 import app.myco.ui.theme.StatusReachable
 import app.myco.ui.theme.StatusThin
+import app.myco.ui.theme.TransportBluetooth
+import app.myco.ui.theme.TransportNetwork
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.Dispatchers
@@ -491,10 +497,20 @@ private fun PeerDiagnosticRow(peer: PeerDiagnostic, expanded: Boolean, onToggle:
         peer.name.ifEmpty { peer.npub.ifEmpty { peer.nodeAddrHex.ifEmpty { peer.bleAddr } } }
     }
     Column(modifier = Modifier.fillMaxWidth().clickable(onClick = onToggle)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+        ) {
+        // Which radio carried this peer, read at a glance down the left edge.
+        // Deliberately larger than the text beside it: scanning the column for
+        // "which of these is on Bluetooth" is the common question, and it
+        // should not require reading a word on the second line.
+        TransportIcon(peer.transport, Modifier.padding(start = 14.dp, end = 2.dp))
+        Column(modifier = Modifier.weight(1f)) {
         // Line 1: who. The caret is the affordance — a row that opens has to
         // look like one before it is tapped, and the dot alone never said so.
         Row(
-            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 8.dp),
+            modifier = Modifier.fillMaxWidth().padding(start = 2.dp, end = 16.dp, top = 8.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
         ) {
@@ -520,7 +536,7 @@ private fun PeerDiagnosticRow(peer: PeerDiagnostic, expanded: Boolean, onToggle:
         // that keeps re-establishing from one that is simply holding, and that
         // is worth seeing without opening every row.
         Row(
-            modifier = Modifier.fillMaxWidth().padding(start = 30.dp, end = 16.dp, top = 1.dp, bottom = 8.dp),
+            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 1.dp, bottom = 8.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
@@ -534,10 +550,48 @@ private fun PeerDiagnosticRow(peer: PeerDiagnostic, expanded: Boolean, onToggle:
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+        }
+        }
         if (expanded) {
             PeerForensics(peer)
         }
     }
+}
+
+/**
+ * The transport a peer is reachable over, as an icon.
+ *
+ * Three lanes, three glyphs: the Bluetooth rune, the Wi-Fi Aware arcs, and a
+ * globe for anything routed (LAN, the `!FIPS` AP, mDNS). An unknown or absent
+ * transport draws nothing rather than guessing — a peer with no resolved link
+ * is a real state and a wrong icon would assert a link that does not exist.
+ *
+ * Bluetooth keeps its brand blue and the routed lane the app's emerald;
+ * Aware follows `onSurface`, so it reads as the plain radio in either theme.
+ */
+@Composable
+private fun TransportIcon(transport: String, modifier: Modifier = Modifier) {
+    val (res, tint, label) = when (transport) {
+        "ble" -> Triple(R.drawable.ic_transport_bluetooth, TransportBluetooth, "Bluetooth")
+        "aware" -> Triple(
+            R.drawable.ic_transport_wifi_aware,
+            MaterialTheme.colorScheme.onSurface,
+            "Wi-Fi Aware",
+        )
+        "" -> Triple(0, MaterialTheme.colorScheme.onSurfaceVariant, "")
+        // udp, tcp and anything else routed: it reached us over IP.
+        else -> Triple(R.drawable.ic_transport_network, TransportNetwork, "Network")
+    }
+    if (res == 0) {
+        Spacer(modifier.size(26.dp))
+        return
+    }
+    Icon(
+        painter = painterResource(res),
+        contentDescription = label,
+        tint = tint,
+        modifier = modifier.size(26.dp),
+    )
 }
 
 /**

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -98,7 +98,16 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
-        ScreenHeader("Dev", devState, subtitle = "Technical details — myco-core state.")
+        // The own npub leads the screen: it is the first thing needed when
+        // comparing two devices side by side, and the identity card carrying it
+        // sits several cards down.
+        ScreenHeader(
+            "Dev",
+            devState,
+            subtitle = devState.ownNpub.takeIf { it.isNotEmpty() }
+                ?.let { "you: ${short(it)}" }
+                ?: "Technical details — myco-core state.",
+        )
 
         // D-07: the radio self-check leads, because "no peers" is the actual
         // field complaint and this card is what answers "is it me or is it
@@ -489,6 +498,10 @@ private fun PeerForensics(peer: PeerDiagnostic) {
         modifier = Modifier.padding(start = 30.dp, end = 16.dp, bottom = 8.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
+        // Session age, not index age: the FMP receiver_idx rotates on every
+        // rekey (~120s) while the session survives, so a long value here means
+        // the link has held rather than that a handshake went stale.
+        ForensicLine("session age", elapsedExact(peer.authenticatedAtMs))
         ForensicLine("role", peer.role.ifEmpty { "—" })
         ForensicLine("discovery", if (peer.discoveryMs > 0) "${peer.discoveryMs}ms" else "—")
         ForensicLine("send drops", peer.sendDrops.toString())

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -247,6 +247,13 @@ private fun RootSettings(
                             ),
                         )
                     }
+                    RadioAction.ENABLE_LOCATION -> runCatching {
+                        context.startActivity(
+                            android.content.Intent(
+                                android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS,
+                            ),
+                        )
+                    }
                 }
             }
         }
@@ -581,8 +588,16 @@ private fun ConfirmDialog(
     )
 }
 
-/** An actionable radio/VPN misconfiguration (see [radioWarnings]): same visual
- *  language as [BleExhaustedCard], but tappable to jump to the fix. */
+/**
+ * An actionable radio/VPN misconfiguration (see [radioWarnings]): same visual
+ * language as [BleExhaustedCard], but tappable to jump to the fix.
+ *
+ * The trailing chevron is what carries that difference. Without it the two
+ * cards are pixel-for-pixel the same object — one that takes you to the fix and
+ * one that cannot be tapped at all — and the only hint that this one is
+ * interactive was a "Tap to…" sentence buried at the end of the detail text.
+ * The same chevron marks every other navigating row on this screen.
+ */
 @Composable
 private fun RadioWarningCard(warning: RadioWarning, onClick: () -> Unit) {
     Column(
@@ -592,7 +607,21 @@ private fun RadioWarningCard(warning: RadioWarning, onClick: () -> Unit) {
                 MaterialTheme.colorScheme.errorContainer,
                 RoundedCornerShape(14.dp),
             )
-            .clickable(onClick = onClick)
+            // Labelled as a button rather than left as an anonymous clickable:
+            // a screen reader otherwise announces the warning text with no
+            // indication that acting on it is possible from here.
+            //
+            // The label names the *action* only. `clickable` merges the
+            // semantics of its descendants, so both the title and the detail
+            // are already announced as this node's description — the title
+            // alone is thin ("Location is off" says nothing about the
+            // consequence), but the detail that follows it carries that, and
+            // repeating either one here would only say it twice.
+            .clickable(
+                onClickLabel = "fix",
+                role = androidx.compose.ui.semantics.Role.Button,
+                onClick = onClick,
+            )
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
@@ -609,6 +638,13 @@ private fun RadioWarningCard(warning: RadioWarning, onClick: () -> Unit) {
                 color = MaterialTheme.colorScheme.onErrorContainer,
                 fontWeight = FontWeight.SemiBold,
                 style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(20.dp),
             )
         }
         Text(

--- a/android/app/src/main/java/app/myco/ui/theme/Theme.kt
+++ b/android/app/src/main/java/app/myco/ui/theme/Theme.kt
@@ -21,6 +21,14 @@ val Indigo = Color(0xFF6366F1)
 val IndigoSoft = Color(0xFFE0E7FF)
 val IndigoInk = Color(0xFF3730A3)
 val StatusConnected = Color(0xFF22C55E)
+
+/// Transport identity colours for the Dev tab's per-peer icon. Bluetooth keeps
+/// its own brand blue because that glyph is universally recognised in it; the
+/// routed lane takes the app's emerald. Wi-Fi Aware deliberately has no colour
+/// here — it renders in `onSurface` so it reads as "the plain radio" against
+/// both themes.
+val TransportBluetooth = Color(0xFF0082FC)
+val TransportNetwork = Color(0xFF059669)
 val StatusReachable = Color(0xFF14B8A6)
 /// One peer: the mesh works but has no redundancy — lose that peer and you are
 /// alone, so it reads as a caution rather than a fault.

--- a/android/app/src/main/res/drawable/ic_transport_bluetooth.xml
+++ b/android/app/src/main/res/drawable/ic_transport_bluetooth.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Bluetooth rune. Tinted at the call site so the colour stays a UI
+     decision, not an asset one. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L11,14.41V22h1l5.71,-5.71l-4.3,-4.29L17.71,7.71zM13,5.83l1.88,1.88L13,9.59V5.83zM14.88,16.29L13,18.17v-3.76L14.88,16.29z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_transport_network.xml
+++ b/android/app/src/main/res/drawable/ic_transport_network.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Globe: the routed lane — LAN, AP, mDNS, anything that reached us over
+     ordinary IP rather than a direct radio link. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM11,19.93c-3.95,-0.49 -7,-3.85 -7,-7.93 0,-0.62 0.08,-1.21 0.21,-1.79L9,15v1c0,1.1 0.9,2 2,2v1.93zM17.9,17.39c-0.26,-0.81 -1,-1.39 -1.9,-1.39h-1v-3c0,-0.55 -0.45,-1 -1,-1H8v-2h2c0.55,0 1,-0.45 1,-1V7h2c1.1,0 2,-0.9 2,-2v-0.41c2.93,1.19 5,4.06 5,7.41 0,2.08 -0.8,3.97 -2.1,5.39z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_transport_wifi_aware.xml
+++ b/android/app/src/main/res/drawable/ic_transport_wifi_aware.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Wi-Fi Aware: the radiating arcs, no base station — this is device to
+     device, not a link to infrastructure. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,9l2,2c4.97,-4.97 13.03,-4.97 18,0l2,-2C16.93,2.93 7.08,2.93 1,9zM9,17l3,3 3,-3c-1.65,-1.66 -4.34,-1.66 -6,0zM5,13l2,2c2.76,-2.76 7.24,-2.76 10,0l2,-2C15.14,9.14 8.87,9.14 5,13z" />
+</vector>

--- a/myco-core/Cargo.toml
+++ b/myco-core/Cargo.toml
@@ -26,12 +26,13 @@ tokio = { workspace = true }
 reqwest = { workspace = true }
 tokio-tungstenite = { workspace = true }
 futures-util = { workspace = true }
+# `dns_intercept` synthesises the AAAA query it sends to the node's built-in
+# `.fips` responder for route warming. Matches fips's pin.
+simple-dns = "0.11.2"
 
 [dev-dependencies]
 nsite-deck = { path = "../nsite-deck", features = ["testing"] }
 tokio-tungstenite = { workspace = true }
-# Only for dns_intercept tests, to craft/parse DNS packets (matches fips's pin).
-simple-dns = "0.11.2"
 
 # The JNI surface only exists on Android. Host (macOS/Linux) builds skip it and
 # drive `AppRuntime` directly (see tests).

--- a/myco-core/examples/identity.rs
+++ b/myco-core/examples/identity.rs
@@ -3,6 +3,6 @@
 
 fn main() {
     let dir = std::env::temp_dir().join("myco-example-identity");
-    let rt = myco_core::AppRuntime::new(dir.to_str().unwrap(), "0.0.1");
+    let mut rt = myco_core::AppRuntime::new(dir.to_str().unwrap(), "0.0.1");
     println!("{}", rt.state_json());
 }

--- a/myco-core/src/attempt_store.rs
+++ b/myco-core/src/attempt_store.rs
@@ -33,7 +33,7 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-use fips::transport::ble::attempts::{BleAttempt, BlePeerAttempts, MAX_ATTEMPTS_PER_PEER};
+use crate::ble_diag::{BleAttempt, BlePeerAttempts, MAX_ATTEMPTS_PER_PEER};
 
 /// File name under the app-private data dir.
 const FILE_NAME: &str = "ble-attempts.jsonl";
@@ -52,7 +52,7 @@ const EVICT_AFTER: Duration = Duration::from_secs(24 * 60 * 60);
 /// changes meaningfully, so this keeps the disk quiet.
 const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
 
-/// One attempt as persisted. Mirrors the fips record shape; carries no
+/// One attempt as persisted. Mirrors [`BleAttempt`]; carries no
 /// peer-supplied free text, only locally generated values (T-03-03).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -72,7 +72,7 @@ pub struct PersistedAttempt {
 }
 
 impl PersistedAttempt {
-    fn from_fips(a: &BleAttempt) -> Self {
+    fn from_live(a: &BleAttempt) -> Self {
         Self {
             at_ms: a.at_ms,
             ble_addr: a.ble_addr.clone(),
@@ -217,7 +217,7 @@ impl AttemptStore {
                 {
                     continue;
                 }
-                ring.push_back(PersistedAttempt::from_fips(attempt));
+                ring.push_back(PersistedAttempt::from_live(attempt));
                 ring.make_contiguous().sort_by_key(|r| r.at_ms);
                 while ring.len() > MAX_ATTEMPTS_PER_PEER {
                     ring.pop_front();
@@ -247,7 +247,7 @@ impl AttemptStore {
                 attempts: inner
                     .by_addr
                     .get(addr)
-                    .map(|ring| ring.iter().map(to_fips).collect())
+                    .map(|ring| ring.iter().map(to_live).collect())
                     .unwrap_or_default(),
             })
             .collect()
@@ -319,11 +319,11 @@ impl AttemptStore {
     }
 }
 
-/// Rebuild the fips-side record from a persisted one. Unknown role/outcome
+/// Rebuild the live record from a persisted one. Unknown role/outcome
 /// labels from a hand-edited or future-version file are carried through as
 /// recorded rather than being coerced into a wrong enum value.
-fn to_fips(rec: &PersistedAttempt) -> BleAttempt {
-    use fips::transport::ble::attempts::{BleAttemptOutcome, BleRole};
+fn to_live(rec: &PersistedAttempt) -> BleAttempt {
+    use crate::ble_diag::{BleAttemptOutcome, BleRole};
     BleAttempt {
         at_ms: rec.at_ms,
         ble_addr: rec.ble_addr.clone(),
@@ -348,7 +348,7 @@ fn to_fips(rec: &PersistedAttempt) -> BleAttempt {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fips::transport::ble::attempts::{BleAttemptOutcome, BleRole};
+    use crate::ble_diag::{BleAttemptOutcome, BleRole};
 
     fn tmp_dir(tag: &str) -> PathBuf {
         let d =

--- a/myco-core/src/aware_bridge_jni.rs
+++ b/myco-core/src/aware_bridge_jni.rs
@@ -2,8 +2,10 @@
 //!
 //! Unlike the BLE bridge, this is *control-plane only*: there is no byte
 //! bridge and no `AndroidRadio` trait to implement. A Wi-Fi Aware data path
-//! terminates in a kernel network interface, so the bytes ride the ordinary
-//! UDP transport (bound at `runtime::WIFI_AWARE_PORT` on the NDP interface).
+//! terminates in a kernel network interface, so the bytes ride an ordinary
+//! UDP transport — the node's `"aware"` instance, bound at
+//! `runtime::AWARE_UDP_PORT` and pinned by `AwareRadio` to the NDP's
+//! `android.net.Network`.
 //! The Kotlin `AwareRadio` runs discovery autonomously and only pushes
 //! "peer reachable" events into Myco's own bounded queue
 //! ([`crate::platform_peers`]), which a tokio task drains onto the node's
@@ -21,10 +23,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use jni::objects::{JClass, JString};
-use jni::sys::{jboolean, jint};
+use jni::sys::{jboolean, jint, jlong};
 use jni::JNIEnv;
-
-const TRANSPORT_TYPE: &str = "udp";
 
 fn jstring(env: &mut JNIEnv, s: &JString) -> Option<String> {
     env.get_string(s).ok().map(Into::into)
@@ -36,10 +36,17 @@ fn jstring(env: &mut JNIEnv, s: &JString) -> Option<String> {
 /// a routing hint.
 ///
 /// `lane` is `"aware"` or `"udp"` — which Kotlin radio (Wi-Fi Aware vs. the
-/// LAN/AP lane) observed this peer. Both ride fips's plain UDP transport, so
-/// `TRANSPORT_TYPE` below is unchanged and still `"udp"` for both; `lane` is
-/// recorded separately, in [`crate::lane_observation`], for `merge_peers()`'s
-/// `lane_by_npub` override and never reaches fips.
+/// LAN/AP lane) observed this peer. Each lane is its own UDP transport
+/// instance with its own socket, pinned to its own `android.net.Network`, so
+/// the address is qualified with that instance's name (`"udp/aware"`,
+/// `"udp/lan"`). fips's `TransportSpec` routes the dial to the matching socket
+/// and, crucially, refuses rather than substituting the other one — dialing an
+/// Aware peer from the Wi-Fi-pinned socket is unroutable and was the reason
+/// Aware never carried a handshake.
+///
+/// `lane` is *also* recorded, separately, in [`crate::lane_observation`], for
+/// `merge_peers()`'s `lane_by_npub` override; that record is Myco-owned and
+/// never reaches fips.
 #[no_mangle]
 pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerFound(
     mut env: JNIEnv,
@@ -56,20 +63,21 @@ pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerFound(
         return;
     };
     crate::lane_observation::set_lane(&npub, &lane);
-    crate::platform_peers::push(&npub, &addr, TRANSPORT_TYPE);
+    let transport = format!("udp/{}", crate::runtime::udp_instance_for_lane(&lane));
+    crate::platform_peers::push(&npub, &addr, &transport);
 }
 
 /// Kotlin observed the Wi-Fi Aware data path to `npub` go away.
 ///
 /// **Nothing is told to the node, deliberately.** This used to call fips's
 /// `platform_peer_lost`, which resolved the peer and asked the named transport
-/// to close its connection — but the name pushed here is always `"udp"` for
-/// both lanes, and the UDP transport does not override `close_connection`; it
-/// falls through to the connectionless no-op default. So the call has never
-/// had any effect, and the premise it was written on ("the node closes the
-/// pooled UDP session so the dead socket is not re-used") was wrong: a
-/// connectionless transport has no pooled socket. Falling back to BLE was
-/// always the node's ordinary liveness machinery doing its job.
+/// to close its connection — but the UDP transport does not override
+/// `close_connection`; it falls through to the connectionless no-op default.
+/// So the call has never had any effect, and the premise it was written on
+/// ("the node closes the pooled UDP session so the dead socket is not
+/// re-used") was wrong: a connectionless transport has no pooled socket.
+/// Falling back to BLE was always the node's ordinary liveness machinery doing
+/// its job.
 ///
 /// The control socket's `disconnect` is not a replacement. It keys on npub
 /// alone, with no transport parameter, and does a full teardown — notify the
@@ -165,20 +173,45 @@ pub extern "system" fn Java_app_myco_core_NativeCore_setUpstreamDns(
     crate::dns_intercept::set_upstream(parsed);
 }
 
-/// Rust → Kotlin: the UDP transport's raw socket fd, once it has opened.
-/// Blocks up to `timeout_ms`; returns `-1` on timeout (no transport, or it
-/// hasn't started yet). The fd is sent once per node lifetime (see
-/// [`crate::udp_fd_bridge`]) — callers poll this once at startup, not in a
-/// loop, then use the fd with `android.net.Network.bindSocket` to pin the
-/// socket to whichever local-only network (Wi-Fi Aware NDP, the `!FIPS` AP)
-/// currently carries the platform-pushed peer, so replies aren't lost to a
-/// competing validated default network (e.g. cellular).
+/// Rust → Kotlin: the raw socket fd of the UDP transport carrying `lane`, once
+/// it has opened and if it is newer than `since_version`. Blocks up to
+/// `timeout_ms`.
+///
+/// `lane` is the caller's own label (`"aware"` or `"udp"`), mapped to a fips
+/// instance name by [`crate::runtime::udp_instance_for_lane`]. The node binds
+/// one socket per lane and fips labels each fd with the instance it belongs to,
+/// so a radio can only ever be handed *its* descriptor — never the other
+/// lane's, which it would then pin to the wrong `android.net.Network` and
+/// black-hole. A lane whose socket did not bind is told nothing instead.
+///
+/// The result packs `(version << 32) | fd`, because JNI has no tuple and two
+/// calls could not be made atomic. `fd` is `-1` when nothing newer arrived; the
+/// caller passes the returned version back on the next call, and 0 on the
+/// first. Versioning rather than plain edge-triggering because a radio is
+/// created and destroyed with its lane's toggle while the node keeps running,
+/// so it must be able to learn a socket announced before it existed — and
+/// because a node restart's replacement socket can reuse the same fd number,
+/// which still needs re-binding.
+///
+/// What the caller does with the fd: `android.net.Network.bindSocket`, pinning
+/// it to the local-only network carrying that lane's peers (a Wi-Fi Aware NDP,
+/// the `!FIPS` AP). Without it, replies are lost to a competing validated
+/// default network (e.g. cellular).
 #[no_mangle]
 pub extern "system" fn Java_app_myco_core_NativeCore_nextUdpTransportFd(
-    _env: JNIEnv,
+    mut env: JNIEnv,
     _class: JClass,
+    lane: JString,
+    since_version: jlong,
     timeout_ms: jint,
-) -> jint {
-    crate::udp_fd_bridge::next_fd(std::time::Duration::from_millis(timeout_ms.max(0) as u64))
-        as jint
+) -> jlong {
+    let Some(lane) = jstring(&mut env, &lane) else {
+        return -1i32 as u32 as jlong;
+    };
+    let (version, fd) = crate::udp_fd_bridge::next_fd(
+        crate::runtime::udp_instance_for_lane(&lane),
+        since_version.max(0) as u64,
+        std::time::Duration::from_millis(timeout_ms.max(0) as u64),
+    );
+    ((version << 32) | (fd as u32 as u64)) as jlong
 }

--- a/myco-core/src/aware_bridge_jni.rs
+++ b/myco-core/src/aware_bridge_jni.rs
@@ -5,8 +5,10 @@
 //! terminates in a kernel network interface, so the bytes ride the ordinary
 //! UDP transport (bound at `runtime::WIFI_AWARE_PORT` on the NDP interface).
 //! The Kotlin `AwareRadio` runs discovery autonomously and only pushes
-//! "peer reachable / lost" events into fips's process-global platform peer
-//! queue (`fips::discovery::platform`), which the node drains each tick.
+//! "peer reachable" events into Myco's own bounded queue
+//! ([`crate::platform_peers`]), which a tokio task drains onto the node's
+//! control socket. The push itself never touches the socket: it arrives on the
+//! radio's single `HandlerThread`, which must not be held.
 //!
 //! Kotlin passes the peer's link-local address already formatted with a
 //! *numeric* scope (`"[fe80::x%3]:4871"`, ifindex resolved from
@@ -14,7 +16,7 @@
 //! docs/design/wifi-aware-interop.md § "Dialing a link-local peer").
 //!
 //! Compiled only on Android; the host build exercises the same seam directly
-//! through `fips::discovery::platform`.
+//! through [`crate::platform_peers`].
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -54,17 +56,32 @@ pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerFound(
         return;
     };
     crate::lane_observation::set_lane(&npub, &lane);
-    fips::discovery::platform::platform_peer_available(&npub, &addr, TRANSPORT_TYPE);
+    crate::platform_peers::push(&npub, &addr, TRANSPORT_TYPE);
 }
 
-/// Kotlin observed the Wi-Fi Aware data path to `npub` go away. The node
-/// closes the pooled UDP session so the dead socket is not re-used;
-/// reconnection (e.g. falling back to BLE) is the node's ordinary job.
+/// Kotlin observed the Wi-Fi Aware data path to `npub` go away.
 ///
-/// `lane` names which radio observed the loss; [`crate::lane_observation`]
-/// clears the recorded lane for `npub` only if it still matches `lane`, so a
-/// stale loss from one lane cannot erase a fresher record pushed by the
-/// other.
+/// **Nothing is told to the node, deliberately.** This used to call fips's
+/// `platform_peer_lost`, which resolved the peer and asked the named transport
+/// to close its connection — but the name pushed here is always `"udp"` for
+/// both lanes, and the UDP transport does not override `close_connection`; it
+/// falls through to the connectionless no-op default. So the call has never
+/// had any effect, and the premise it was written on ("the node closes the
+/// pooled UDP session so the dead socket is not re-used") was wrong: a
+/// connectionless transport has no pooled socket. Falling back to BLE was
+/// always the node's ordinary liveness machinery doing its job.
+///
+/// The control socket's `disconnect` is not a replacement. It keys on npub
+/// alone, with no transport parameter, and does a full teardown — notify the
+/// peer, drop every session, index and link, and suppress auto-reconnect. Aware
+/// data paths are fragile and `onLost` fires often, so wiring it here would let
+/// a routine NDP drop tear down a live BLE session to the same peer. That is a
+/// direct hit on the one thing the product has to do.
+///
+/// What remains is the Myco-owned Dev-tab label: `lane` names which radio
+/// observed the loss, and [`crate::lane_observation`] clears the recorded lane
+/// for `npub` only if it still matches, so a stale loss from one lane cannot
+/// erase a fresher record pushed by the other.
 #[no_mangle]
 pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerLost(
     mut env: JNIEnv,
@@ -76,7 +93,6 @@ pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerLost(
         return;
     };
     crate::lane_observation::clear_lane(&npub, &lane);
-    fips::discovery::platform::platform_peer_lost(&npub, TRANSPORT_TYPE);
 }
 
 // ============================================================================

--- a/myco-core/src/ble_bridge_jni.rs
+++ b/myco-core/src/ble_bridge_jni.rs
@@ -13,6 +13,7 @@
 //! Compiled only on Android (the host build drives `AppRuntime` directly and the
 //! fips bridge logic is unit-tested with a mock radio in fips itself).
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -371,38 +372,69 @@ fn rssi_from_jint(rssi: jint) -> Option<i16> {
     }
 }
 
+/// Whether Kotlin has ever pushed a scanning state — until it has, the value is
+/// unknown, never a guessed false.
+static BLE_SCANNING_KNOWN: AtomicBool = AtomicBool::new(false);
+/// The last-pushed scanning value, meaningful only once `BLE_SCANNING_KNOWN`.
+static BLE_SCANNING: AtomicBool = AtomicBool::new(false);
+/// Whether Kotlin has ever pushed an advertising state.
+static BLE_ADVERTISING_KNOWN: AtomicBool = AtomicBool::new(false);
+/// The last-pushed advertising value, meaningful only once
+/// `BLE_ADVERTISING_KNOWN`.
+static BLE_ADVERTISING: AtomicBool = AtomicBool::new(false);
+
+/// The last-observed scanning state, or `None` if Kotlin has never pushed one
+/// (radio never started, or a non-Android build) — the caller must render
+/// unknown rather than guessing false.
+pub(crate) fn ble_scanning() -> Option<bool> {
+    if BLE_SCANNING_KNOWN.load(Ordering::Relaxed) {
+        Some(BLE_SCANNING.load(Ordering::Relaxed))
+    } else {
+        None
+    }
+}
+
+/// The last-observed advertising state, or `None` if Kotlin has never pushed
+/// one.
+pub(crate) fn ble_advertising() -> Option<bool> {
+    if BLE_ADVERTISING_KNOWN.load(Ordering::Relaxed) {
+        Some(BLE_ADVERTISING.load(Ordering::Relaxed))
+    } else {
+        None
+    }
+}
+
 /// Kotlin reports whether its BLE scan loop is live right now, pushed from the
 /// scan callback's own start/stop/retry-failure sites.
 ///
-/// TODO(stage 2): currently discarded. The restacked `AndroidBleBridge` has no
-/// `set_scanning`/`is_scanning` — and it should not: this was only ever Myco
-/// reading back a flag Kotlin had pushed into a struct that happened to live in
-/// fips. The Aware lane already keeps the equivalent in two Myco-owned
-/// `AtomicBool`s (`aware_bridge_jni::set_aware_discovering`); mirror that here
-/// so `AppState.ble.scanning` reports observed state again instead of
-/// "unknown". Diagnostic only — nothing functional reads it. The export is kept
-/// so the Kotlin call site does not have to change twice.
+/// Kept in a Myco-owned atomic rather than read back off fips's
+/// `AndroidBleBridge`, which is where it used to live: the flag was only ever
+/// Kotlin's own push bouncing off a struct in the wrong crate. Same shape as
+/// the Aware lane's `set_aware_discovering`. Diagnostic only — nothing
+/// functional reads it.
 #[no_mangle]
 pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverScanningState(
     _env: JNIEnv,
     _class: JClass,
     _handle: jlong,
-    _on: jboolean,
+    on: jboolean,
 ) {
+    BLE_SCANNING.store(on != 0, Ordering::Relaxed);
+    BLE_SCANNING_KNOWN.store(true, Ordering::Relaxed);
 }
 
 /// Kotlin reports whether its BLE advertiser is live right now, pushed from the
-/// advertise callback's own install/clear sites.
-///
-/// TODO(stage 2): currently discarded, for the same reason and with the same
-/// fix as [`Java_app_myco_core_NativeCore_bleDeliverScanningState`].
+/// advertise callback's own install/clear sites. Same ownership rationale as
+/// [`Java_app_myco_core_NativeCore_bleDeliverScanningState`].
 #[no_mangle]
 pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverAdvertisingState(
     _env: JNIEnv,
     _class: JClass,
     _handle: jlong,
-    _on: jboolean,
+    on: jboolean,
 ) {
+    BLE_ADVERTISING.store(on != 0, Ordering::Relaxed);
+    BLE_ADVERTISING_KNOWN.store(true, Ordering::Relaxed);
 }
 
 /// Kotlin read one L2CAP packet. Returns 1 if delivered, 0 if the channel is gone.

--- a/myco-core/src/ble_bridge_jni.rs
+++ b/myco-core/src/ble_bridge_jni.rs
@@ -22,7 +22,7 @@ use jni::sys::{jboolean, jint, jlong};
 use jni::{JNIEnv, JavaVM};
 
 use fips::transport::ble::addr::BleAddr;
-use fips::transport::ble::android_io::{set_android_ble_bridge, AndroidBleBridge, AndroidRadio};
+use fips::transport::ble::android_io::{AndroidBleBridge, AndroidRadio, BleRadioSlot};
 
 /// Process-wide JavaVM, captured in `initializeAndroidContext`. Needed to attach
 /// tokio worker threads to the JVM before issuing control upcalls.
@@ -121,6 +121,70 @@ impl AndroidRadio for KotlinRadio {
 }
 
 // ============================================================================
+// Radio installation — matching two independent lifecycles
+// ============================================================================
+
+/// The node's radio slot, once a node has been built, and the bridge Kotlin
+/// last created. Either can arrive first, so both are kept and re-married
+/// whenever one of them changes.
+///
+/// The slot used to be a fips process-global (`set_android_ble_bridge`); it is
+/// node-scoped now, handed out by `Node::enable_app_owned_ble_radio`. That is a
+/// better shape but it does not, on its own, span the two lifecycles Myco has
+/// to reconcile:
+///
+/// - The **node** is rebuilt on a BLE off→on cycle, because `run_rx_loop`
+///   consumes it. Each rebuild yields a fresh slot, which must be re-populated
+///   with the radio that is already running.
+/// - The **radio** belongs to `BleService`, which deliberately does *not*
+///   bounce the node when it starts a fresh one (bouncing tore down every peer
+///   and session). `bleBridgeNew` also runs on the Android service thread,
+///   before `StartNode` — so a bridge routinely exists before any slot does.
+///
+/// Keeping both here, in a static rather than on `AppRuntime`, is the same
+/// pattern the TUN and UDP-fd bridges use: the JNI exports have no
+/// `AppRuntime` handle, and a JVM thread must never take the reducer lock.
+struct Installation {
+    slot: Option<Arc<BleRadioSlot>>,
+    bridge: Option<Arc<AndroidBleBridge>>,
+}
+
+static INSTALLATION: OnceLock<std::sync::Mutex<Installation>> = OnceLock::new();
+
+fn installation() -> &'static std::sync::Mutex<Installation> {
+    INSTALLATION.get_or_init(|| {
+        std::sync::Mutex::new(Installation {
+            slot: None,
+            bridge: None,
+        })
+    })
+}
+
+/// Hand this node's radio slot over, replacing any prior node's.
+///
+/// Called from `AppRuntime::start_node` while it still holds `&mut Node`. If
+/// Kotlin already created a radio, it is installed into the new slot
+/// immediately — the whole point of the slot being resolvable per operation is
+/// that this can happen under a node that is already running.
+pub(crate) fn set_radio_slot(slot: Arc<BleRadioSlot>) {
+    let mut install = installation().lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(bridge) = install.bridge.as_ref() {
+        slot.install(Arc::clone(bridge));
+    }
+    install.slot = Some(slot);
+}
+
+/// Record the radio Kotlin just built and install it into the current slot, if
+/// there is one. Replaces any prior radio.
+fn set_radio_bridge(bridge: Arc<AndroidBleBridge>) {
+    let mut install = installation().lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(slot) = install.slot.as_ref() {
+        slot.install(Arc::clone(&bridge));
+    }
+    install.bridge = Some(bridge);
+}
+
+// ============================================================================
 // Bridge handle + helpers
 // ============================================================================
 
@@ -142,9 +206,11 @@ fn jstring_to_addr(env: &mut JNIEnv, s: &JString) -> Option<BleAddr> {
 // JNI exports (called by the Kotlin BleRadio / BleService)
 // ============================================================================
 
-/// Create the bridge over a Kotlin `BleRadio`, inject it into fips so the node's
-/// BLE transport picks it up at start, and return an opaque handle. Must be
-/// called before dispatching StartNode.
+/// Create the bridge over a Kotlin `BleRadio`, install it into the node's radio
+/// slot (or hold it until a node hands one over), and return an opaque handle.
+///
+/// No longer has to precede `StartNode`: the transport resolves the slot per
+/// operation, so a radio that appears later is picked up without a rebuild.
 #[no_mangle]
 pub extern "system" fn Java_app_myco_core_NativeCore_bleBridgeNew(
     env: JNIEnv,
@@ -157,9 +223,9 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleBridgeNew(
         Err(_) => return 0,
     };
     let bridge = AndroidBleBridge::new(Arc::new(KotlinRadio { radio: global }));
-    // Inject (replacing any prior bridge) so the node — fresh or rebuilt after a
-    // BLE off/on cycle — picks up this radio.
-    set_android_ble_bridge(Arc::clone(&bridge));
+    // Install (replacing any prior radio) so the node — fresh, rebuilt after a
+    // BLE off/on cycle, or not yet built — ends up driving this one.
+    set_radio_bridge(Arc::clone(&bridge));
     Box::into_raw(Box::new(bridge)) as jlong
 }
 
@@ -170,8 +236,9 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleBridgeFree(
     handle: jlong,
 ) {
     if handle != 0 {
-        // SAFETY: reclaims the Box from bleBridgeNew. The fips global keeps its
-        // own Arc clone, so the bridge itself lives as long as the node does.
+        // SAFETY: reclaims the Box from bleBridgeNew. The radio slot and the
+        // installation record keep their own Arc clones, so the bridge itself
+        // outlives this handle.
         unsafe { drop(Box::from_raw(handle as *mut Arc<AndroidBleBridge>)) };
     }
 }
@@ -237,38 +304,54 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverScan(
         return;
     };
     if let Some(ble_addr) = jstring_to_addr(&mut env, &addr) {
-        bridge.deliver_scan(ble_addr, psm.max(0) as u16, rssi);
+        bridge.deliver_scan(ble_addr, psm.max(0) as u16, rssi_from_jint(rssi));
+    }
+}
+
+/// Android's `ScanResult.rssi` in dBm, as an optional signal strength.
+///
+/// `127` is the platform's "RSSI unknown" sentinel and is not a real reading,
+/// so it maps to `None` rather than to an implausibly strong signal. Anything
+/// outside `i16` cannot come from the radio and is treated the same way.
+fn rssi_from_jint(rssi: jint) -> Option<i16> {
+    match rssi {
+        127 => None,
+        v => i16::try_from(v).ok(),
     }
 }
 
 /// Kotlin reports whether its BLE scan loop is live right now, pushed from the
-/// scan callback's own start/stop/retry-failure sites. Observed radio state for
-/// the developer diagnostics UI only — a zero or stale handle is a no-op.
+/// scan callback's own start/stop/retry-failure sites.
+///
+/// TODO(stage 2): currently discarded. The restacked `AndroidBleBridge` has no
+/// `set_scanning`/`is_scanning` — and it should not: this was only ever Myco
+/// reading back a flag Kotlin had pushed into a struct that happened to live in
+/// fips. The Aware lane already keeps the equivalent in two Myco-owned
+/// `AtomicBool`s (`aware_bridge_jni::set_aware_discovering`); mirror that here
+/// so `AppState.ble.scanning` reports observed state again instead of
+/// "unknown". Diagnostic only — nothing functional reads it. The export is kept
+/// so the Kotlin call site does not have to change twice.
 #[no_mangle]
 pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverScanningState(
     _env: JNIEnv,
     _class: JClass,
-    handle: jlong,
-    on: jboolean,
+    _handle: jlong,
+    _on: jboolean,
 ) {
-    if let Some(bridge) = unsafe { bridge_ref(handle) } {
-        bridge.set_scanning(on != 0);
-    }
 }
 
 /// Kotlin reports whether its BLE advertiser is live right now, pushed from the
-/// advertise callback's own install/clear sites. Observed radio state for the
-/// developer diagnostics UI only — a zero or stale handle is a no-op.
+/// advertise callback's own install/clear sites.
+///
+/// TODO(stage 2): currently discarded, for the same reason and with the same
+/// fix as [`Java_app_myco_core_NativeCore_bleDeliverScanningState`].
 #[no_mangle]
 pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverAdvertisingState(
     _env: JNIEnv,
     _class: JClass,
-    handle: jlong,
-    on: jboolean,
+    _handle: jlong,
+    _on: jboolean,
 ) {
-    if let Some(bridge) = unsafe { bridge_ref(handle) } {
-        bridge.set_advertising(on != 0);
-    }
 }
 
 /// Kotlin read one L2CAP packet. Returns 1 if delivered, 0 if the channel is gone.

--- a/myco-core/src/ble_bridge_jni.rs
+++ b/myco-core/src/ble_bridge_jni.rs
@@ -184,6 +184,36 @@ fn set_radio_bridge(bridge: Arc<AndroidBleBridge>) {
     install.bridge = Some(bridge);
 }
 
+/// Retract a radio Kotlin has shut down, clearing it out of the node's slot.
+///
+/// Without this the installation kept holding a dead radio, and the next
+/// [`set_radio_slot`] — which a mesh toggle reaches, because rebuilding the
+/// node yields a fresh slot — installed that dead radio into the new slot.
+/// The transport's `listen` and `start_advertising` then ran against closed
+/// sockets until Kotlin's next `bleBridgeNew` replaced it, about a second
+/// later. Benign in that window, but it is the same shape as the stale-PSM
+/// bug: state that outlives the thing it describes. An empty slot parks the
+/// backend until a live radio arrives, which is the correct degradation.
+///
+/// Retracts only the radio it was handed. `bleBridgeNew` may already have
+/// installed a newer one — a stop racing a start must not take that one down.
+fn clear_radio_bridge(bridge: &Arc<AndroidBleBridge>) {
+    let mut install = installation().lock().unwrap_or_else(|e| e.into_inner());
+    if !install
+        .bridge
+        .as_ref()
+        .is_some_and(|held| Arc::ptr_eq(held, bridge))
+    {
+        return;
+    }
+    install.bridge = None;
+    if let Some(slot) = install.slot.as_ref() {
+        if slot.current().is_some_and(|c| Arc::ptr_eq(&c, bridge)) {
+            slot.clear();
+        }
+    }
+}
+
 // ============================================================================
 // Bridge handle + helpers
 // ============================================================================
@@ -227,6 +257,27 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleBridgeNew(
     // BLE off/on cycle, or not yet built — ends up driving this one.
     set_radio_bridge(Arc::clone(&bridge));
     Box::into_raw(Box::new(bridge)) as jlong
+}
+
+/// Retract the radio behind `handle` from the node's slot.
+///
+/// Called by `BleService.stopBle` after it shuts the radio down. Does *not*
+/// free the handle — the radio's I/O threads may still be winding down through
+/// it — it only stops the core from driving a radio that is gone.
+#[no_mangle]
+pub extern "system" fn Java_app_myco_core_NativeCore_bleBridgeClear(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+) {
+    if handle == 0 {
+        return;
+    }
+    // SAFETY: borrows, without reclaiming, the Box that `bleBridgeNew`
+    // leaked. Kotlin holds the handle for the life of its radio and passes it
+    // back exactly once, before any `bleBridgeFree`.
+    let bridge = unsafe { &*(handle as *const Arc<AndroidBleBridge>) };
+    clear_radio_bridge(bridge);
 }
 
 #[no_mangle]

--- a/myco-core/src/ble_diag.rs
+++ b/myco-core/src/ble_diag.rs
@@ -1,0 +1,138 @@
+//! Myco's own vocabulary for BLE connect-attempt diagnostics.
+//!
+//! These types used to be fips's (`fips::transport::ble::attempts`), read out
+//! of a process-global log in the transport. That log is gone: the restacked
+//! fips counts connect outcomes into `BleStats` instead, queryable over the
+//! control socket's `show_transports`.
+//!
+//! Myco already *owned* the accumulation — [`crate::attempt_store`] merges,
+//! deduplicates, persists and evicts on its own retention policy, and only
+//! round-tripped through fips types because it was retrofitted onto a
+//! fips-owned ring. Owning the record type removes that round trip and lets
+//! the store and the Dev-tab merge keep their shape while the producer is
+//! rewired.
+//!
+//! # TODO(stage 2): nothing produces these yet
+//!
+//! `AppRuntime::ble_attempts()` returns an empty slice, so every consumer here
+//! renders "no recorded history". Stage 2 fills them from `BleStats` counters
+//! read over `show_transports`. Note the shape mismatch to resolve then: these
+//! are *per-attempt* records keyed by BLE address, and `BleStats` is
+//! *aggregate* counters per transport — the Dev tab's per-peer attempt rows
+//! cannot be reconstructed from counters alone, so stage 2 either reshapes the
+//! rows or asks fips for something per-peer.
+
+/// Maximum attempts retained per peer address, oldest dropped first. Myco's
+/// own retention policy now; it happens to match the ring fips used to keep.
+pub const MAX_ATTEMPTS_PER_PEER: usize = 20;
+
+/// Which side of the L2CAP connection this node took for an attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BleRole {
+    /// This node dialled the peer (outbound probe).
+    Central,
+    /// This node accepted the peer's connection (inbound).
+    Peripheral,
+}
+
+impl BleRole {
+    /// Stable lowercase wire label, as persisted and as sent across the FFI.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BleRole::Central => "central",
+            BleRole::Peripheral => "peripheral",
+        }
+    }
+}
+
+/// How one discovery-to-resolution cycle ended. Exactly one value per attempt,
+/// so one cycle is one record rather than several fragments.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BleAttemptOutcome {
+    /// The connection was promoted into the pool and is carrying traffic.
+    Connected,
+    /// The L2CAP connect exceeded the configured connect timeout.
+    ConnectTimeout,
+    /// The L2CAP connect returned an error.
+    ConnectError,
+    /// The connection opened but the pubkey exchange did not complete.
+    PubkeyExchangeFailed,
+    /// The cross-probe tiebreaker resolved in the peer's favour, so this side
+    /// dropped its connection and deferred to the peer's.
+    LostTiebreaker,
+    /// The connection was usable but the pool had no room for it.
+    PoolRejected,
+    /// The peer was already connected under a different link address, so this
+    /// duplicate was dropped — a peer rotating resolvable private addresses
+    /// being absorbed rather than filling the pool.
+    DuplicateNode,
+}
+
+impl BleAttemptOutcome {
+    /// Stable kebab-case wire label, as persisted and as sent across the FFI.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BleAttemptOutcome::Connected => "connected",
+            BleAttemptOutcome::ConnectTimeout => "connect-timeout",
+            BleAttemptOutcome::ConnectError => "connect-error",
+            BleAttemptOutcome::PubkeyExchangeFailed => "pubkey-exchange-failed",
+            BleAttemptOutcome::LostTiebreaker => "lost-tiebreaker",
+            BleAttemptOutcome::PoolRejected => "pool-rejected",
+            BleAttemptOutcome::DuplicateNode => "duplicate-node",
+        }
+    }
+}
+
+/// One resolved connect attempt against one peer.
+#[derive(Clone, Debug)]
+pub struct BleAttempt {
+    /// Wall-clock milliseconds since the Unix epoch at which the attempt
+    /// resolved. Wall clock rather than monotonic because these are persisted
+    /// and must compare across process lifetimes.
+    pub at_ms: u64,
+    /// The peer's BLE address.
+    pub ble_addr: String,
+    /// The peer's node address in hex, when the attempt got far enough to learn
+    /// one; empty otherwise. Never guessed.
+    pub node_addr_hex: String,
+    /// Which role this node took.
+    pub role: BleRole,
+    /// Milliseconds between the address being discovered and this resolution;
+    /// `0` when no discovery stamp was recorded.
+    pub discovery_ms: u64,
+    /// How the attempt ended.
+    pub outcome: BleAttemptOutcome,
+}
+
+/// Everything recorded about one peer address.
+#[derive(Clone, Debug)]
+pub struct BlePeerAttempts {
+    /// The peer's BLE address.
+    pub ble_addr: String,
+    /// The node address hex learned for this peer, or empty if no attempt has
+    /// carried one yet.
+    pub node_addr_hex: String,
+    /// Count of sends to this peer that failed at the link.
+    pub send_failures: u64,
+    /// Attempts oldest-first, capped at [`MAX_ATTEMPTS_PER_PEER`].
+    pub attempts: Vec<BleAttempt>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The labels cross the FFI into the Kotlin Dev tab and are written into
+    /// the persisted JSONL, so they are a compatibility surface, not cosmetics.
+    #[test]
+    fn wire_labels_are_stable() {
+        assert_eq!(BleRole::Central.as_str(), "central");
+        assert_eq!(BleRole::Peripheral.as_str(), "peripheral");
+        assert_eq!(BleAttemptOutcome::Connected.as_str(), "connected");
+        assert_eq!(
+            BleAttemptOutcome::PubkeyExchangeFailed.as_str(),
+            "pubkey-exchange-failed"
+        );
+        assert_eq!(BleAttemptOutcome::DuplicateNode.as_str(), "duplicate-node");
+    }
+}

--- a/myco-core/src/control_client.rs
+++ b/myco-core/src/control_client.rs
@@ -91,10 +91,6 @@ impl ControlClient {
         }
     }
 
-    pub fn path(&self) -> &str {
-        &self.socket_path
-    }
-
     /// Issue one command and return its `data` object.
     ///
     /// Every failure mode — the socket not existing (the bind failed, or the
@@ -132,13 +128,10 @@ impl ControlClient {
             .map_err(|e| format!("shutdown: {e}"))?;
 
         let mut response = String::new();
-        timeout(
-            IO_TIMEOUT,
-            BufReader::new(reader).read_line(&mut response),
-        )
-        .await
-        .map_err(|_| "read timed out".to_string())?
-        .map_err(|e| format!("read: {e}"))?;
+        timeout(IO_TIMEOUT, BufReader::new(reader).read_line(&mut response))
+            .await
+            .map_err(|_| "read timed out".to_string())?
+            .map_err(|e| format!("read: {e}"))?;
         if response.is_empty() {
             return Err("server closed the connection without a response".to_string());
         }
@@ -213,7 +206,11 @@ fn peer_from_json(peer: &Value) -> PeerView {
     PeerView {
         node_addr_hex: s("node_addr"),
         npub: s("npub"),
-        connected: is_connected(peer.get("connectivity").and_then(Value::as_str).unwrap_or("")),
+        connected: is_connected(
+            peer.get("connectivity")
+                .and_then(Value::as_str)
+                .unwrap_or(""),
+        ),
         last_seen_ms: peer
             .get("last_seen_ms")
             .and_then(Value::as_u64)
@@ -236,7 +233,10 @@ mod tests {
         assert!(is_connected("stale"));
         assert!(!is_connected("reconnecting"));
         assert!(!is_connected("disconnected"));
-        assert!(!is_connected(""), "an absent key must not read as connected");
+        assert!(
+            !is_connected(""),
+            "an absent key must not read as connected"
+        );
     }
 
     /// Field mapping against a row observed verbatim on device (probe

--- a/myco-core/src/control_client.rs
+++ b/myco-core/src/control_client.rs
@@ -1,0 +1,372 @@
+//! Client for the fips node's Unix-domain control socket.
+//!
+//! The node no longer exposes an in-process read handle or a Rust API for
+//! pushing platform-discovered peers; both are control-socket commands now
+//! (`show_peers`, `connect`). This module is Myco's only way to talk to a node
+//! that `run_rx_loop` has borrowed for its whole life.
+//!
+//! The wire format is fips's own (`docs/reference/control-socket.md`):
+//! newline-delimited JSON, one request line per connection, the write half shut
+//! down so the server stops waiting for more, one response line back, envelope
+//! `{"status":"ok","data":…}` / `{"status":"error","message":…}`. The reference
+//! client lives in fips's `src/bin/`, not its library, so it cannot be imported.
+//!
+//! **Never call this from the FFI thread.** A connect + write + read with a 5s
+//! timeout is not a substitute for the lock-free `peer_views()` read it
+//! replaces; `AppRuntime::state()` reads a cached snapshot the 8s tick writes.
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::time::timeout;
+
+/// File name of the control socket inside the app-private data dir.
+///
+/// The default fips path resolves `/run/fips` → `$XDG_RUNTIME_DIR` → `/tmp`,
+/// none of which an Android app UID can write, so Myco always sets this
+/// explicitly. `/data/user/0/app.myco/files/fips-control.sock` is 45 of the
+/// 108 `sun_path` bytes bionic allows — verified on device.
+pub const SOCKET_FILE_NAME: &str = "fips-control.sock";
+
+/// Where the control socket lives for a given app data dir.
+pub fn socket_path(data_dir: &str) -> String {
+    format!("{}/{}", data_dir.trim_end_matches('/'), SOCKET_FILE_NAME)
+}
+
+/// Matches the 5s both fips's server and its reference client use.
+const IO_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One peer, as Myco needs it — the fields it consumes out of a `show_peers`
+/// row, not the whole row (which carries MMP link quality, tree position, noise
+/// counters and more).
+///
+/// Named after the `fips::control::read_handle::PeerView` it replaces so the
+/// merge in [`crate::peer_diagnostics`] keeps its shape, but Myco-owned now.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PeerView {
+    /// The peer's `node_addr`, hex-encoded (`node_addr` on the wire — the value
+    /// is hex, the key is not).
+    pub node_addr_hex: String,
+    /// The peer's npub. `show_peers` returns authenticated peers only, so this
+    /// is always a real npub rather than an address stand-in.
+    pub npub: String,
+    /// Whether Myco should treat this peer as usable right now — see
+    /// [`is_connected`].
+    pub connected: bool,
+    /// Milliseconds since the epoch this peer was last heard from.
+    pub last_seen_ms: u64,
+    /// Transport type carrying the peer's link (`"ble"`, `"udp"`, …).
+    pub transport: String,
+    /// fips's render-ready name. **This is an abbreviated npub**
+    /// (`"npub1qrjr...msuc"`), not a profile name — observed on device.
+    pub display_name: String,
+}
+
+/// Myco's notion of "connected", derived from fips's `connectivity` string.
+///
+/// `connectivity` is `ConnectivityState`'s `Display` — a closed set of exactly
+/// four values (`connected`, `stale`, `reconnecting`, `disconnected`) — and
+/// fips has three disagreeing predicates over it. This one is `can_send()`:
+/// `connected` **or** `stale`. A stale peer is still routable, so matching only
+/// the literal `"connected"` would silently drop usable peers out of the
+/// content sync tick and leave their relay dial backoff un-reset.
+pub fn is_connected(connectivity: &str) -> bool {
+    matches!(connectivity, "connected" | "stale")
+}
+
+/// A client for one control socket path.
+///
+/// Stateless and cheap to clone: fips's server reads exactly one request per
+/// connection, so there is no session to keep and each call dials afresh.
+#[derive(Clone, Debug)]
+pub struct ControlClient {
+    socket_path: String,
+}
+
+impl ControlClient {
+    pub fn new(socket_path: impl Into<String>) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+        }
+    }
+
+    pub fn path(&self) -> &str {
+        &self.socket_path
+    }
+
+    /// Issue one command and return its `data` object.
+    ///
+    /// Every failure mode — the socket not existing (the bind failed, or the
+    /// node has not started), a timeout, an `{"status":"error"}` envelope — is
+    /// an `Err` with a human-readable reason, because Myco has to be able to
+    /// tell "no peers" from "no peer feed" (fips's bind failure is non-fatal
+    /// and warns only, so an unbound socket is otherwise invisible).
+    pub async fn request(&self, command: &str, params: Option<Value>) -> Result<Value, String> {
+        let mut req = json!({ "command": command });
+        if let Some(params) = params {
+            req["params"] = params;
+        }
+        let mut line = req.to_string();
+        line.push('\n');
+
+        let stream = timeout(
+            IO_TIMEOUT,
+            tokio::net::UnixStream::connect(&self.socket_path),
+        )
+        .await
+        .map_err(|_| "connect timed out".to_string())?
+        .map_err(|e| format!("connect {}: {e}", self.socket_path))?;
+
+        let (reader, mut writer) = tokio::io::split(stream);
+
+        timeout(IO_TIMEOUT, writer.write_all(line.as_bytes()))
+            .await
+            .map_err(|_| "write timed out".to_string())?
+            .map_err(|e| format!("write: {e}"))?;
+        // The server reads exactly one line and would otherwise keep waiting on
+        // a half-open stream.
+        writer
+            .shutdown()
+            .await
+            .map_err(|e| format!("shutdown: {e}"))?;
+
+        let mut response = String::new();
+        timeout(
+            IO_TIMEOUT,
+            BufReader::new(reader).read_line(&mut response),
+        )
+        .await
+        .map_err(|_| "read timed out".to_string())?
+        .map_err(|e| format!("read: {e}"))?;
+        if response.is_empty() {
+            return Err("server closed the connection without a response".to_string());
+        }
+
+        let value: Value =
+            serde_json::from_str(response.trim()).map_err(|e| format!("bad response JSON: {e}"))?;
+        match value.get("status").and_then(Value::as_str) {
+            Some("ok") => Ok(value.get("data").cloned().unwrap_or(Value::Null)),
+            Some("error") => Err(value
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unspecified error")
+                .to_string()),
+            other => Err(format!("unexpected status: {other:?}")),
+        }
+    }
+
+    /// The node's currently authenticated peers.
+    ///
+    /// Note the semantic delta from the read handle this replaces: a peer that
+    /// was seen and is now gone **disappears from the list** rather than
+    /// appearing with `connected: false`.
+    pub async fn show_peers(&self) -> Result<Vec<PeerView>, String> {
+        let data = self.request("show_peers", None).await?;
+        let peers = data
+            .get("peers")
+            .and_then(Value::as_array)
+            .ok_or_else(|| "show_peers response has no peers array".to_string())?;
+        Ok(peers.iter().map(peer_from_json).collect())
+    }
+
+    /// Tell the node a platform-discovered peer is reachable.
+    ///
+    /// `address` is a fully-formatted socket address (Wi-Fi Aware link-locals
+    /// carry a numeric scope, `"[fe80::x%3]:4871"`). The npub is only a routing
+    /// hint — Noise IK is what authenticates — but fips pre-seeds its identity
+    /// cache from it, which warms the route for free.
+    ///
+    /// This is a *mutation*, so it takes the rx-loop path rather than being
+    /// served off a snapshot: it is serialised behind whatever the packet loop
+    /// is doing. Call it only from the drain task in
+    /// [`crate::platform_peers`], never from a radio callback thread.
+    pub async fn connect_peer(
+        &self,
+        npub: &str,
+        address: &str,
+        transport: &str,
+    ) -> Result<(), String> {
+        self.request(
+            "connect",
+            Some(json!({
+                "npub": npub,
+                "address": address,
+                "transport": transport,
+            })),
+        )
+        .await
+        .map(|_| ())
+    }
+}
+
+/// Map one `show_peers` row onto [`PeerView`]. Every field is optional on the
+/// wire (`transport_addr`/`transport_type` are conditional keys), so a missing
+/// one degrades to empty rather than dropping the peer.
+fn peer_from_json(peer: &Value) -> PeerView {
+    let s = |key: &str| {
+        peer.get(key)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+    PeerView {
+        node_addr_hex: s("node_addr"),
+        npub: s("npub"),
+        connected: is_connected(peer.get("connectivity").and_then(Value::as_str).unwrap_or("")),
+        last_seen_ms: peer
+            .get("last_seen_ms")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        transport: s("transport_type"),
+        display_name: s("display_name"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The four `connectivity` values, against `can_send()` semantics. A peer
+    /// that is `stale` is still routable; dropping it here is what would leave
+    /// a returning Circle member waiting out a 180s dial backoff.
+    #[test]
+    fn connectivity_maps_with_can_send_semantics() {
+        assert!(is_connected("connected"));
+        assert!(is_connected("stale"));
+        assert!(!is_connected("reconnecting"));
+        assert!(!is_connected("disconnected"));
+        assert!(!is_connected(""), "an absent key must not read as connected");
+    }
+
+    /// Field mapping against a row observed verbatim on device (probe
+    /// 260811-urj), trimmed to the keys Myco reads. The key names are the
+    /// non-obvious part: `node_addr` not `node_addr_hex`, `transport_type` not
+    /// `transport`, and `connectivity` (a string) not `connected` (a bool).
+    #[test]
+    fn maps_an_observed_peer_row() {
+        let row = serde_json::json!({
+            "authenticated_at_ms": 1786483829884u64,
+            "connectivity": "connected",
+            "display_name": "npub1qrjr...msuc",
+            "ipv6_addr": "fdad:9d5c:b1a2:48d4:ff21:e9f3:c10:b3ea",
+            "last_seen_ms": 1786484197793u64,
+            "node_addr": "ad9d5cb1a248d4ff21e9f30c10b3ea40",
+            "npub": "npub1qrjrvpelneupkjnk5nmkxxjfyxkyp5yg5l38t3e8fxs75lzwtgqqfqmsuc",
+            "transport_addr": "[::ffff:192.168.8.238]:2121",
+            "transport_type": "udp",
+        });
+        let view = peer_from_json(&row);
+        assert_eq!(view.node_addr_hex, "ad9d5cb1a248d4ff21e9f30c10b3ea40");
+        assert_eq!(
+            view.npub,
+            "npub1qrjrvpelneupkjnk5nmkxxjfyxkyp5yg5l38t3e8fxs75lzwtgqqfqmsuc"
+        );
+        assert!(view.connected);
+        assert_eq!(view.last_seen_ms, 1786484197793);
+        assert_eq!(view.transport, "udp");
+        assert_eq!(view.display_name, "npub1qrjr...msuc");
+    }
+
+    #[test]
+    fn a_row_missing_conditional_keys_still_maps() {
+        let row = serde_json::json!({ "npub": "npub1x", "connectivity": "stale" });
+        let view = peer_from_json(&row);
+        assert!(view.connected);
+        assert!(view.transport.is_empty());
+        assert_eq!(view.last_seen_ms, 0);
+    }
+
+    fn temp_socket(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("myco-ctl-{}-{tag}.sock", std::process::id()))
+    }
+
+    /// Serve exactly one request the way fips does — read a line, write a line
+    /// — and hand the request back so the test can assert on it.
+    async fn serve_once(path: std::path::PathBuf, response: &'static str) -> String {
+        let listener = tokio::net::UnixListener::bind(&path).expect("bind");
+        let (stream, _) = listener.accept().await.expect("accept");
+        let (reader, mut writer) = tokio::io::split(stream);
+        let mut request = String::new();
+        BufReader::new(reader)
+            .read_line(&mut request)
+            .await
+            .expect("read");
+        writer.write_all(response.as_bytes()).await.expect("write");
+        writer.flush().await.expect("flush");
+        request
+    }
+
+    #[tokio::test]
+    async fn show_peers_round_trips() {
+        let path = temp_socket("peers");
+        let _ = std::fs::remove_file(&path);
+        let server = tokio::spawn(serve_once(
+            path.clone(),
+            "{\"status\":\"ok\",\"data\":{\"peers\":[\
+             {\"npub\":\"npub1a\",\"connectivity\":\"connected\",\"node_addr\":\"aa\"},\
+             {\"npub\":\"npub1b\",\"connectivity\":\"disconnected\",\"node_addr\":\"bb\"}]}}\n",
+        ));
+        // The listener binds inside the task; retry the dial until it is up.
+        let client = ControlClient::new(path.to_str().unwrap());
+        let peers = loop {
+            match client.show_peers().await {
+                Ok(p) => break p,
+                Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+            }
+        };
+        let request = server.await.expect("server task");
+        assert!(request.contains("\"command\":\"show_peers\""));
+        assert_eq!(peers.len(), 2, "both peers are returned, connected or not");
+        assert!(peers[0].connected);
+        assert!(!peers[1].connected);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn connect_sends_the_three_params_and_surfaces_an_error_envelope() {
+        let path = temp_socket("connect");
+        let _ = std::fs::remove_file(&path);
+        let server = tokio::spawn(serve_once(
+            path.clone(),
+            "{\"status\":\"error\",\"message\":\"no such transport\"}\n",
+        ));
+        let client = ControlClient::new(path.to_str().unwrap());
+        let err = loop {
+            match client
+                .connect_peer("npub1x", "[fe80::1%3]:4871", "udp")
+                .await
+            {
+                Err(e) if e.starts_with("connect ") => {
+                    tokio::time::sleep(Duration::from_millis(10)).await
+                }
+                Err(e) => break e,
+                Ok(()) => panic!("an error envelope must not read as success"),
+            }
+        };
+        assert_eq!(err, "no such transport");
+        let request = server.await.expect("server task");
+        assert!(request.contains("\"command\":\"connect\""));
+        assert!(request.contains("\"npub\":\"npub1x\""));
+        assert!(request.contains("\"address\":\"[fe80::1%3]:4871\""));
+        assert!(request.contains("\"transport\":\"udp\""));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// An absent socket is the shape a failed bind takes, and it must be an
+    /// error rather than an empty peer list.
+    #[tokio::test]
+    async fn an_absent_socket_is_an_error_not_an_empty_list() {
+        let client = ControlClient::new(temp_socket("absent").to_str().unwrap());
+        assert!(client.show_peers().await.is_err());
+    }
+
+    #[test]
+    fn socket_path_sits_in_the_data_dir() {
+        assert_eq!(
+            socket_path("/data/user/0/app.myco/files"),
+            "/data/user/0/app.myco/files/fips-control.sock"
+        );
+        assert_eq!(socket_path("/tmp/"), "/tmp/fips-control.sock");
+    }
+}

--- a/myco-core/src/control_client.rs
+++ b/myco-core/src/control_client.rs
@@ -56,6 +56,12 @@ pub struct PeerView {
     pub connected: bool,
     /// Milliseconds since the epoch this peer was last heard from.
     pub last_seen_ms: u64,
+    /// Milliseconds since the epoch the FMP session with this peer completed
+    /// authentication. The age derived from this is the *session's* lifetime,
+    /// not the current FMP index's: `receiver_idx` rotates on every rekey
+    /// (`node.rekey.after_secs`, default 120s) while the session survives, so
+    /// a long age here is the link holding rather than a stale handshake.
+    pub authenticated_at_ms: u64,
     /// Transport type carrying the peer's link (`"ble"`, `"udp"`, …).
     pub transport: String,
     /// fips's render-ready name. **This is an abbreviated npub**
@@ -215,6 +221,10 @@ fn peer_from_json(peer: &Value) -> PeerView {
             .get("last_seen_ms")
             .and_then(Value::as_u64)
             .unwrap_or(0),
+        authenticated_at_ms: peer
+            .get("authenticated_at_ms")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
         transport: s("transport_type"),
         display_name: s("display_name"),
     }
@@ -264,6 +274,7 @@ mod tests {
         );
         assert!(view.connected);
         assert_eq!(view.last_seen_ms, 1786484197793);
+        assert_eq!(view.authenticated_at_ms, 1786483829884);
         assert_eq!(view.transport, "udp");
         assert_eq!(view.display_name, "npub1qrjr...msuc");
     }
@@ -275,6 +286,9 @@ mod tests {
         assert!(view.connected);
         assert!(view.transport.is_empty());
         assert_eq!(view.last_seen_ms, 0);
+        // A peer row without it must read as "unknown", never as "aged zero" —
+        // the UI shows a dash rather than an age computed from the epoch.
+        assert_eq!(view.authenticated_at_ms, 0);
     }
 
     fn temp_socket(tag: &str) -> std::path::PathBuf {

--- a/myco-core/src/dns_intercept.rs
+++ b/myco-core/src/dns_intercept.rs
@@ -8,9 +8,16 @@
 //! synthesises a reply, so any app can resolve `<npub>.fips` (and, via a host map
 //! later, aliases) to a mesh `fd00::` address — without a real DNS server socket.
 //!
-//! Resolution itself is pure computation: `<npub>.fips` → `fd00::` is derived from
-//! the public key alone (see [`fips::upper::dns::handle_dns_packet`]), so this
-//! works with no network and no upstream resolver.
+//! Resolution itself is **not** done here. The node runs its own `.fips`
+//! responder and publishes the address it bound to ([`set_responder_addr`]);
+//! this module lifts the DNS payload out of the packet, sends it there over an
+//! ordinary UDP socket, and splices the answer back into a reply packet. That
+//! is the whole point of the indirection: answering a `<npub>.fips` query is
+//! what puts the peer's public key into the node's identity cache, and a mesh
+//! address is a truncated hash — the key cannot be recovered from it. With no
+//! cache entry the first packet to a freshly-resolved name is rejected with
+//! ICMPv6 "No route", a failure direct neighbours mask entirely because their
+//! identity arrives with the Noise handshake.
 //!
 //! Because the sentinel is the *only* resolver the tunnel advertises, this
 //! module owns every name the device looks up, not just mesh ones: non-`.fips`
@@ -20,52 +27,138 @@
 //! real one denies it authoritatively, so mesh names would resolve or not
 //! depending on which server happened to be picked.
 
+use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
-use fips::upper::dns::{handle_dns_packet, DnsIdentityTx, DnsResolvedIdentity};
-use fips::upper::hosts::HostMap;
 use fips::upper::tcp_mss::recalculate_l4_checksum;
 
-/// Sender that feeds each DNS-resolved identity to the node's rx-loop so it
-/// populates its identity cache — the route-warming side effect the built-in
-/// desktop DNS responder provides. Without it, a resolved `<npub>.fips` answers
-/// the AAAA but the first packet to that address has no cached pubkey to open a
-/// session with, so it is dropped and the connection silently hangs. Installed
-/// from `runtime.rs` via [`fips::Node::enable_app_owned_dns`].
-static IDENTITY_TX: OnceLock<Mutex<Option<DnsIdentityTx>>> = OnceLock::new();
-
-fn identity_tx() -> &'static Mutex<Option<DnsIdentityTx>> {
-    IDENTITY_TX.get_or_init(|| Mutex::new(None))
-}
-
-/// Install the node's DNS-identity sender. Replaces any prior install (the node
-/// is rebuilt on a transport off→on cycle, yielding a fresh channel).
-pub fn set_identity_tx(tx: DnsIdentityTx) {
-    *identity_tx().lock().unwrap() = Some(tx);
-}
-
-/// Teach the node an npub's address→pubkey mapping without going through a DNS
-/// lookup, so a packet sent to that mesh address can open a session.
+/// Where the node's built-in `.fips` responder is listening, or `None` when it
+/// is not running.
 ///
-/// Dialling a peer by raw `fd00::` literal skips resolution, so nothing
-/// registers the identity and the node has no pubkey to open a session with —
-/// the send is dropped and the address looks unroutable. That is invisible for
-/// a *direct* neighbour, whose identity the node already holds from the
-/// handshake, which is why only adjacent peers used to be reachable. Every
-/// address is derived from the public key alone, so this needs no network.
+/// Published by `runtime::start_node` from `Node::dns_local_addr()` once
+/// `start()` has returned — a one-shot read, because `run_rx_loop` then borrows
+/// the node for the rest of its life. The responder is either up for that whole
+/// life or it never came up.
+///
+/// This replaces the app-owned DNS identity channel, and inverts the data path
+/// while it is at it. Myco used to answer `.fips` itself and push each resolved
+/// identity *into* the node; the node's own responder start-up then overwrote
+/// the receiver on that channel, so every push was silently dropped and route
+/// warming quietly stopped. Now the responder answers and registers the
+/// identity as its own side effect, and there is no channel left to clobber.
+static RESPONDER: OnceLock<Mutex<Option<SocketAddr>>> = OnceLock::new();
+
+fn responder() -> &'static Mutex<Option<SocketAddr>> {
+    RESPONDER.get_or_init(|| Mutex::new(None))
+}
+
+/// Publish (or retract) the responder's address. Replaces any prior value: the
+/// node is rebuilt on a transport off→on cycle and binds a fresh socket.
+///
+/// Clears the warmed-npub set, because a fresh node has a fresh, empty identity
+/// cache and everything has to be warmed again.
+pub fn set_responder_addr(addr: Option<SocketAddr>) {
+    *responder().lock().unwrap() = addr;
+    warmed().lock().unwrap().clear();
+}
+
+fn responder_addr() -> Option<SocketAddr> {
+    *responder().lock().unwrap()
+}
+
+/// How long to wait for the responder. It is in-process on loopback, so this is
+/// a liveness bound, not a latency budget.
+const RESPONDER_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// npubs already resolved through the responder since the current node started.
+///
+/// `keepwarm_tick` calls [`warm_route`] for every Circle member every 8s. That
+/// used to be an in-memory channel send; it is a UDP round trip now, on the
+/// battery-sensitive background path, so it happens once per npub per node.
+static WARMED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn warmed() -> &'static Mutex<HashSet<String>> {
+    WARMED.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Transaction ids for synthesised queries, so a reply can be matched to the
+/// query that asked for it.
+static QUERY_ID: AtomicU16 = AtomicU16::new(1);
+
+/// Teach the node an npub's address→pubkey mapping ahead of any dial, so the
+/// first packet to that mesh address can open a session.
+///
+/// A FIPS address is a truncated double hash of the public key, so the node
+/// cannot recover the key from the address; with no cache entry the send is
+/// dropped and the address looks unroutable. A *direct* neighbour hides this,
+/// since its identity came from the Noise handshake.
+///
+/// `keepwarm_tick`'s dials go to `ws://<npub>.fips:4870`, a name — so they warm
+/// themselves through resolution eventually. This pre-warm exists because the
+/// dial and the resolution are concurrent, and losing that race is the whole
+/// failure. Fire-and-forget on its own thread: the caller is a tokio task and
+/// this must not be what stalls the keepwarm loop.
 pub fn warm_route(npub: &str) {
-    let Ok(peer) = fips::PeerIdentity::from_npub(npub) else {
+    if fips::PeerIdentity::from_npub(npub).is_err() {
+        return;
+    }
+    if responder_addr().is_none() {
+        return; // no node, nothing to warm; retried on the next tick
+    }
+    if !warmed().lock().unwrap().insert(npub.to_string()) {
+        return;
+    }
+    let Some(query) = build_aaaa_query(&format!("{npub}.fips")) else {
         return;
     };
-    let id = DnsResolvedIdentity {
-        node_addr: *peer.node_addr(),
-        pubkey: peer.pubkey_full(),
-    };
-    if let Some(tx) = identity_tx().lock().unwrap().as_ref() {
-        let _ = tx.try_send(id);
+    std::thread::spawn(move || {
+        // The answer is discarded — registering the identity is the side
+        // effect this exists for.
+        let _ = resolve_via_responder(&query);
+    });
+}
+
+/// A minimal AAAA query for `name`, as the responder expects it: payload only,
+/// no IP or UDP header.
+fn build_aaaa_query(name: &str) -> Option<Vec<u8>> {
+    use simple_dns::{Name, Packet, Question, CLASS, QCLASS, QTYPE, TYPE};
+    let mut packet = Packet::new_query(QUERY_ID.fetch_add(1, Ordering::Relaxed));
+    packet.questions.push(Question::new(
+        Name::new(name).ok()?,
+        QTYPE::TYPE(TYPE::AAAA),
+        QCLASS::CLASS(CLASS::IN),
+        false,
+    ));
+    packet.build_bytes_vec().ok()
+}
+
+/// One blocking UDP round trip to the node's responder, returning the DNS reply
+/// payload. `None` if there is no responder, or it did not answer in time, or
+/// the answer did not match the question.
+fn resolve_via_responder(dns_query: &[u8]) -> Option<Vec<u8>> {
+    if dns_query.len() < 2 {
+        return None;
     }
+    let addr = responder_addr()?;
+    let bind: SocketAddr = if addr.is_ipv6() {
+        "[::1]:0".parse().ok()?
+    } else {
+        "127.0.0.1:0".parse().ok()?
+    };
+    let sock = std::net::UdpSocket::bind(bind).ok()?;
+    sock.set_read_timeout(Some(RESPONDER_TIMEOUT)).ok()?;
+    sock.send_to(dns_query, addr).ok()?;
+
+    let mut buf = [0u8; 1500];
+    let (n, from) = sock.recv_from(&mut buf).ok()?;
+    // Only the server we asked, and only an answer to the question we sent.
+    if from.ip() != addr.ip() || n < 2 || buf[..2] != dns_query[..2] {
+        return None;
+    }
+    Some(buf[..n].to_vec())
 }
 
 /// The sentinel DNS-server address, `fd00::53`. Chosen inside the routed
@@ -73,12 +166,10 @@ pub fn warm_route(npub: &str) {
 /// npub-derived node address (those fill the whole 128 bits from a hash).
 const SENTINEL: [u8; 16] = [0xfd, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x53];
 
-/// String form used by the Kotlin VPN builder's `addDnsServer`.
+/// String form used by the Kotlin VPN builder's `addDnsServer`. Its only
+/// consumer is on the other side of the FFI, so nothing in Rust reads it.
+#[allow(dead_code)]
 pub const SENTINEL_STR: &str = "fd00::53";
-
-/// TTL (seconds) on synthesised AAAA answers. Short: a node's mesh address is
-/// stable, but keeping it low means a stale mapping self-heals quickly.
-const ANSWER_TTL: u32 = 30;
 
 const IPV6_HEADER_LEN: usize = 40;
 const UDP_HEADER_LEN: usize = 8;
@@ -87,34 +178,33 @@ const DNS_PORT: u16 = 53;
 
 /// What [`handle_query`] did with a packet.
 pub enum Dns {
-    /// A `.fips` query, answered here — write this reply to the TUN.
-    Answered(Vec<u8>),
-    /// Not ours to answer, sent to a real resolver instead; the reply will be
-    /// delivered later through [`crate::tun_bridge::push_local`]. The caller
-    /// must consume the packet either way.
+    /// Ours, and now in flight to a resolver — the node's own `.fips` responder
+    /// or a real upstream one. The reply is delivered later through
+    /// [`crate::tun_bridge::push_local`]; the caller must consume the packet
+    /// regardless, because it must not reach the mesh either way.
     Forwarded,
     /// Not a DNS query to the sentinel — forward it into the mesh unchanged.
     NotOurs,
 }
 
 /// Handle a packet the TUN pump read, if it is a UDP DNS query to
-/// `[fd00::53]:53`. `.fips` names are answered from the public key alone;
-/// everything else is relayed to a real resolver (see [`set_upstream`]),
-/// because the sentinel is the tunnel's *only* advertised server — anything we
-/// decline here would simply fail to resolve on the device.
+/// `[fd00::53]:53`. `.fips` names go to the node's own responder; everything
+/// else is relayed to a real resolver (see [`set_upstream`]), because the
+/// sentinel is the tunnel's *only* advertised server — anything we decline here
+/// would simply fail to resolve on the device.
+///
+/// Both paths are asynchronous now. `.fips` used to be answered inline, from
+/// the public key alone; it is a round trip to the responder instead, so the
+/// route-warming side effect happens where the identity cache actually lives.
 pub fn handle_query(packet: &[u8]) -> Dns {
     match parse_query(packet) {
         Some((src_addr, src_port, dns_query)) => {
             if is_fips_name(dns_query) {
-                match answer_fips(src_addr, src_port, dns_query) {
-                    Some(reply) => Dns::Answered(reply),
-                    // Malformed enough that even SERVFAIL can't be built.
-                    None => Dns::Forwarded,
-                }
+                forward_to_responder(src_addr, src_port, dns_query);
             } else {
                 forward_upstream(src_addr, src_port, dns_query);
-                Dns::Forwarded
             }
+            Dns::Forwarded
         }
         None => Dns::NotOurs,
     }
@@ -145,20 +235,31 @@ fn parse_query(packet: &[u8]) -> Option<(&[u8], u16, &[u8])> {
     Some((&packet[8..24], src_port, dns_query))
 }
 
-/// Answer a `.fips` query from the public key alone, and warm the route.
-fn answer_fips(src_addr: &[u8], src_port: u16, dns_query: &[u8]) -> Option<Vec<u8>> {
-    // Empty host map: `<npub>.fips` resolves by pure computation without it.
-    let (dns_reply, identity) = handle_dns_packet(dns_query, ANSWER_TTL, &HostMap::new())?;
-
-    // Warm the route: hand the resolved identity to the node so it caches the
-    // pubkey and can open a session to this address (see [`set_identity_tx`]).
-    if let Some(id) = identity {
-        if let Some(tx) = identity_tx().lock().unwrap().as_ref() {
-            let _ = tx.try_send(id);
-        }
+/// Send a `.fips` query to the node's own responder and inject its answer back
+/// into the TUN.
+///
+/// Runs on its own thread for the same reason [`forward_upstream`] does: the
+/// caller is the TUN read loop, and blocking it would stall every other packet
+/// on the device. Mesh DNS volume is low enough that a thread per outstanding
+/// query is cheaper than the machinery to avoid one.
+///
+/// A dropped query is a query the OS resolver retries. With no responder
+/// published — the node is stopped, or its bind failed — nothing is sent and
+/// the name simply does not resolve, which is the honest outcome: answering it
+/// here would resolve the name while leaving the node unable to reach it.
+fn forward_to_responder(src_addr: &[u8], src_port: u16, dns_query: &[u8]) {
+    if responder_addr().is_none() {
+        return;
     }
+    let mut querier = [0u8; 16];
+    querier.copy_from_slice(src_addr);
+    let query = dns_query.to_vec();
 
-    Some(build_reply(src_addr, src_port, &dns_reply))
+    std::thread::spawn(move || {
+        if let Some(reply) = resolve_via_responder(&query) {
+            crate::tun_bridge::push_local(build_reply(&querier, src_port, &reply));
+        }
+    });
 }
 
 /// Real resolvers to relay non-`.fips` queries to, set by the platform from the
@@ -307,27 +408,94 @@ mod tests {
         pkt
     }
 
-    #[test]
-    fn resolves_npub_fips_query() {
-        // A valid npub (from fips test vectors would be ideal; use a well-formed one).
-        let npub = "npub1mqelkzqp4659fws35h2wvr7z9caka5ml8qddj3ssnwaulwpxdd9sdc3esw";
-        let pkt = make_query(&format!("{npub}.fips"), SENTINEL);
-        let Dns::Answered(reply) = handle_query(&pkt) else {
-            panic!("a .fips query must be answered here, not forwarded");
-        };
+    const NPUB: &str = "npub1mqelkzqp4659fws35h2wvr7z9caka5ml8qddj3ssnwaulwpxdd9sdc3esw";
 
-        // Reply is IPv6/UDP, from :53, back to the querier, addressed to the client.
+    /// A stand-in for the node's built-in responder: echoes back whatever it is
+    /// sent, with the DNS QR bit set so it reads as a response. Returns the
+    /// address it bound to.
+    fn fake_responder() -> SocketAddr {
+        let sock = std::net::UdpSocket::bind("[::1]:0").expect("bind fake responder");
+        let addr = sock.local_addr().expect("local addr");
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 1500];
+            while let Ok((n, from)) = sock.recv_from(&mut buf) {
+                if n >= 3 {
+                    buf[2] |= 0x80; // QR = response
+                }
+                let _ = sock.send_to(&buf[..n], from);
+            }
+        });
+        addr
+    }
+
+    /// The load-bearing leg: a `.fips` query is proxied to the responder and its
+    /// answer comes back, matched by transaction id. Route warming rides on this
+    /// round trip actually happening — the responder registering the peer's
+    /// public key is the side effect the whole indirection exists for.
+    #[test]
+    fn a_fips_query_round_trips_through_the_responder() {
+        set_responder_addr(Some(fake_responder()));
+
+        let query = build_aaaa_query(&format!("{NPUB}.fips")).expect("query builds");
+        let reply = resolve_via_responder(&query).expect("responder answered");
+
+        assert_eq!(&reply[..2], &query[..2], "transaction id must match");
+        assert_ne!(
+            reply[2] & 0x80,
+            0,
+            "must be a response, not the echo of a query"
+        );
+
+        set_responder_addr(None);
+    }
+
+    /// An answer from somewhere other than the responder, or to a different
+    /// question, must not be spliced into the tunnel.
+    #[test]
+    fn a_mismatched_transaction_id_is_rejected() {
+        set_responder_addr(Some(fake_responder()));
+
+        let query = build_aaaa_query(&format!("{NPUB}.fips")).expect("query builds");
+        let mut different = query.clone();
+        different[0] ^= 0xff;
+        // The fake echoes the id it was sent, so asking with one id and
+        // checking against another is the same shape as an off-query reply.
+        let reply = resolve_via_responder(&different).expect("responder answered");
+        assert_ne!(&reply[..2], &query[..2]);
+
+        set_responder_addr(None);
+    }
+
+    /// With no responder published, a `.fips` name resolves to nothing rather
+    /// than being answered locally. Answering it would hand the caller an
+    /// address the node has no key for, which is the "No route" failure.
+    #[test]
+    fn a_fips_query_is_consumed_but_not_answered_locally() {
+        set_responder_addr(None);
+        let pkt = make_query(&format!("{NPUB}.fips"), SENTINEL);
+        assert!(
+            matches!(handle_query(&pkt), Dns::Forwarded),
+            "a .fips query is ours, so it must never reach the mesh"
+        );
+    }
+
+    /// The reply packet assembly is unchanged and still owned here: the
+    /// responder returns a DNS payload, not an IPv6 packet.
+    #[test]
+    fn reply_packets_are_addressed_back_to_the_querier() {
+        let pkt = make_query(&format!("{NPUB}.fips"), SENTINEL);
+        let reply = build_reply(&pkt[8..24], 40000, b"\x12\x34payload");
+
         assert_eq!(reply[0] >> 4, 6);
         assert_eq!(reply[6], NEXT_HEADER_UDP);
         assert_eq!(&reply[8..24], &SENTINEL); // src = sentinel
         assert_eq!(&reply[24..40], &pkt[8..24]); // dst = original client
         assert_eq!(u16::from_be_bytes([reply[40], reply[41]]), DNS_PORT);
         assert_eq!(u16::from_be_bytes([reply[42], reply[43]]), 40000);
-
-        // The DNS answer carries an AAAA in the mesh prefix.
-        let dns = &reply[IPV6_HEADER_LEN + UDP_HEADER_LEN..];
-        let parsed = simple_dns::Packet::parse(dns).unwrap();
-        assert_eq!(parsed.answers.len(), 1);
+        assert_eq!(
+            &reply[IPV6_HEADER_LEN + UDP_HEADER_LEN..],
+            b"\x12\x34payload"
+        );
     }
 
     #[test]
@@ -344,10 +512,9 @@ mod tests {
 
     #[test]
     fn ignores_wrong_destination() {
-        let npub = "npub1mqelkzqp4659fws35h2wvr7z9caka5ml8qddj3ssnwaulwpxdd9sdc3esw";
         // Same query but to a non-sentinel address → not ours, forward to mesh.
         let other = [0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9];
-        let pkt = make_query(&format!("{npub}.fips"), other);
+        let pkt = make_query(&format!("{NPUB}.fips"), other);
         assert!(matches!(handle_query(&pkt), Dns::NotOurs));
     }
 

--- a/myco-core/src/dns_intercept.rs
+++ b/myco-core/src/dns_intercept.rs
@@ -105,9 +105,9 @@ pub fn warm_route(npub: &str) {
     if fips::PeerIdentity::from_npub(npub).is_err() {
         return;
     }
-    if responder_addr().is_none() {
+    let Some(addr) = responder_addr() else {
         return; // no node, nothing to warm; retried on the next tick
-    }
+    };
     if !warmed().lock().unwrap().insert(npub.to_string()) {
         return;
     }
@@ -117,7 +117,7 @@ pub fn warm_route(npub: &str) {
     std::thread::spawn(move || {
         // The answer is discarded — registering the identity is the side
         // effect this exists for.
-        let _ = resolve_via_responder(&query);
+        let _ = resolve_via_responder(addr, &query);
     });
 }
 
@@ -135,14 +135,17 @@ fn build_aaaa_query(name: &str) -> Option<Vec<u8>> {
     packet.build_bytes_vec().ok()
 }
 
-/// One blocking UDP round trip to the node's responder, returning the DNS reply
-/// payload. `None` if there is no responder, or it did not answer in time, or
-/// the answer did not match the question.
-fn resolve_via_responder(dns_query: &[u8]) -> Option<Vec<u8>> {
+/// One blocking UDP round trip to the responder at `addr`, returning the DNS
+/// reply payload. `None` if it did not answer in time, or the answer did not
+/// match the question.
+///
+/// Takes the address rather than reading the published one so the round trip is
+/// testable without publishing a responder — publishing one would leak DNS
+/// replies into the shared TUN queue that other tests read.
+fn resolve_via_responder(addr: SocketAddr, dns_query: &[u8]) -> Option<Vec<u8>> {
     if dns_query.len() < 2 {
         return None;
     }
-    let addr = responder_addr()?;
     let bind: SocketAddr = if addr.is_ipv6() {
         "[::1]:0".parse().ok()?
     } else {
@@ -248,15 +251,15 @@ fn parse_query(packet: &[u8]) -> Option<(&[u8], u16, &[u8])> {
 /// the name simply does not resolve, which is the honest outcome: answering it
 /// here would resolve the name while leaving the node unable to reach it.
 fn forward_to_responder(src_addr: &[u8], src_port: u16, dns_query: &[u8]) {
-    if responder_addr().is_none() {
+    let Some(addr) = responder_addr() else {
         return;
-    }
+    };
     let mut querier = [0u8; 16];
     querier.copy_from_slice(src_addr);
     let query = dns_query.to_vec();
 
     std::thread::spawn(move || {
-        if let Some(reply) = resolve_via_responder(&query) {
+        if let Some(reply) = resolve_via_responder(addr, &query) {
             crate::tun_bridge::push_local(build_reply(&querier, src_port, &reply));
         }
     });
@@ -434,10 +437,9 @@ mod tests {
     /// public key is the side effect the whole indirection exists for.
     #[test]
     fn a_fips_query_round_trips_through_the_responder() {
-        set_responder_addr(Some(fake_responder()));
-
+        let addr = fake_responder();
         let query = build_aaaa_query(&format!("{NPUB}.fips")).expect("query builds");
-        let reply = resolve_via_responder(&query).expect("responder answered");
+        let reply = resolve_via_responder(addr, &query).expect("responder answered");
 
         assert_eq!(&reply[..2], &query[..2], "transaction id must match");
         assert_ne!(
@@ -445,33 +447,29 @@ mod tests {
             0,
             "must be a response, not the echo of a query"
         );
-
-        set_responder_addr(None);
     }
 
     /// An answer from somewhere other than the responder, or to a different
     /// question, must not be spliced into the tunnel.
     #[test]
     fn a_mismatched_transaction_id_is_rejected() {
-        set_responder_addr(Some(fake_responder()));
-
+        let addr = fake_responder();
         let query = build_aaaa_query(&format!("{NPUB}.fips")).expect("query builds");
         let mut different = query.clone();
         different[0] ^= 0xff;
         // The fake echoes the id it was sent, so asking with one id and
         // checking against another is the same shape as an off-query reply.
-        let reply = resolve_via_responder(&different).expect("responder answered");
+        let reply = resolve_via_responder(addr, &different).expect("responder answered");
         assert_ne!(&reply[..2], &query[..2]);
-
-        set_responder_addr(None);
     }
 
-    /// With no responder published, a `.fips` name resolves to nothing rather
-    /// than being answered locally. Answering it would hand the caller an
-    /// address the node has no key for, which is the "No route" failure.
+    /// A `.fips` query is consumed here whatever happens next — never handed to
+    /// the mesh, and never answered locally. Answering it locally would give
+    /// the caller an address the node has no key for, which is the "No route"
+    /// failure this whole indirection exists to avoid. No responder is
+    /// published in tests, so this exercises the no-responder path too.
     #[test]
     fn a_fips_query_is_consumed_but_not_answered_locally() {
-        set_responder_addr(None);
         let pkt = make_query(&format!("{NPUB}.fips"), SENTINEL);
         assert!(
             matches!(handle_query(&pkt), Dns::Forwarded),

--- a/myco-core/src/lane_observation.rs
+++ b/myco-core/src/lane_observation.rs
@@ -1,10 +1,10 @@
 //! npub → observed lane record — the lane disambiguation seam for D-19's
 //! merged peer diagnostics row (01-02).
 //!
-//! Wi-Fi Aware and the LAN/AP lane both ride fips's plain UDP transport and
-//! share one JNI push site (`aware_bridge_jni.rs`'s `TRANSPORT_TYPE =
-//! "udp"`), so fips itself structurally cannot tell them apart — only the
-//! Kotlin radio that observed a given peer knows which lane carried it. This
+//! Wi-Fi Aware and the LAN/AP lane both ride UDP and share one JNI push site,
+//! and while each now dials down its own named UDP instance, fips reports a
+//! peer's transport by *type* — so a peer row still cannot say which radio
+//! found it. Only the Kotlin radio that observed a given peer knows that. This
 //! module holds that record: plain lock-based state with no JNI or Android
 //! dependency, so it is unit-testable on the host even though
 //! `aware_bridge_jni.rs` (Android-only) is its sole real caller, pushing on

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -51,8 +51,9 @@ mod tun_bridge;
 // System-wide `.fips` DNS interception; driven by the TUN pump on Android.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod dns_intercept;
-// Surfaces the UDP transport's raw fd so Android can pin it to a specific
-// `Network` (Wi-Fi Aware / the AP lane). Android-only consumer.
+// Surfaces each UDP transport instance's raw fd, keyed by instance name, so
+// Android can pin the right socket to the right `Network` (the Aware NDP vs.
+// the AP/LAN lane). Android-only consumer.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod udp_fd_bridge;
 

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -12,6 +12,12 @@
 mod action;
 mod attempt_store;
 mod content;
+// Client for the fips node's Unix-domain control socket — the only way to read
+// peer state or push a platform-discovered peer into a node whose `run_rx_loop`
+// has borrowed it. Polled only by the Android peer-state tick and the platform
+// peer drainer, so it reads as dead on the host build (its own tests aside).
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod control_client;
 // The mesh gossiper is wired only into the Android relay server (runtime.rs); on
 // the host it is exercised only by its own tests, so it reads as dead there.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -38,6 +38,10 @@ mod lane_observation;
 mod peer_diagnostics;
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod peer_relay;
+// Bounded queue + drainer between the Kotlin radios' callback threads and the
+// node's control socket, where pushing a platform-discovered peer now lives.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod platform_peers;
 mod runtime;
 mod state;
 // The bridge is pumped only by the Android VpnService (via tun_bridge_jni) and

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -11,6 +11,11 @@
 
 mod action;
 mod attempt_store;
+// Myco-owned BLE connect-attempt vocabulary. These used to be fips types read
+// out of a transport-global log; the restacked fips counts outcomes into
+// `BleStats` instead. Nothing produces these yet — see the module doc's
+// TODO(stage 2).
+mod ble_diag;
 mod content;
 // Client for the fips node's Unix-domain control socket — the only way to read
 // peer state or push a platform-discovered peer into a node whose `run_rx_loop`

--- a/myco-core/src/peer_diagnostics.rs
+++ b/myco-core/src/peer_diagnostics.rs
@@ -133,6 +133,7 @@ pub fn merge_peers(
             .or_else(|| pv.map(|p| p.transport.clone()))
             .unwrap_or_default();
         let last_seen_ms = pv.map(|p| p.last_seen_ms).unwrap_or(0);
+        let authenticated_at_ms = pv.map(|p| p.authenticated_at_ms).unwrap_or(0);
         rows.push(PeerDiagnosticView {
             key,
             npub: bp.npub.clone(),
@@ -150,6 +151,7 @@ pub fn merge_peers(
             transport,
             also_reachable_via: Vec::new(),
             last_seen_ms,
+            authenticated_at_ms,
             rssi: bp.rssi,
             psm: bp.psm,
             pair_state: String::new(),
@@ -201,6 +203,7 @@ pub fn merge_peers(
                 transport: String::new(),
                 also_reachable_via: Vec::new(),
                 last_seen_ms: 0,
+                authenticated_at_ms: 0,
                 rssi: Some(adv.rssi),
                 psm: adv.psm,
                 pair_state: String::new(),
@@ -243,6 +246,7 @@ pub fn merge_peers(
             transport: String::new(),
             also_reachable_via: Vec::new(),
             last_seen_ms: 0,
+            authenticated_at_ms: 0,
             rssi: None,
             psm: 0,
             pair_state: String::new(),
@@ -374,6 +378,7 @@ mod tests {
             npub: npub.to_string(),
             connected,
             last_seen_ms,
+            authenticated_at_ms: 0,
             transport: transport.to_string(),
             display_name: String::new(),
         }

--- a/myco-core/src/peer_diagnostics.rs
+++ b/myco-core/src/peer_diagnostics.rs
@@ -14,9 +14,9 @@
 
 use std::collections::HashMap;
 
-use fips::control::read_handle::PeerView;
+use crate::control_client::PeerView;
 
-use fips::transport::ble::attempts::{BlePeerAttempts, MAX_ATTEMPTS_PER_PEER};
+use crate::ble_diag::{BlePeerAttempts, MAX_ATTEMPTS_PER_PEER};
 
 use crate::content::{CircleContact, OutboundPairView, PairRequestView};
 use crate::state::{BleAdvert, BlePeer, PeerAttemptView, PeerDiagnosticView};
@@ -85,7 +85,7 @@ fn short(s: &str) -> String {
 /// link-local vs. routable) — that would be exactly the sort of
 /// inference-presented-as-observation this phase prohibits.
 ///
-/// `ble_attempts` is the fips BLE transport's per-peer attempt log, keyed by BLE
+/// `ble_attempts` is the per-peer BLE connect-attempt log, keyed by BLE
 /// address. It supplies three things: the role/discovery/outcome history joined
 /// onto each row, the per-peer link send-failure count, and the learned
 /// address-to-node-address pairs that let step 2 attribute an advert to an
@@ -847,7 +847,7 @@ mod tests {
     /// `AppState` JSON carrying its role, discovery duration and outcome.
     #[test]
     fn recorded_lost_tiebreaker_reaches_the_serialized_row() {
-        use fips::transport::ble::attempts::{BleAttempt, BleAttemptOutcome, BleRole};
+        use crate::ble_diag::{BleAttempt, BleAttemptOutcome, BleRole};
 
         let views = vec![pv("beef", "npub-tiebreak", false, 1_000, "ble")];
         let peers = vec![bp("beef", "npub-tiebreak", false)];
@@ -926,7 +926,7 @@ mod tests {
     /// producing a second one (D-09).
     #[test]
     fn advert_with_learned_node_addr_collapses_into_the_peer_row() {
-        use fips::transport::ble::attempts::{BleAttempt, BleAttemptOutcome, BleRole};
+        use crate::ble_diag::{BleAttempt, BleAttemptOutcome, BleRole};
 
         let views = vec![pv("beef", "npub-known", true, 1_000, "ble")];
         let peers = vec![bp("beef", "npub-known", true)];

--- a/myco-core/src/platform_peers.rs
+++ b/myco-core/src/platform_peers.rs
@@ -1,0 +1,258 @@
+//! Bounded queue and drainer for platform-discovered peers.
+//!
+//! Wi-Fi Aware and the `!FIPS` AP lane are discovered by Kotlin, not by the
+//! mesh stack, so the app has to tell a *running* node "peer `<npub>` is
+//! reachable at `<address>`". fips used to expose a process-global queue for
+//! exactly this; it is now the control socket's `connect` command, and that
+//! changes the threading contract enough to need an adapter on this side.
+//!
+//! `connect` is a mutation, so it does not render off a snapshot — it goes
+//! through the rx loop's control arm and is awaited inside the packet loop,
+//! behind whatever that loop is doing. The push, meanwhile, arrives on
+//! `AwareRadio`'s or `ApRadio`'s single `HandlerThread`, which also serves
+//! every `NetworkCallback` and discovery callback for that lane. Blocking one
+//! of those for a control round-trip would serialise every subsequent NDP-up,
+//! NDP-lost and network-change event behind it — during a discovery burst,
+//! which is precisely when several peers are coming up at once.
+//!
+//! So: [`push`] never blocks and never touches the socket, and a tokio task
+//! owns the client and issues `connect`.
+//!
+//! **Overflow policy: drop-new.** A full queue discards the arriving push
+//! rather than the oldest queued one. Both are defensible; drop-new is what a
+//! bounded `try_send` gives, and it favours peers already waiting to be dialled
+//! over a burst that is, by definition, still arriving. Losing a push is
+//! acceptable either way — platform discovery re-fires periodically.
+//!
+//! There is no withdrawal counterpart, deliberately. Myco's old `peer_lost`
+//! call was a no-op (it named the `udp` transport, which does not override
+//! `close_connection`), and the control socket's `disconnect` keys on npub
+//! alone and does a full peer teardown — so a routine Aware NDP drop would
+//! kill a live BLE session to the same peer and suppress its reconnect.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::control_client::ControlClient;
+
+/// Queued pushes held before the drainer gets to them.
+///
+/// Sized for a discovery burst, not for a backlog: a peer that does not make it
+/// out of here within a few seconds is better re-discovered than re-dialled
+/// from a stale address.
+const QUEUE_CAP: usize = 64;
+
+/// How long the same `(npub, address)` is suppressed after being enqueued.
+///
+/// Kotlin re-pushes on every rediscovery, on the assumption that the mesh
+/// dedups. That is true of the *handshake*, not of the dial: `api_connect`
+/// either refreshes an already-connected peer's path or calls
+/// `initiate_peer_connection` outright, with no freshness gate and no connect
+/// budget of the kind the old in-tree queue had. Without this, an Aware
+/// discovery burst becomes a dial burst.
+const REPUSH_SUPPRESSION: Duration = Duration::from_secs(10);
+
+/// Attempts per queued push, covering the window where the node is up but the
+/// control socket is not yet accepting — fips binds it inside `run_rx_loop`,
+/// which only starts after `node.start()` completes.
+const CONNECT_ATTEMPTS: u32 = 3;
+const CONNECT_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// One platform-discovered peer, as Kotlin observed it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlatformPeer {
+    /// The peer's npub, from the Aware service-info or the mDNS TXT record. A
+    /// routing hint only — Noise IK is what authenticates.
+    pub npub: String,
+    /// A fully-formatted socket address. Link-locals carry a *numeric* scope
+    /// (`"[fe80::x%3]:4871"`); interface-name scopes do not parse.
+    pub address: String,
+    /// The fips transport type that will carry it. Both lanes ride plain UDP.
+    pub transport: String,
+}
+
+struct Queue {
+    tx: Sender<PlatformPeer>,
+    /// Taken once, by the drainer.
+    rx: Mutex<Option<Receiver<PlatformPeer>>>,
+    /// When each `(npub, address)` was last accepted, for re-push suppression.
+    last_push: Mutex<HashMap<(String, String), Instant>>,
+}
+
+static QUEUE: OnceLock<Queue> = OnceLock::new();
+
+fn queue() -> &'static Queue {
+    QUEUE.get_or_init(|| {
+        let (tx, rx) = tokio::sync::mpsc::channel(QUEUE_CAP);
+        Queue {
+            tx,
+            rx: Mutex::new(Some(rx)),
+            last_push: Mutex::new(HashMap::new()),
+        }
+    })
+}
+
+/// Enqueue a platform-discovered peer. Never blocks; safe from any thread,
+/// including one with no tokio runtime.
+///
+/// Returns whether it was accepted, for logging only — no caller can do
+/// anything useful with a rejection, and both rejection reasons (suppressed as
+/// a duplicate, or queue full) are expected traffic rather than faults.
+pub fn push(npub: &str, address: &str, transport: &str) -> bool {
+    let key = (npub.to_string(), address.to_string());
+    {
+        let mut last = queue().last_push.lock().unwrap_or_else(|e| e.into_inner());
+        let now = Instant::now();
+        // Prune while we hold the lock; the map is otherwise unbounded in the
+        // number of addresses a peer has ever been seen at.
+        last.retain(|_, at| now.duration_since(*at) < REPUSH_SUPPRESSION);
+        if last.contains_key(&key) {
+            return false;
+        }
+        last.insert(key, now);
+    }
+    queue()
+        .tx
+        .try_send(PlatformPeer {
+            npub: npub.to_string(),
+            address: address.to_string(),
+            transport: transport.to_string(),
+        })
+        .is_ok()
+}
+
+/// Drain the queue onto the control socket, forever.
+///
+/// Held rather than dropped while the node is down: `ApRadio` arms its network
+/// callback independently of node lifecycle, so pushes routinely precede
+/// `StartNode` and outlive a BLE off→on rebuild. The queue is process-global
+/// and the drainer is spawned once, so both survive a node being replaced
+/// underneath them.
+pub fn spawn_drainer(
+    rt: &tokio::runtime::Runtime,
+    control: ControlClient,
+    node_live: Arc<AtomicBool>,
+) {
+    let Some(mut rx) = queue().rx.lock().unwrap_or_else(|e| e.into_inner()).take() else {
+        return; // already spawned
+    };
+    rt.spawn(async move {
+        loop {
+            // Wait for a node before taking the item, so a push that raced
+            // StartNode is held in the queue rather than binned on arrival.
+            while !node_live.load(Ordering::Relaxed) {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            let Some(peer) = rx.recv().await else {
+                return; // sender is static, so only on shutdown
+            };
+            deliver(&control, &peer).await;
+        }
+    });
+}
+
+/// Issue one `connect`, retrying a few times so a push that arrives while the
+/// rx loop is still coming up is not lost to the startup window.
+async fn deliver(control: &ControlClient, peer: &PlatformPeer) {
+    for attempt in 1..=CONNECT_ATTEMPTS {
+        match control
+            .connect_peer(&peer.npub, &peer.address, &peer.transport)
+            .await
+        {
+            Ok(()) => return,
+            Err(e) if attempt == CONNECT_ATTEMPTS => {
+                tracing::warn!(
+                    npub = %peer.npub,
+                    address = %peer.address,
+                    error = %e,
+                    "platform peer push gave up; discovery will re-fire"
+                );
+            }
+            Err(e) => {
+                tracing::debug!(
+                    npub = %peer.npub,
+                    attempt,
+                    error = %e,
+                    "platform peer push failed; retrying"
+                );
+                tokio::time::sleep(CONNECT_RETRY_DELAY).await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The queue is process-global, so the tests share it and must not assume
+    /// they own it. Each uses its own npub prefix and drains what it enqueued.
+    fn drain_now(rx: &mut Receiver<PlatformPeer>, prefix: &str) -> Vec<PlatformPeer> {
+        let mut out = Vec::new();
+        while let Ok(p) = rx.try_recv() {
+            if p.npub.starts_with(prefix) {
+                out.push(p);
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn a_repush_of_the_same_pair_is_suppressed_but_a_new_address_is_not() {
+        let mut rx = queue()
+            .rx
+            .lock()
+            .unwrap()
+            .take()
+            .expect("no drainer runs in tests");
+
+        assert!(push("npub1sup", "[fe80::1%3]:4871", "udp"));
+        assert!(
+            !push("npub1sup", "[fe80::1%3]:4871", "udp"),
+            "an immediate re-push of the same (npub, address) is a duplicate dial"
+        );
+        assert!(
+            push("npub1sup", "[fe80::2%3]:4871", "udp"),
+            "a new address for the same peer is a path change, not a duplicate"
+        );
+
+        let got = drain_now(&mut rx, "npub1sup");
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].address, "[fe80::1%3]:4871");
+        assert_eq!(got[1].address, "[fe80::2%3]:4871");
+        assert_eq!(got[0].transport, "udp");
+
+        *queue().rx.lock().unwrap() = Some(rx);
+    }
+
+    /// Overflow must not block the caller: it is a framework callback thread
+    /// that also serves every other event on its lane.
+    #[tokio::test]
+    async fn a_full_queue_drops_the_arriving_push_without_blocking() {
+        let mut rx = queue()
+            .rx
+            .lock()
+            .unwrap()
+            .take()
+            .expect("no drainer runs in tests");
+
+        let mut accepted = 0;
+        for i in 0..(QUEUE_CAP * 2) {
+            if push("npub1full", &format!("[fe80::{i}%3]:4871"), "udp") {
+                accepted += 1;
+            }
+        }
+        assert!(
+            accepted <= QUEUE_CAP,
+            "the queue is bounded at {QUEUE_CAP}, accepted {accepted}"
+        );
+        assert!(accepted > 0, "pushes must get through at all");
+
+        drain_now(&mut rx, "npub1full");
+        *queue().rx.lock().unwrap() = Some(rx);
+    }
+}

--- a/myco-core/src/platform_peers.rs
+++ b/myco-core/src/platform_peers.rs
@@ -190,19 +190,18 @@ mod tests {
     use super::*;
 
     /// The queue is process-global, so the tests share it and must not assume
-    /// they own it. Each uses its own npub prefix and drains what it enqueued.
-    fn drain_now(rx: &mut Receiver<PlatformPeer>, prefix: &str) -> Vec<PlatformPeer> {
+    /// they own it — and there is exactly one receiver to take, so this is one
+    /// test rather than several racing for it.
+    fn drain_now(rx: &mut Receiver<PlatformPeer>) -> Vec<PlatformPeer> {
         let mut out = Vec::new();
         while let Ok(p) = rx.try_recv() {
-            if p.npub.starts_with(prefix) {
-                out.push(p);
-            }
+            out.push(p);
         }
         out
     }
 
     #[tokio::test]
-    async fn a_repush_of_the_same_pair_is_suppressed_but_a_new_address_is_not() {
+    async fn the_queue_suppresses_duplicates_and_drops_rather_than_blocks() {
         let mut rx = queue()
             .rx
             .lock()
@@ -210,6 +209,9 @@ mod tests {
             .take()
             .expect("no drainer runs in tests");
 
+        // Re-push suppression is per (npub, address): the same pair inside the
+        // window is a duplicate dial, a new address for the same peer is a path
+        // change and must get through.
         assert!(push("npub1sup", "[fe80::1%3]:4871", "udp"));
         assert!(
             !push("npub1sup", "[fe80::1%3]:4871", "udp"),
@@ -220,26 +222,15 @@ mod tests {
             "a new address for the same peer is a path change, not a duplicate"
         );
 
-        let got = drain_now(&mut rx, "npub1sup");
+        let got = drain_now(&mut rx);
         assert_eq!(got.len(), 2);
         assert_eq!(got[0].address, "[fe80::1%3]:4871");
         assert_eq!(got[1].address, "[fe80::2%3]:4871");
         assert_eq!(got[0].transport, "udp");
 
-        *queue().rx.lock().unwrap() = Some(rx);
-    }
-
-    /// Overflow must not block the caller: it is a framework callback thread
-    /// that also serves every other event on its lane.
-    #[tokio::test]
-    async fn a_full_queue_drops_the_arriving_push_without_blocking() {
-        let mut rx = queue()
-            .rx
-            .lock()
-            .unwrap()
-            .take()
-            .expect("no drainer runs in tests");
-
+        // Overflow must not block the caller: it is a framework callback thread
+        // that also serves every other event on its lane. Nothing is drained
+        // meanwhile, so the queue genuinely fills.
         let mut accepted = 0;
         for i in 0..(QUEUE_CAP * 2) {
             if push("npub1full", &format!("[fe80::{i}%3]:4871"), "udp") {
@@ -251,8 +242,12 @@ mod tests {
             "the queue is bounded at {QUEUE_CAP}, accepted {accepted}"
         );
         assert!(accepted > 0, "pushes must get through at all");
+        assert_eq!(
+            drain_now(&mut rx).len(),
+            accepted,
+            "everything accepted is queued, and nothing else is"
+        );
 
-        drain_now(&mut rx, "npub1full");
         *queue().rx.lock().unwrap() = Some(rx);
     }
 }

--- a/myco-core/src/platform_peers.rs
+++ b/myco-core/src/platform_peers.rs
@@ -25,7 +25,7 @@
 //! acceptable either way — platform discovery re-fires periodically.
 //!
 //! There is no withdrawal counterpart, deliberately. Myco's old `peer_lost`
-//! call was a no-op (it named the `udp` transport, which does not override
+//! call was a no-op (the UDP transport does not override
 //! `close_connection`), and the control socket's `disconnect` keys on npub
 //! alone and does a full peer teardown — so a routine Aware NDP drop would
 //! kill a live BLE session to the same peer and suppress its reconnect.
@@ -71,7 +71,10 @@ pub struct PlatformPeer {
     /// A fully-formatted socket address. Link-locals carry a *numeric* scope
     /// (`"[fe80::x%3]:4871"`); interface-name scopes do not parse.
     pub address: String,
-    /// The fips transport type that will carry it. Both lanes ride plain UDP.
+    /// The fips transport that will carry it, qualified with the instance
+    /// name of the lane's own UDP socket (`"udp/aware"`, `"udp/lan"`). Both
+    /// lanes ride UDP, but each has its own socket pinned to its own
+    /// `android.net.Network`, and a dial down the wrong one is unroutable.
     pub transport: String,
 }
 

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -271,15 +271,22 @@ impl AppRuntime {
             // 1Hz for foreground snappiness, but its poll pauses when the app is
             // backgrounded — this loop is what keeps peer-driven relay sync alive
             // then.
+            let control = crate::control_client::ControlClient::new(
+                crate::control_client::socket_path(data_dir),
+            );
+
+            // Platform-discovered peers (Wi-Fi Aware, the AP lane) reach the
+            // node over the same socket. The Kotlin radios push into a bounded
+            // queue from their own callback threads; this task owns the client
+            // and issues `connect`. Spawned once for the process, so it spans
+            // node rebuilds and the window before the first StartNode.
+            crate::platform_peers::spawn_drainer(&rt, control.clone(), node_live.clone());
+
             {
                 let content = content.clone();
                 let peer_cache = peer_cache.clone();
                 let peer_feed = peer_feed.clone();
                 let node_live = node_live.clone();
-                let control =
-                    crate::control_client::ControlClient::new(crate::control_client::socket_path(
-                        data_dir,
-                    ));
                 rt.spawn(async move {
                     let mut tick = tokio::time::interval(std::time::Duration::from_secs(8));
                     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -802,6 +802,12 @@ impl AppRuntime {
             // handshake replies can be lost to a competing validated default
             // network (e.g. cellular).
             crate::udp_fd_bridge::install(node.enable_app_owned_udp_fd());
+            // Hand this node's BLE radio slot to the JNI bridge. The radio
+            // itself belongs to `BleService` and may already be running (it
+            // deliberately does not bounce the node when it starts a fresh
+            // one), so the bridge installs whatever it is holding into the new
+            // slot rather than waiting to be handed a radio.
+            crate::ble_bridge_jni::set_radio_slot(node.enable_app_owned_ble_radio());
         }
         let task = rt.spawn(async move {
             let mut node = node;
@@ -1072,19 +1078,17 @@ impl AppRuntime {
         }
     }
 
-    /// The BLE radio's observed scanning/advertising state, read from the fips
-    /// bridge rather than computed from other flags. `known` is true only when
-    /// the bridge actually resolves (Android, radio started); the host build and
-    /// an absent bridge both report unknown.
-    #[cfg(target_os = "android")]
-    fn ble_radio_state(&self) -> (bool, bool, bool, bool) {
-        match fips::transport::ble::android_io::android_ble_bridge() {
-            Some(b) => (b.is_scanning(), true, b.is_advertising(), true),
-            None => (false, false, false, false),
-        }
-    }
-
-    #[cfg(not(target_os = "android"))]
+    /// The BLE radio's observed scanning/advertising state, as
+    /// `(scanning, scanning_known, advertising, advertising_known)`.
+    ///
+    /// TODO(stage 2): always reports unknown. The flags used to be read back off
+    /// fips's `AndroidBleBridge`, which no longer keeps them — correctly, since
+    /// they were only ever Kotlin's own pushes bouncing off a struct in the
+    /// wrong crate. Restore by mirroring the Aware lane's two Myco-owned
+    /// atomics; the JNI push sites are still there, discarding their argument.
+    /// Diagnostic only: it decides whether the Dev tab renders "scanning" or
+    /// "unknown", nothing more. Reporting unknown is the honest degradation —
+    /// the code has always refused to guess `false`.
     fn ble_radio_state(&self) -> (bool, bool, bool, bool) {
         (false, false, false, false)
     }
@@ -1121,40 +1125,30 @@ impl AppRuntime {
         std::collections::HashMap::new()
     }
 
-    /// Raw scan adverts (address / PSM / RSSI) from the BLE radio bridge. The
-    /// radio is Android-only; on the host there is no bridge.
-    #[cfg(target_os = "android")]
-    fn ble_adverts(&self) -> Vec<BleAdvert> {
-        fips::transport::ble::android_io::android_ble_bridge()
-            .map(|b| {
-                b.advert_views()
-                    .into_iter()
-                    .map(|a| BleAdvert {
-                        addr: a.addr,
-                        psm: a.psm,
-                        rssi: a.rssi,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-
-    #[cfg(not(target_os = "android"))]
+    /// Raw scan adverts (address / PSM / RSSI) seen by the BLE radio.
+    ///
+    /// TODO(stage 2): always empty. `AndroidBleBridge::advert_views()` is gone;
+    /// the bridge forwards each advert straight into the transport's scanner
+    /// channel now and keeps no list. Every advert still crosses
+    /// `bleDeliverScan` in `ble_bridge_jni`, so the cheapest restoration is a
+    /// small Myco-owned ring populated there. Diagnostic only: this feeds
+    /// `AppState.ble_adverts` and the merge step that collapses an advert onto
+    /// an existing peer row.
     fn ble_adverts(&self) -> Vec<BleAdvert> {
         Vec::new()
     }
 
-    /// Per-peer BLE connect-attempt history from the fips transport's process-
-    /// global log. The BLE transport only runs on Android; on the host there are
-    /// no attempts to report, so the merge sees an empty slice and every row
-    /// renders as having no recorded history.
-    #[cfg(target_os = "android")]
-    fn ble_attempts(&self) -> Vec<fips::transport::ble::attempts::BlePeerAttempts> {
-        fips::transport::ble::attempts::ble_attempt_log().snapshot()
-    }
-
-    #[cfg(not(target_os = "android"))]
-    fn ble_attempts(&self) -> Vec<fips::transport::ble::attempts::BlePeerAttempts> {
+    /// Per-peer BLE connect-attempt history.
+    ///
+    /// TODO(stage 2): always empty, so every Dev-tab row renders as having no
+    /// recorded history. `fips::transport::ble::attempts` is gone; the restacked
+    /// transport counts connect outcomes into `BleStats`, readable over the
+    /// control socket's `show_transports`. Note the shape gap before wiring it:
+    /// those are aggregate counters per transport, and these are per-attempt
+    /// records keyed by BLE address. Diagnostic only — verified by tracing every
+    /// consumer (`AttemptStore`, `merge_peers`, `AppState.peers`, the Kotlin Dev
+    /// tab); nothing branches on it.
+    fn ble_attempts(&self) -> Vec<crate::ble_diag::BlePeerAttempts> {
         Vec::new()
     }
 

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -1288,16 +1288,28 @@ impl AppRuntime {
     }
 
     /// The BLE radio's observed scanning/advertising state, as
-    /// `(scanning, scanning_known, advertising, advertising_known)`.
+    /// `(scanning, scanning_known, advertising, advertising_known)`, read from
+    /// the BLE bridge's process-global flags rather than derived from other
+    /// flags. Each `known` is false until Kotlin has pushed at least once (or
+    /// on the host build, where the BLE bridge does not exist) — the UI renders
+    /// unknown rather than guessing false.
     ///
-    /// TODO(stage 2): always reports unknown. The flags used to be read back off
-    /// fips's `AndroidBleBridge`, which no longer keeps them — correctly, since
-    /// they were only ever Kotlin's own pushes bouncing off a struct in the
-    /// wrong crate. Restore by mirroring the Aware lane's two Myco-owned
-    /// atomics; the JNI push sites are still there, discarding their argument.
-    /// Diagnostic only: it decides whether the Dev tab renders "scanning" or
-    /// "unknown", nothing more. Reporting unknown is the honest degradation —
-    /// the code has always refused to guess `false`.
+    /// Diagnostic only: it decides whether the Dev tab's radio self-check card
+    /// renders "active"/"idle" or "unknown", nothing more.
+    #[cfg(target_os = "android")]
+    fn ble_radio_state(&self) -> (bool, bool, bool, bool) {
+        let (scanning, scanning_known) = match crate::ble_bridge_jni::ble_scanning() {
+            Some(v) => (v, true),
+            None => (false, false),
+        };
+        let (advertising, advertising_known) = match crate::ble_bridge_jni::ble_advertising() {
+            Some(v) => (v, true),
+            None => (false, false),
+        };
+        (scanning, scanning_known, advertising, advertising_known)
+    }
+
+    #[cfg(not(target_os = "android"))]
     fn ble_radio_state(&self) -> (bool, bool, bool, bool) {
         (false, false, false, false)
     }

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -44,12 +44,11 @@ const LAN_UDP_PORT: u16 = 4871;
 /// path (which this reuses) is already UDP + scoped link-local IPv6.
 /// See docs/design/wifi-aware-interop.md.
 ///
-/// **This is a flag day between phones.** The port is embedded in the address
-/// each phone advertises over Aware (`AwareRadio` formats
-/// `"[fe80::x%ifindex]:port"` from `AppState.wifi_aware.port`), so two phones
-/// on either side of this change will not peer over Aware until both are
-/// flashed. Nothing else is affected — the Aware lane carried no traffic
-/// before this change, and desktop LAN peers stay on [`LAN_UDP_PORT`].
+/// **Not a flag day.** Each phone advertises this port to its peers in the
+/// Aware identity exchange and is dialled at the port it advertised, so a
+/// phone on a build from before this port existed — which advertises no port
+/// and listens on [`LAN_UDP_PORT`] — is still reachable. `AwareRadio` formats
+/// `"[fe80::x%ifindex]:<peer's port>"`; see its `parsePeer`.
 const AWARE_UDP_PORT: u16 = 4872;
 
 /// Which UDP transport instance a Kotlin radio's lane rides.

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -383,23 +383,26 @@ impl AppRuntime {
         config.node.identity.nsec = Some(nsec);
         config.node.identity.persistent = true;
         config.tun.enabled = false;
-        // No built-in DNS responder: we answer `.fips` ourselves in the TUN pump
-        // (`dns_intercept`), because on Android there is no system DNS socket to
-        // bind — the OS resolver is pointed at the in-mesh sentinel instead.
+        // The built-in `.fips` responder runs, and Myco proxies to it.
         //
-        // This must be off, not merely unused. `dns.enabled` defaults to *true*,
-        // and the responder's start-up in `Node::start` assigns
-        // `self.dns_identity_rx`, clobbering the receiver that
-        // `enable_app_owned_dns()` installed moments earlier. Our sender in
-        // `dns_intercept` is then attached to a dropped receiver, so every
-        // `try_send` of a resolved identity fails silently and nothing is ever
-        // registered. The name still resolves — the interceptor answers the
-        // packet regardless — so the only visible symptom is that the first
-        // packet to a freshly-resolved `<npub>.fips` gets ICMPv6 "No route".
-        // That looks like a routing/distance bug, but reproduces with no peers
-        // at all: direct neighbours mask it because their identity comes from
-        // the Noise handshake, never from resolution.
-        config.dns.enabled = false;
+        // Android has no system DNS socket to point at the responder — the
+        // VpnService aims the OS resolver into the tunnel, so queries surface
+        // as IPv6/UDP packets on the app's own fd. Myco still owns the packet
+        // plane, but it lifts the DNS payload out and forwards it here instead
+        // of resolving in-app: answering a `<npub>.fips` query is what puts
+        // that peer's public key in the node's identity cache, and the key
+        // cannot be recovered from the mesh address.
+        //
+        // This is the inversion of the previous fix, not a regression of it.
+        // Before, Myco answered and pushed identities *into* the node over a
+        // channel that the responder's own start-up then overwrote — so the
+        // responder had to be off. Now there is no app-owned channel to
+        // clobber, and the responder being off is what would break warming.
+        //
+        // Port 0: the address is read back off the bound socket via
+        // `dns_local_addr()`, so the kernel picks and nothing squats on 5354.
+        config.dns.enabled = true;
+        config.dns.port = Some(0);
         // The control socket is now load-bearing, not an operator convenience:
         // it carries peer state (`show_peers`, the 8s tick) and every
         // platform-discovered peer push (`connect`). Without it the Wi-Fi Aware
@@ -791,11 +794,6 @@ impl AppRuntime {
             let max_mss = node.effective_ipv6_mtu().saturating_sub(60);
             let (tun_outbound_tx, tun_inbound_rx) = node.enable_app_owned_tun();
             crate::tun_bridge::install(tun_outbound_tx, tun_inbound_rx, max_mss);
-            // Wire the app-owned DNS interceptor's identity channel into the node
-            // so resolving `<npub>.fips` warms the route (caches the pubkey), the
-            // same side effect fips's own DNS responder has. Without this the
-            // first packet to a resolved address has no session and is dropped.
-            crate::dns_intercept::set_identity_tx(node.enable_app_owned_dns());
             // Let Android learn the UDP transport's raw fd once it opens, so it
             // can pin the socket to whichever local-only network (Wi-Fi Aware
             // NDP, the `!FIPS` AP) carries a platform-pushed peer — otherwise
@@ -815,6 +813,20 @@ impl AppRuntime {
                 tracing::error!("fips node start failed: {e}");
                 return;
             }
+            // Publish where the built-in `.fips` responder bound, so the TUN
+            // pump can forward queries to it. This has to happen *here*, inside
+            // the task: `dns_local_addr()` is only meaningful after `start()`
+            // returns, and `run_rx_loop` below borrows the node for the rest of
+            // its life, so this is the only moment a `&Node` exists and the
+            // value is settled. `None` means the responder never came up (its
+            // bind only warns), and `.fips` then resolves to nothing rather
+            // than to an address the node has no key for.
+            let dns_addr = node.dns_local_addr();
+            match dns_addr {
+                Some(addr) => tracing::info!(%addr, "fips DNS responder listening"),
+                None => tracing::warn!("fips DNS responder is not running; .fips will not resolve"),
+            }
+            crate::dns_intercept::set_responder_addr(dns_addr);
             // Runs until the packet channel closes or the task is aborted.
             if let Err(e) = node.run_rx_loop().await {
                 tracing::warn!("fips rx loop ended: {e}");
@@ -835,6 +847,9 @@ impl AppRuntime {
             task.abort();
         }
         self.node_live.store(false, Ordering::Relaxed);
+        // The responder dies with the node; leaving its address published would
+        // send every `.fips` query to a closed socket.
+        crate::dns_intercept::set_responder_addr(None);
         self.peer_cache.lock().unwrap().clear();
         *self.peer_feed.lock().unwrap() = PeerFeedHealth::default();
         self.node_running = false;

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -1,13 +1,14 @@
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use fips::control::read_handle::ControlReadHandle;
 use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
 
 use crate::action::NativeAppAction;
 use crate::content::{CacheView, Content};
+use crate::control_client::PeerView;
 use crate::identity_store;
 use crate::state::{
     AppState, BleAdvert, BlePeer, BleStatus, IdentityView, NodeStatus, WifiAwareStatus,
@@ -20,6 +21,33 @@ use crate::state::{
 /// path (which this reuses) is already UDP + scoped link-local IPv6.
 /// See docs/design/wifi-aware-interop.md.
 const WIFI_AWARE_PORT: u16 = 4871;
+
+/// Consecutive failed `show_peers` queries before the peer feed is reported as
+/// broken in [`AppState::error`].
+///
+/// A failure on the first tick after `StartNode` is normal: fips binds the
+/// control socket *inside* `run_rx_loop`, which only begins after
+/// `node.start()` completes, so there is a startup window where the node is up
+/// and the socket is not yet accepting. Three ticks is ~24s — long past that
+/// window, and short enough to be visible while the fault is still on screen.
+///
+/// Shouting matters because the failure is otherwise invisible at every layer
+/// at once: the Dev tab's peer rows come from this same source so they read as
+/// "no peers nearby", the relay-reachability rows come from the relay pool and
+/// keep populating, and the radios' own diagnostics are Myco-owned and keep
+/// reporting "discovering". A bind failure in fips only warns and lets its task
+/// exit; the node keeps running.
+const PEER_FEED_FAILURES_BEFORE_ERROR: u32 = 3;
+
+/// How the control-socket peer feed is doing. Written by the 8s tick (a
+/// detached task with no `&mut self`), read synchronously by `state()`.
+#[derive(Clone, Debug, Default)]
+struct PeerFeedHealth {
+    /// Failed queries since the last success. Reset to zero on any success.
+    consecutive_failures: u32,
+    /// The most recent failure's reason, for the error banner.
+    last_error: String,
+}
 
 /// The app runtime behind the FFI. Owns the device identity, a multi-thread
 /// Tokio runtime, and the embedded fips node. A `Mutex<AppRuntime>` is what the
@@ -45,9 +73,10 @@ pub struct AppRuntime {
     rt: Option<Runtime>,
     /// The embedded fips node, held until `StartNode` moves it into the loop task.
     node: Option<fips::Node>,
-    /// Lock-free read view of the running node's peer state (cloned out of the
-    /// node before it moves into the loop task; safe to read while the loop runs).
-    read_handle: Option<ControlReadHandle>,
+    /// Whether the node's loop task is live, shared with the detached 8s tick so
+    /// it does not query a control socket that cannot exist yet. Mirrors
+    /// `node_running`, which the tick has no `&self` to read.
+    node_live: Arc<AtomicBool>,
     /// The background task running `node.start()` + `run_rx_loop()`. Aborting it
     /// drops the node and stops its transports.
     loop_task: Option<JoinHandle<()>>,
@@ -57,11 +86,17 @@ pub struct AppRuntime {
     /// Latest dev-menu peer speedtest result; written by the spawned run task and
     /// read back into `state()`. Shared so the async task can update it in place.
     speedtest: Arc<std::sync::Mutex<crate::state::SpeedtestView>>,
-    /// Read-handle slot shared with the keepwarm loop (populated on StartNode,
-    /// cleared on StopNode). The keepwarm tick feeds mesh connectivity to the
-    /// content layer from here, so peer-driven relay sync keeps working while
-    /// the app is backgrounded and the UI's `state()` poll is paused.
-    shared_read: Arc<std::sync::Mutex<Option<ControlReadHandle>>>,
+    /// Last peer snapshot the 8s tick pulled off the control socket.
+    ///
+    /// `state()` runs on the FFI thread holding the reducer mutex and must
+    /// never block, so it reads this cache rather than querying. That is a real
+    /// change from the lock-free `peer_views()` read it replaces: the Dev tab's
+    /// peer rows are now up to 8s stale.
+    peer_cache: Arc<std::sync::Mutex<Vec<PeerView>>>,
+    /// Whether the peer feed is working, so an unbound control socket surfaces
+    /// as an error instead of an empty room. See
+    /// [`PEER_FEED_FAILURES_BEFORE_ERROR`].
+    peer_feed: Arc<std::sync::Mutex<PeerFeedHealth>>,
     /// Crash-surviving history for the BLE attempt log (D-13). Shared so the
     /// rate-limited flush can be spawned onto the tokio runtime rather than
     /// running on the FFI thread. `None` only on a startup error, in which case
@@ -118,9 +153,14 @@ impl AppRuntime {
         // file makes this idempotent and lets a user who removes it stay removed.
         seed_default_sites(&content, &rt, Path::new(data_dir));
 
-        // Read-handle slot for the keepwarm loop; populated once the node starts.
-        let shared_read: Arc<std::sync::Mutex<Option<ControlReadHandle>>> =
-            Arc::new(std::sync::Mutex::new(None));
+        // Peer state now comes off the node's control socket, so the tick needs
+        // somewhere to publish it and somewhere to record whether the feed
+        // works at all. Both are read synchronously by `state()`.
+        let peer_cache: Arc<std::sync::Mutex<Vec<PeerView>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let peer_feed: Arc<std::sync::Mutex<PeerFeedHealth>> =
+            Arc::new(std::sync::Mutex::new(PeerFeedHealth::default()));
+        let node_live = Arc::new(AtomicBool::new(false));
 
         // Serve the relay + Blossom over the mesh so paired peers can pull this
         // device's nsites at ws://<npub>.fips:4870 / http://<npub>.fips:24243.
@@ -233,26 +273,59 @@ impl AppRuntime {
             // then.
             {
                 let content = content.clone();
-                let shared_read = shared_read.clone();
+                let peer_cache = peer_cache.clone();
+                let peer_feed = peer_feed.clone();
+                let node_live = node_live.clone();
+                let control =
+                    crate::control_client::ControlClient::new(crate::control_client::socket_path(
+                        data_dir,
+                    ));
                 rt.spawn(async move {
                     let mut tick = tokio::time::interval(std::time::Duration::from_secs(8));
                     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
                     loop {
                         tick.tick().await;
-                        let handle = shared_read.lock().unwrap().clone();
-                        if let Some(h) = handle {
-                            let connected: Vec<String> = h
-                                .peer_views()
-                                .into_iter()
-                                .filter(|p| p.connected && !p.npub.is_empty())
-                                .map(|p| p.npub)
-                                .collect();
-                            content.set_connected_peers(connected);
-                            if !content.circle_npubs().is_empty() {
-                                for addr in content.retriable_library_addrs() {
-                                    let content = content.clone();
-                                    tokio::spawn(
-                                        async move { content.open_site(addr, None).await },
+                        // Nothing binds the socket until the node's rx loop is
+                        // up; querying before then would only manufacture
+                        // failures for the health counter to shout about.
+                        if node_live.load(Ordering::Relaxed) {
+                            match control.show_peers().await {
+                                Ok(peers) => {
+                                    let connected: Vec<String> = peers
+                                        .iter()
+                                        .filter(|p| p.connected && !p.npub.is_empty())
+                                        .map(|p| p.npub.clone())
+                                        .collect();
+                                    *peer_cache.lock().unwrap() = peers;
+                                    {
+                                        let mut health = peer_feed.lock().unwrap();
+                                        health.consecutive_failures = 0;
+                                        health.last_error.clear();
+                                    }
+                                    content.set_connected_peers(connected);
+                                    if !content.circle_npubs().is_empty() {
+                                        for addr in content.retriable_library_addrs() {
+                                            let content = content.clone();
+                                            tokio::spawn(async move {
+                                                content.open_site(addr, None).await
+                                            });
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    // The last snapshot is deliberately kept:
+                                    // stale peer rows plus a visible error beat
+                                    // an empty list that reads as a quiet room.
+                                    let mut health = peer_feed.lock().unwrap();
+                                    health.consecutive_failures =
+                                        health.consecutive_failures.saturating_add(1);
+                                    health.last_error = e.clone();
+                                    let n = health.consecutive_failures;
+                                    drop(health);
+                                    tracing::warn!(
+                                        error = %e,
+                                        consecutive_failures = n,
+                                        "peer state query failed"
                                     );
                                 }
                             }
@@ -275,11 +348,12 @@ impl AppRuntime {
             node_status: "fips node constructed (not started)".to_string(),
             rt: Some(rt),
             node: Some(node),
-            read_handle: None,
+            node_live,
             loop_task: None,
             content: Some(content),
             speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
-            shared_read,
+            peer_cache,
+            peer_feed,
             // Load once here; a missing file is an empty history, and an
             // unreadable one degrades to empty rather than failing the launch.
             attempt_store: Some(Arc::new(crate::attempt_store::AttemptStore::load(
@@ -319,10 +393,18 @@ impl AppRuntime {
         // at all: direct neighbours mask it because their identity comes from
         // the Noise handshake, never from resolution.
         config.dns.enabled = false;
-        // No control socket: peer state is read via the in-process control read
-        // handle (peer_views), not the Unix socket. The tick publishes the
-        // snapshot regardless of this flag.
-        config.node.control.enabled = false;
+        // The control socket is now load-bearing, not an operator convenience:
+        // it carries peer state (`show_peers`, the 8s tick) and every
+        // platform-discovered peer push (`connect`). Without it the Wi-Fi Aware
+        // and AP lanes carry no peers at all.
+        //
+        // The default path resolves `/run/fips` → `$XDG_RUNTIME_DIR` → `/tmp`,
+        // none of which an Android app UID can write, so it is pointed at
+        // app-private storage. Verified on device under SELinux Enforcing: the
+        // socket binds with the app's own `app_data_file` label, and a stale
+        // file from a force-stop is removed and rebound on the next launch.
+        config.node.control.enabled = true;
+        config.node.control.socket_path = crate::control_client::socket_path(data_dir);
         // On Android, configure a BLE transport instance so node.start() brings up
         // the AndroidIo backend (the Kotlin radio drives it via the injected
         // bridge). Host builds have no BLE backend, so this is Android-only.
@@ -369,11 +451,12 @@ impl AppRuntime {
             node_status: "error".to_string(),
             rt: None,
             node: None,
-            read_handle: None,
+            node_live: Arc::new(AtomicBool::new(false)),
             loop_task: None,
             content: None,
             speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
-            shared_read: Arc::new(std::sync::Mutex::new(None)),
+            peer_cache: Arc::new(std::sync::Mutex::new(Vec::new())),
+            peer_feed: Arc::new(std::sync::Mutex::new(PeerFeedHealth::default())),
             // No valid data dir on this path, so there is nowhere to persist to.
             // Attempts still render live; they just do not survive a restart.
             attempt_store: None,
@@ -713,9 +796,6 @@ impl AppRuntime {
             // network (e.g. cellular).
             crate::udp_fd_bridge::install(node.enable_app_owned_udp_fd());
         }
-        // Clone the lock-free read handle out before the node moves into the loop
-        // task — peer state is then readable while run_rx_loop owns the node.
-        let handle = node.control_read_handle();
         let task = rt.spawn(async move {
             let mut node = node;
             if let Err(e) = node.start().await {
@@ -727,8 +807,10 @@ impl AppRuntime {
                 tracing::warn!("fips rx loop ended: {e}");
             }
         });
-        *self.shared_read.lock().unwrap() = Some(handle.clone());
-        self.read_handle = Some(handle);
+        // The control socket is bound inside `run_rx_loop`, so peer queries only
+        // start making sense once this flag is up — and even then not for the
+        // first tick or two.
+        self.node_live.store(true, Ordering::Relaxed);
         self.loop_task = Some(task);
         self.node_running = true;
         self.node_status = "running".to_string();
@@ -739,8 +821,9 @@ impl AppRuntime {
         if let Some(task) = self.loop_task.take() {
             task.abort();
         }
-        *self.shared_read.lock().unwrap() = None;
-        self.read_handle = None;
+        self.node_live.store(false, Ordering::Relaxed);
+        self.peer_cache.lock().unwrap().clear();
+        *self.peer_feed.lock().unwrap() = PeerFeedHealth::default();
         self.node_running = false;
         self.node_status = "stopped".to_string();
     }
@@ -759,14 +842,11 @@ impl AppRuntime {
     }
 
     pub fn state(&self) -> AppState {
-        // Live peers, read lock-free from the node's tick-published snapshot
-        // (empty until the loop runs / peers are seen). On Android every peer is
-        // a BLE peer (the only transport configured).
-        let peer_views = self
-            .read_handle
-            .as_ref()
-            .map(|h| h.peer_views())
-            .unwrap_or_default();
+        // Peers as of the last 8s tick. `state()` holds the reducer mutex on the
+        // FFI thread, so it must never query the control socket itself — a
+        // connect + write + read with a 5s timeout is not a drop-in for the
+        // lock-free snapshot read this replaces.
+        let peer_views: Vec<PeerView> = self.peer_cache.lock().unwrap().clone();
 
         let ble_peers: Vec<BlePeer> = peer_views
             .iter()
@@ -883,7 +963,7 @@ impl AppRuntime {
 
         AppState {
             rev: self.rev,
-            error: self.error.clone(),
+            error: self.error_with_feed_health(),
             app_version: self.app_version.clone(),
             identity: self.identity.clone(),
             node: NodeStatus {
@@ -958,6 +1038,30 @@ impl AppRuntime {
                 .unwrap_or_default(),
             speedtest: self.speedtest.lock().unwrap().clone(),
             peers,
+        }
+    }
+
+    /// `self.error` plus, once the peer feed has failed
+    /// [`PEER_FEED_FAILURES_BEFORE_ERROR`] ticks running, a line saying so.
+    ///
+    /// The tick is a detached task with no `&mut self`, so it cannot write
+    /// `self.error` itself; it records into a shared health slot and the banner
+    /// is composed here. Without this the only symptom of an unbound control
+    /// socket is an empty peer list, which is exactly what a room with no peers
+    /// in it looks like.
+    fn error_with_feed_health(&self) -> String {
+        let health = self.peer_feed.lock().unwrap();
+        if health.consecutive_failures < PEER_FEED_FAILURES_BEFORE_ERROR {
+            return self.error.clone();
+        }
+        let note = format!(
+            "peer state unavailable ({} failed queries): {}",
+            health.consecutive_failures, health.last_error
+        );
+        if self.error.is_empty() {
+            note
+        } else {
+            format!("{}; {note}", self.error)
         }
     }
 
@@ -1196,19 +1300,25 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Every subsystem we run ourselves in-process must be switched off in the
-    /// node's config, not merely left unused.
+    /// Which of the node's subsystems Myco runs itself, and which it now
+    /// depends on the node to run. Getting either wrong is silent.
     ///
-    /// `dns` is the one that bites: it defaults to *enabled*, and the built-in
-    /// responder's start-up assigns `dns_identity_rx`, discarding the receiver
-    /// `enable_app_owned_dns()` installed. The identity sender in
-    /// `dns_intercept` is then orphaned and silently drops every resolved
-    /// identity, so a freshly-resolved `<npub>.fips` answers its AAAA but the
-    /// first packet to it is rejected with ICMPv6 "No route". Direct neighbours
-    /// hide the breakage (their identity comes from the Noise handshake), which
-    /// is what made it read as a multi-hop routing fault.
+    /// The TUN stays app-owned: the VpnService holds the fd, so a system TUN
+    /// would be a second, competing packet plane.
+    ///
+    /// `dns` is now **on**, and that is the inversion. Myco used to answer
+    /// `.fips` itself and push each resolved identity into the node over a
+    /// channel; the responder's own start-up clobbered the receiver on that
+    /// channel, so route warming silently stopped and the first packet to a
+    /// freshly-resolved `<npub>.fips` came back "No route". The fix then was to
+    /// switch the responder off. The fix now is the opposite: the responder
+    /// runs, publishes where it bound, and Myco forwards `.fips` queries to it
+    /// — so registering the identity is the responder's own side effect and
+    /// there is no app-owned channel left to clobber.
+    ///
+    /// `control` is on because peer state and every platform peer push ride it.
     #[test]
-    fn in_process_subsystems_are_disabled_in_node_config() {
+    fn node_config_matches_who_owns_each_subsystem() {
         let dir = temp_dir("owned-subsystems");
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("temp data dir");
@@ -1218,17 +1328,59 @@ mod tests {
         let config = node.config();
 
         assert!(
-            !config.dns.enabled,
-            "fips's DNS responder must be off — it would clobber the app-owned \
-             DNS identity channel and silently strip route warming"
+            config.dns.enabled,
+            "fips's DNS responder must be on — Myco proxies `.fips` queries to \
+             it, and answering them is what warms the route"
         );
         assert!(
             !config.tun.enabled,
             "the TUN is app-owned (VpnService holds the fd)"
         );
         assert!(
-            !config.node.control.enabled,
-            "peer state is read via the in-process control read handle"
+            config.node.control.enabled,
+            "peer state and platform peer pushes both ride the control socket"
+        );
+        assert_eq!(
+            config.node.control.socket_path,
+            crate::control_client::socket_path(dir.to_str().unwrap()),
+            "the default path resolves to /run, $XDG_RUNTIME_DIR or /tmp — none \
+             writable by an Android app UID"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A broken peer feed must not look like an empty room. Three consecutive
+    /// failures is the threshold; below it the banner stays clean, because the
+    /// socket is bound inside `run_rx_loop` and the first tick after StartNode
+    /// legitimately races it.
+    #[test]
+    fn a_sustained_peer_feed_failure_reaches_the_error_banner() {
+        let dir = temp_dir("peer-feed-health");
+        let _ = std::fs::remove_dir_all(&dir);
+        let rt = AppRuntime::new(dir.to_str().unwrap(), "0.0.1");
+
+        assert!(rt.state().error.is_empty(), "healthy by default");
+
+        {
+            let mut health = rt.peer_feed.lock().unwrap();
+            health.consecutive_failures = PEER_FEED_FAILURES_BEFORE_ERROR - 1;
+            health.last_error = "connect: No such file or directory".to_string();
+        }
+        assert!(
+            rt.state().error.is_empty(),
+            "a startup-window failure must not shout"
+        );
+
+        rt.peer_feed.lock().unwrap().consecutive_failures = PEER_FEED_FAILURES_BEFORE_ERROR;
+        let error = rt.state().error;
+        assert!(
+            error.contains("peer state unavailable"),
+            "sustained failure must be visible, got: {error}"
+        );
+        assert!(
+            error.contains("No such file or directory"),
+            "the reason must survive into the banner, got: {error}"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -14,13 +14,58 @@ use crate::state::{
     AppState, BleAdvert, BlePeer, BleStatus, IdentityView, NodeStatus, WifiAwareStatus,
 };
 
+/// The node runs **two** UDP transport instances, not one, and everything
+/// below names them.
+///
+/// One socket cannot serve both lanes. Android routes by the network a socket
+/// is *marked* with, not by destination alone: `Network.bindSocket` pins a
+/// descriptor to one `android.net.Network`, and a socket pinned to
+/// infrastructure Wi-Fi cannot reach a Wi-Fi Aware peer, whose NDP is a
+/// separate `Network` with its own routing table. With a single shared socket
+/// the AP lane's bind won, so Aware discovery worked end to end (match, npub
+/// exchange, NDP up) and then every dial over it timed out in the handshake.
+///
+/// So: one instance per lane, each pinned by its own Kotlin radio (see
+/// [`crate::udp_fd_bridge`]), and peer addresses qualified with the instance
+/// name (`"udp/lan"`, `"udp/aware"`) so fips dials down the lane the peer was
+/// actually observed on rather than whichever transport id sorted lowest.
+const LAN_UDP_INSTANCE: &str = "lan";
+const AWARE_UDP_INSTANCE: &str = "aware";
+
+/// UDP port for the LAN / `!FIPS` AP lane. Unchanged at 4871: this lane talks
+/// to desktop fips nodes today and works, and desktop peers are discovered by
+/// mDNS advert, so moving it would break a working lane for nothing.
+const LAN_UDP_PORT: u16 = 4871;
+
 /// UDP port for the Wi-Fi Aware bulk lane. Both peers bind it on the NDP
 /// interface and exchange over it — symmetric, no listener/dialer roles. A
 /// fixed app constant (we bind our own port), so there is no PSM-style
 /// discovery problem. UDP is fips's native transport and the LAN-discovery
 /// path (which this reuses) is already UDP + scoped link-local IPv6.
 /// See docs/design/wifi-aware-interop.md.
-const WIFI_AWARE_PORT: u16 = 4871;
+///
+/// **This is a flag day between phones.** The port is embedded in the address
+/// each phone advertises over Aware (`AwareRadio` formats
+/// `"[fe80::x%ifindex]:port"` from `AppState.wifi_aware.port`), so two phones
+/// on either side of this change will not peer over Aware until both are
+/// flashed. Nothing else is affected — the Aware lane carried no traffic
+/// before this change, and desktop LAN peers stay on [`LAN_UDP_PORT`].
+const AWARE_UDP_PORT: u16 = 4872;
+
+/// Which UDP transport instance a Kotlin radio's lane rides.
+///
+/// `lane` is the label the radio itself pushes (`AwareRadio` sends `"aware"`,
+/// `ApRadio` sends `"udp"`); this is the single place it is turned into a fips
+/// instance name, so the name a socket is pinned by and the name a dial is
+/// routed by cannot drift apart. Anything unrecognised is the AP lane, which
+/// is the one that behaves as UDP always has.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub(crate) fn udp_instance_for_lane(lane: &str) -> &'static str {
+    match lane {
+        "aware" => AWARE_UDP_INSTANCE,
+        _ => LAN_UDP_INSTANCE,
+    }
+}
 
 /// Consecutive failed `show_peers` queries before the peer feed is reported as
 /// broken in [`AppState::error`].
@@ -456,24 +501,32 @@ impl AppRuntime {
                     ..Default::default()
                 });
         }
-        // The Wi-Fi Aware bulk lane: a UDP transport bound `[::]:4871`. UDP is
+        // Two UDP transports, one per lane — see the instance constants at the
+        // top of this file for why one socket cannot serve both. UDP is
         // symmetric (no listener/dialer), fips-native, and reuses the proven
         // scoped-link-local path. Peers are supplied only by the platform peer
-        // queue (`fips::discovery::platform`) — UDP is not advertised on Nostr
-        // and no peer config points here — so `offline_only` semantics survive.
+        // queue — UDP is not advertised on Nostr and no peer config points
+        // here — so `offline_only` semantics survive.
         //
-        // It is configured UNCONDITIONALLY on Android (like the BLE transport
-        // above), not gated on the Aware toggle: the toggle then controls only
-        // the Kotlin radio (whether peers get pushed), never the node's
-        // transport set — so flipping Wi-Fi Aware never restarts the node and
-        // never disrupts an active BLE link. `wifi_aware` still adds it on the
-        // host for the LAN-based dev/test stand-in.
+        // Both are configured UNCONDITIONALLY on Android (like the BLE
+        // transport above), not gated on the Aware toggle: the toggle then
+        // controls only the Kotlin radio (whether peers get pushed), never the
+        // node's transport set — so flipping Wi-Fi Aware never restarts the
+        // node and never disrupts an active BLE link. `wifi_aware` still adds
+        // them on the host for the LAN-based dev/test stand-in.
         if wifi_aware || cfg!(target_os = "android") {
-            config.transports.udp =
-                fips::config::TransportInstances::Single(fips::config::UdpConfig {
-                    bind_addr: Some(format!("[::]:{WIFI_AWARE_PORT}")),
-                    ..Default::default()
-                });
+            let udp = |port: u16| fips::config::UdpConfig {
+                bind_addr: Some(format!("[::]:{port}")),
+                ..Default::default()
+            };
+            config.transports.udp = fips::config::TransportInstances::Named(
+                [
+                    (LAN_UDP_INSTANCE.to_string(), udp(LAN_UDP_PORT)),
+                    (AWARE_UDP_INSTANCE.to_string(), udp(AWARE_UDP_PORT)),
+                ]
+                .into_iter()
+                .collect(),
+            );
         }
         fips::Node::new(config).map_err(|e| anyhow::anyhow!("fips Node::new failed: {e}"))
     }
@@ -881,11 +934,14 @@ impl AppRuntime {
             let max_mss = node.effective_ipv6_mtu().saturating_sub(60);
             let (tun_outbound_tx, tun_inbound_rx) = node.enable_app_owned_tun();
             crate::tun_bridge::install(tun_outbound_tx, tun_inbound_rx, max_mss);
-            // Let Android learn the UDP transport's raw fd once it opens, so it
-            // can pin the socket to whichever local-only network (Wi-Fi Aware
-            // NDP, the `!FIPS` AP) carries a platform-pushed peer — otherwise
-            // handshake replies can be lost to a competing validated default
-            // network (e.g. cellular).
+            // Let Android learn each UDP transport's raw fd once it opens, so
+            // every lane can pin its own socket to its own local-only network
+            // (the Wi-Fi Aware NDP, the `!FIPS` AP) — otherwise handshake
+            // replies are lost to a competing validated default network (e.g.
+            // cellular), and worse, a socket pinned to one lane's network
+            // cannot reach the other lane's peers at all. Deliveries are
+            // labelled with the instance name, so a radio can only ever be
+            // handed its own descriptor.
             crate::udp_fd_bridge::install(node.enable_app_owned_udp_fd());
             // Hand this node's BLE radio slot to the JNI bridge. The radio
             // itself belongs to `BleService` and may already be running (it
@@ -1216,7 +1272,7 @@ impl AppRuntime {
                 WifiAwareStatus {
                     enabled: self.wifi_aware_enabled,
                     port: if self.wifi_aware_enabled {
-                        WIFI_AWARE_PORT
+                        AWARE_UDP_PORT
                     } else {
                         0
                     },

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -39,6 +39,17 @@ const WIFI_AWARE_PORT: u16 = 4871;
 /// exit; the node keeps running.
 const PEER_FEED_FAILURES_BEFORE_ERROR: u32 = 3;
 
+/// How long a `StopNode` waits for the node's own graceful teardown before
+/// giving up and aborting the loop task.
+///
+/// fips bounds the drain itself with `node.drain_timeout_secs` (2s by default)
+/// and the teardown after it is a handful of `abort()`s plus a best-effort
+/// `stop_advertising`, so this only has to be comfortably longer than that.
+/// Reaching it means the transports leaked — exactly the failure the graceful
+/// path exists to prevent — so it is logged at error level, and the abort is the
+/// last resort that keeps the toggle from wedging forever.
+const NODE_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// How the control-socket peer feed is doing. Written by the 8s tick (a
 /// detached task with no `&mut self`), read synchronously by `state()`.
 #[derive(Clone, Debug, Default)]
@@ -77,9 +88,24 @@ pub struct AppRuntime {
     /// it does not query a control socket that cannot exist yet. Mirrors
     /// `node_running`, which the tick has no `&self` to read.
     node_live: Arc<AtomicBool>,
-    /// The background task running `node.start()` + `run_rx_loop()`. Aborting it
-    /// drops the node and stops its transports.
+    /// The background task running `node.start()`, the rx loop, and the node's
+    /// own graceful teardown. It is *completing* — not aborting — that stops the
+    /// transports; see [`AppRuntime::stop_node`].
     loop_task: Option<JoinHandle<()>>,
+    /// Fires the rx loop's shutdown signal. Sending on it (or dropping it) makes
+    /// `Node::run_rx_loop_with_shutdown` enter fips's bounded drain and return,
+    /// after which the loop task calls `Node::finish_shutdown` and the
+    /// transports are genuinely down.
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    /// Set at `StopNode` and cleared only once the loop task has actually
+    /// finished. [`AppRuntime::start_node`] refuses to build a second node while
+    /// it is set: two live nodes fighting over the single Kotlin BLE radio is
+    /// the failure this whole dance exists to prevent. Shared and atomic because
+    /// the detached watchdog that clears it has no `&mut self`.
+    stopping: Arc<AtomicBool>,
+    /// A `StartNode` that arrived while `stopping` was still set, replayed by
+    /// [`AppRuntime::poll_pending_start`] on the next state read.
+    start_pending: bool,
     /// The content layer (embedded relay + Blossom + gateway + Library). `None`
     /// only on a startup error (no valid data dir).
     content: Option<Arc<Content>>,
@@ -357,6 +383,9 @@ impl AppRuntime {
             node: Some(node),
             node_live,
             loop_task: None,
+            shutdown_tx: None,
+            stopping: Arc::new(AtomicBool::new(false)),
+            start_pending: false,
             content: Some(content),
             speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
             peer_cache,
@@ -415,6 +444,7 @@ impl AppRuntime {
         // file from a force-stop is removed and rebound on the next launch.
         config.node.control.enabled = true;
         config.node.control.socket_path = crate::control_client::socket_path(data_dir);
+        Self::clear_control_socket(&config.node.control.socket_path);
         // On Android, configure a BLE transport instance so node.start() brings up
         // the AndroidIo backend (the Kotlin radio drives it via the injected
         // bridge). Host builds have no BLE backend, so this is Android-only.
@@ -448,6 +478,34 @@ impl AppRuntime {
         fips::Node::new(config).map_err(|e| anyhow::anyhow!("fips Node::new failed: {e}"))
     }
 
+    /// Unlink the control socket file before a node is built, so the next
+    /// `ControlSocket::bind` inside `run_rx_loop` always gets the path.
+    ///
+    /// fips spawns its control accept loop from `run_rx_loop` without keeping
+    /// the `JoinHandle`, so the previous node's accept task — and the
+    /// `UnixListener` it owns — survives that node's teardown. `bind` treats a
+    /// path that still answers `connect()` as "already in use" and refuses,
+    /// which would leave the freshly started node with no control socket at all:
+    /// no `show_peers`, no platform peer pushes, an empty Dev tab.
+    ///
+    /// Unlinking first leaves the orphan bound to an unnamed inode — unreachable
+    /// by any new client, and harmless — while the new node binds a fresh one.
+    /// Safe because Myco is a single process and the path is app-private, so the
+    /// "someone else is listening" case `bind` guards against cannot arise; and
+    /// because the only caller either has no node running yet (`try_new`) or has
+    /// waited for the previous one to finish (`start_node`).
+    fn clear_control_socket(socket_path: &str) {
+        match std::fs::remove_file(socket_path) {
+            Ok(()) => tracing::info!(path = socket_path, "removed the previous control socket"),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::warn!(
+                path = socket_path,
+                error = %e,
+                "could not remove the previous control socket; the node may fail to bind it"
+            ),
+        }
+    }
+
     fn from_error(app_version: &str, msg: &str) -> Self {
         Self {
             app_version: app_version.to_string(),
@@ -463,6 +521,9 @@ impl AppRuntime {
             node: None,
             node_live: Arc::new(AtomicBool::new(false)),
             loop_task: None,
+            shutdown_tx: None,
+            stopping: Arc::new(AtomicBool::new(false)),
+            start_pending: false,
             content: None,
             speedtest: Arc::new(std::sync::Mutex::new(crate::state::SpeedtestView::default())),
             peer_cache: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -760,9 +821,35 @@ impl AppRuntime {
     }
 
     fn start_node(&mut self) {
+        // A loop task that has already finished on its own — `node.start()`
+        // failed, or the packet channel closed — otherwise leaves
+        // `node_running` stuck true and the mesh permanently down, with no way
+        // back short of a process restart. Treat it as stopped so this call can
+        // rebuild. The task tears its own node down before returning, so there
+        // is nothing left running to collide with.
+        if self.node_running && self.loop_task.as_ref().is_some_and(|t| t.is_finished()) {
+            tracing::warn!("fips loop task exited on its own; rebuilding the node");
+            self.loop_task = None;
+            self.shutdown_tx = None;
+            self.node_running = false;
+            self.node_live.store(false, Ordering::Relaxed);
+        }
         if self.node_running {
             return;
         }
+        // Never build a second node while the previous one's transports are
+        // still up. They would both drive the one shared Kotlin BLE radio, and
+        // the node the UI reads (the new one, which rebinds the control socket
+        // last) is not the node doing the work — so the app reports an empty
+        // room while BLE is genuinely peered. Queue the start instead;
+        // `poll_pending_start` replays it on the next state read, within a
+        // second of the drain finishing.
+        if self.stopping.load(Ordering::Acquire) {
+            self.start_pending = true;
+            self.node_status = "waiting for the previous node to stop".to_string();
+            return;
+        }
+        self.start_pending = false;
         // Rebuild the node if a prior stop consumed it (BLE toggled off then on).
         if self.node.is_none() {
             match Self::build_node(&self.data_dir, self.wifi_aware_enabled) {
@@ -807,10 +894,18 @@ impl AppRuntime {
             // slot rather than waiting to be handed a radio.
             crate::ble_bridge_jni::set_radio_slot(node.enable_app_owned_ble_radio());
         }
+        // The rx loop serves until this fires, then drains in place. Dropping
+        // the sender resolves the receiver too, so a runtime torn down without a
+        // `StopNode` still asks the node to shut down rather than vanishing.
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let task = rt.spawn(async move {
             let mut node = node;
             if let Err(e) = node.start().await {
                 tracing::error!("fips node start failed: {e}");
+                // A partial start can still have left children up (a transport
+                // bound, the responder listening). Tear down what exists rather
+                // than dropping the node on top of them.
+                node.finish_shutdown().await;
                 return;
             }
             // Publish where the built-in `.fips` responder bound, so the TUN
@@ -827,33 +922,121 @@ impl AppRuntime {
                 None => tracing::warn!("fips DNS responder is not running; .fips will not resolve"),
             }
             crate::dns_intercept::set_responder_addr(dns_addr);
-            // Runs until the packet channel closes or the task is aborted.
-            if let Err(e) = node.run_rx_loop().await {
+            // Serves until `StopNode` fires the signal (or the packet channel
+            // closes), then runs fips's bounded in-place drain and returns.
+            if let Err(e) = node
+                .run_rx_loop_with_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+            {
                 tracing::warn!("fips rx loop ended: {e}");
             }
+            // The half that actually stops the radios. The BLE accept loop, the
+            // scan+probe loop and the advertiser are separately spawned tasks
+            // holding `Arc` clones of the pool, the io and the stats; only
+            // `Transport::stop` — reached from here — aborts them, and `Drop`
+            // cannot run async teardown to catch them.
+            node.finish_shutdown().await;
+            // The responder socket is gone with the node's children, so retract
+            // its address now (not at `StopNode`: it kept answering for the
+            // whole drain window). Nothing can have republished it in between —
+            // `start_node` will not build a new node until this task has
+            // finished.
+            crate::dns_intercept::set_responder_addr(None);
+            tracing::info!("fips node stopped and its transports torn down");
         });
         // The control socket is bound inside `run_rx_loop`, so peer queries only
         // start making sense once this flag is up — and even then not for the
         // first tick or two.
         self.node_live.store(true, Ordering::Relaxed);
         self.loop_task = Some(task);
+        self.shutdown_tx = Some(shutdown_tx);
         self.node_running = true;
         self.node_status = "running".to_string();
     }
 
+    /// Stop the node — without blocking, and without leaving its transports
+    /// running.
+    ///
+    /// This used to be `loop_task.abort()`, on the belief that dropping the node
+    /// stopped its transports. It does not. The BLE accept loop, the scan+probe
+    /// loop and the advertiser are *separately spawned* tokio tasks holding
+    /// `Arc` clones of the connection pool, the io backend and the stats;
+    /// aborting the parent touches none of them, and async teardown cannot run
+    /// from `Drop`. The old node kept scanning, advertising and dialling the one
+    /// shared Kotlin radio forever, and the next `StartNode` stacked a second
+    /// node on top of it — two DNS responders, two BLE transports, one process.
+    /// The new node rebound the control socket last, so `show_peers` reported
+    /// *its* peers (none) while the old node held the live BLE session.
+    ///
+    /// The constraint that makes this awkward: `stop_node` runs on the FFI
+    /// thread under the reducer mutex, so it must never await the teardown.
+    /// Instead it fires the shutdown signal and hands the waiting to a detached
+    /// watchdog. `start_node` refuses to build a new node until that watchdog
+    /// clears [`Self::stopping`], and `poll_pending_start` replays the queued
+    /// start when it does.
     fn stop_node(&mut self) {
-        // Aborting the loop task drops the node, stopping its transports.
-        if let Some(task) = self.loop_task.take() {
-            task.abort();
+        // An explicit stop cancels a start that was queued behind an earlier one.
+        self.start_pending = false;
+        // Ask the rx loop to drain. Dropping the sender would do it too; sending
+        // says so explicitly, and a closed receiver just means the task is
+        // already on its way out.
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
         }
+        let task = self.loop_task.take();
+        if let (Some(task), Some(rt)) = (task, self.rt.as_ref()) {
+            self.stopping.store(true, Ordering::Release);
+            let stopping = self.stopping.clone();
+            rt.spawn(async move {
+                let mut task = task;
+                if tokio::time::timeout(NODE_STOP_TIMEOUT, &mut task)
+                    .await
+                    .is_err()
+                {
+                    tracing::error!(
+                        timeout_secs = NODE_STOP_TIMEOUT.as_secs(),
+                        "fips node teardown did not finish; aborting the loop task as a last \
+                         resort — its BLE loops may survive and fight the next node for the radio"
+                    );
+                    task.abort();
+                    let _ = task.await;
+                    // The task never reached its own retraction.
+                    crate::dns_intercept::set_responder_addr(None);
+                }
+                // Releases the gate in `start_node`: the transports are down (or
+                // as down as an abort can make them), so a new node may claim
+                // the radio. Ordered after the retraction above so a queued
+                // start can only ever publish a fresh responder address.
+                stopping.store(false, Ordering::Release);
+            });
+        } else {
+            // Nothing was running (or there is no runtime): no drain to wait
+            // for, so retract the responder address here instead.
+            crate::dns_intercept::set_responder_addr(None);
+            self.stopping.store(false, Ordering::Release);
+        }
+        // Gates the 8s peer tick and the platform-peer drainer off immediately:
+        // the node is on its way out and must not be handed new peers to dial.
+        // The control socket does keep answering for the drain window, but
+        // nothing should be reading a draining node's peer list.
         self.node_live.store(false, Ordering::Relaxed);
-        // The responder dies with the node; leaving its address published would
-        // send every `.fips` query to a closed socket.
-        crate::dns_intercept::set_responder_addr(None);
         self.peer_cache.lock().unwrap().clear();
         *self.peer_feed.lock().unwrap() = PeerFeedHealth::default();
         self.node_running = false;
         self.node_status = "stopped".to_string();
+    }
+
+    /// Replay a `StartNode` that arrived while the previous node was still
+    /// draining. Called from `state_json` — which the UI polls at 1Hz and which
+    /// every `dispatch_json` ends with — so a queued start lands within about a
+    /// second of the old node actually being down.
+    fn poll_pending_start(&mut self) {
+        if self.start_pending && !self.stopping.load(Ordering::Acquire) {
+            tracing::info!("previous node is down; starting the queued node");
+            self.start_node();
+        }
     }
 
     /// Parse a JSON action, reduce it, and return the new state as JSON. A bad
@@ -996,7 +1179,18 @@ impl AppRuntime {
             identity: self.identity.clone(),
             node: NodeStatus {
                 running: self.node_running,
-                status_text: self.node_status.clone(),
+                // The drain is a real, visible state: the node is neither
+                // running nor yet gone, and a queued start is waiting on it.
+                // Saying so beats a flat "stopped" that the toggle contradicts.
+                status_text: if self.stopping.load(Ordering::Acquire) {
+                    if self.start_pending {
+                        "restarting (draining the previous node)".to_string()
+                    } else {
+                        "stopping (draining)".to_string()
+                    }
+                } else {
+                    self.node_status.clone()
+                },
             },
             ble: {
                 let (scanning, scanning_known, advertising, advertising_known) =
@@ -1167,7 +1361,10 @@ impl AppRuntime {
         Vec::new()
     }
 
-    pub fn state_json(&self) -> String {
+    pub fn state_json(&mut self) -> String {
+        // The 1Hz UI poll is also the clock a deferred start runs on; see
+        // `poll_pending_start`.
+        self.poll_pending_start();
         serde_json::to_string(&self.state())
             .unwrap_or_else(|e| format!(r#"{{"error":"serialize failed: {e}"}}"#))
     }
@@ -1313,6 +1510,142 @@ mod tests {
             "node should be stopped after StopNode"
         );
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Wait for the detached stop watchdog to report the old node down.
+    /// Generous: the point is to catch "never finishes", not to time it.
+    fn await_stopped(rt: &AppRuntime) {
+        let deadline = Instant::now() + NODE_STOP_TIMEOUT + Duration::from_secs(5);
+        while rt.stopping.load(Ordering::Acquire) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    /// `StopNode` must actually take the node down, and must do it gracefully —
+    /// the loop task has to run to completion (rx-loop drain →
+    /// `Node::finish_shutdown` → `Transport::stop`), not be aborted.
+    ///
+    /// Aborting is what the old code did, and it is why two nodes could be live
+    /// in one process: the BLE accept / scan+probe / advertiser tasks hold `Arc`
+    /// clones and survive their parent, so nothing but `finish_shutdown` stops
+    /// them. There is no BLE transport on the host, so what this pins down is
+    /// the sequencing: the stop completes on its own well inside
+    /// [`NODE_STOP_TIMEOUT`], i.e. the last-resort abort never had to fire.
+    #[test]
+    fn stopping_the_node_completes_the_loop_task_rather_than_aborting_it() {
+        let dir = temp_dir("node-graceful-stop");
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut rt = AppRuntime::new(dir.to_str().unwrap(), "0.0.1");
+
+        rt.dispatch(NativeAppAction::StartNode);
+        assert!(rt.state().node.running, "node should be running");
+
+        let stopped_at = Instant::now();
+        rt.dispatch(NativeAppAction::StopNode);
+        await_stopped(&rt);
+
+        assert!(
+            !rt.stopping.load(Ordering::Acquire),
+            "the graceful stop never finished — the watchdog would have had to abort"
+        );
+        assert!(
+            stopped_at.elapsed() < NODE_STOP_TIMEOUT,
+            "stop took {:?}, which means the last-resort abort fired",
+            stopped_at.elapsed()
+        );
+        assert!(
+            rt.loop_task.is_none() && rt.shutdown_tx.is_none(),
+            "the loop task and its shutdown signal must be released by StopNode"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A `StartNode` that lands while the previous node is still draining must
+    /// be queued, not honoured. Honouring it is the bug: two nodes in one
+    /// process, both driving the single Kotlin BLE radio, with the UI reading
+    /// the idle one.
+    ///
+    /// The gate is driven directly here rather than by racing a real drain —
+    /// on the host, with no transports and no peers, the drain finishes in
+    /// microseconds and the window would be untestable.
+    #[test]
+    fn a_start_during_a_drain_is_queued_until_the_old_node_is_down() {
+        let dir = temp_dir("node-restart-gate");
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut rt = AppRuntime::new(dir.to_str().unwrap(), "0.0.1");
+
+        // Stand in for "the previous node is still tearing down".
+        rt.stopping.store(true, Ordering::Release);
+
+        rt.dispatch(NativeAppAction::StartNode);
+        assert!(
+            !rt.node_running && rt.loop_task.is_none(),
+            "no second node may be built while the first one's transports are up"
+        );
+        assert!(
+            rt.start_pending,
+            "the start must be remembered, not dropped"
+        );
+        let status = rt.state().node.status_text;
+        assert!(
+            status.contains("draining"),
+            "the UI needs to see the restart in flight, got: {status}"
+        );
+
+        // A state read while still draining must not start it either.
+        let _ = rt.state_json();
+        assert!(!rt.node_running, "still draining — still no node");
+
+        // The watchdog's release edge.
+        rt.stopping.store(false, Ordering::Release);
+        let _ = rt.state_json();
+        assert!(
+            rt.node_running && rt.loop_task.is_some(),
+            "the queued start must be replayed once the old node is down"
+        );
+        assert!(!rt.start_pending, "the queued start must be consumed");
+
+        rt.dispatch(NativeAppAction::StopNode);
+        await_stopped(&rt);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An off→on cycle must leave exactly one node behind. Same shape as the
+    /// mesh toggle on the device: stop, then start again immediately.
+    #[test]
+    fn an_off_on_cycle_leaves_one_node() {
+        let dir = temp_dir("node-off-on");
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut rt = AppRuntime::new(dir.to_str().unwrap(), "0.0.1");
+
+        rt.dispatch(NativeAppAction::StartNode);
+        assert!(rt.state().node.running);
+
+        rt.dispatch(NativeAppAction::StopNode);
+        // The toggle's own start, fired before the drain can possibly be done.
+        rt.dispatch(NativeAppAction::StartNode);
+        assert!(
+            rt.node_running || rt.start_pending,
+            "the restart is either immediate or queued, never lost"
+        );
+
+        // Drive the 1Hz poll the UI would be doing.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !rt.node_running && Instant::now() < deadline {
+            let _ = rt.state_json();
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(rt.node_running, "the node must come back after an off→on");
+        assert!(!rt.start_pending);
+        assert!(
+            !rt.stopping.load(Ordering::Acquire),
+            "the old node must be down before the new one exists"
+        );
+
+        rt.dispatch(NativeAppAction::StopNode);
+        await_stopped(&rt);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/myco-core/src/state.rs
+++ b/myco-core/src/state.rs
@@ -94,6 +94,14 @@ pub struct PeerDiagnosticView {
     /// Milliseconds-since-epoch this row was last heard from; `0` when never
     /// heard from (renders as an em-dash, never "0s").
     pub last_seen_ms: u64,
+    /// Milliseconds-since-epoch the FMP session with this peer authenticated;
+    /// `0` when there is no session (renders as an em-dash, never "0s").
+    ///
+    /// The age derived from this is the session's, not the current FMP index's:
+    /// `receiver_idx` rotates on every rekey (default 120s) while the session
+    /// itself survives, so a long age means the link has held, not that a
+    /// handshake is stale.
+    pub authenticated_at_ms: u64,
     /// Signal strength from the most recent scan advert attributed to this
     /// row, dBm; `None` when no advert has been attributed.
     pub rssi: Option<i32>,

--- a/myco-core/src/tun_bridge.rs
+++ b/myco-core/src/tun_bridge.rs
@@ -67,13 +67,10 @@ pub fn install(
 /// into the mesh. Returns `false` if no TUN is installed or the queue is full.
 pub fn send_packet(mut packet: Vec<u8>) -> bool {
     // System-wide `.fips` DNS: a query to the sentinel resolver is ours —
-    // answered here for `.fips`, or forwarded upstream (the reply arrives
-    // later via `push_local`). Either way it must not go to the mesh.
+    // sent to the node's own responder for `.fips`, or to a real resolver
+    // otherwise. Either way the reply arrives later via `push_local`, and
+    // either way the query itself must not go to the mesh.
     match crate::dns_intercept::handle_query(&packet) {
-        crate::dns_intercept::Dns::Answered(reply) => {
-            local().lock().unwrap().push_back(reply);
-            return true;
-        }
         crate::dns_intercept::Dns::Forwarded => return true,
         crate::dns_intercept::Dns::NotOurs => {}
     }

--- a/myco-core/src/udp_fd_bridge.rs
+++ b/myco-core/src/udp_fd_bridge.rs
@@ -1,39 +1,223 @@
-//! Process-global bridge for the node's UDP transport raw fd (from
-//! [`fips::Node::enable_app_owned_udp_fd`]) — lets the Android side pin that
-//! socket to a specific `android.net.Network` (e.g. the `!FIPS` Wi-Fi AP, or
-//! a Wi-Fi Aware NDP network) via `Network.bindSocket`.
+//! Process-global bridge for the node's UDP transport raw fds (from
+//! [`fips::Node::enable_app_owned_udp_fd`]) — lets the Android side pin each
+//! socket to a specific `android.net.Network` (infrastructure Wi-Fi for the
+//! `!FIPS`/LAN lane, a Wi-Fi Aware NDP for the Aware lane) via
+//! `Network.bindSocket`.
 //!
-//! Platform-pushed peers (Wi-Fi Aware, the AP lane) live on a network that
-//! never passes internet validation, so without an explicit bind the Noise
-//! handshake's replies can be lost to routing/firewall rules that favour a
-//! competing validated default network (e.g. cellular) — the send succeeds
-//! locally, but nothing ever comes back.
+//! Platform-pushed peers live on networks that never pass internet validation,
+//! so without an explicit bind the Noise handshake's replies can be lost to
+//! routing rules that favour a competing validated default network (e.g.
+//! cellular) — the send succeeds locally, but nothing ever comes back.
+//!
+//! # Why this is keyed by instance
+//!
+//! The node runs one UDP transport per lane (`runtime.rs`'s `"lan"` and
+//! `"aware"` instances), so the seam delivers **two** fds. `Network.bindSocket`
+//! is exclusive: a socket marked with the Wi-Fi netid cannot reach a Wi-Fi
+//! Aware peer, whose NDP is a separate network with its own routing table, and
+//! vice versa. Handing the wrong descriptor to a radio is therefore not a
+//! cosmetic mix-up — it is exactly the bug this change fixes.
+//!
+//! Arrival order cannot be used to tell them apart: fips builds transports by
+//! iterating a `HashMap`, so the order is arbitrary and may differ run to run.
+//! Instead fips labels every delivery with the configured instance name
+//! ([`fips::AppOwnedUdpSocket`]), and this module files each one under that
+//! name. A radio asks for its own instance and can only ever receive that
+//! instance's descriptor; a lane whose socket failed to bind gets `-1` rather
+//! than a neighbour's fd.
+//!
+//! # Why a versioned latch and not a queue
+//!
+//! A queue serves a consumer that outlives every producer. These consumers do
+//! not: `AwareRadio` is created and destroyed each time the user toggles the
+//! Wi-Fi Aware lane, while the node — and its sockets — carry on running. A
+//! radio started after its socket was announced must still be able to learn it,
+//! so the latest descriptor per lane is *retained*, with a version that
+//! increments on each new one. A caller passes back the version it last saw and
+//! blocks only for something newer.
 
+use std::collections::HashMap;
 use std::os::unix::io::RawFd;
-use std::sync::mpsc::Receiver;
-use std::sync::{Mutex, OnceLock};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::Duration;
 
-static RX: OnceLock<Mutex<Option<Receiver<RawFd>>>> = OnceLock::new();
+use fips::AppOwnedUdpSocket;
 
-fn rx() -> &'static Mutex<Option<Receiver<RawFd>>> {
-    RX.get_or_init(|| Mutex::new(None))
+/// The retained descriptor for one lane.
+///
+/// `version` starts at 0, meaning "no socket announced yet", and increments on
+/// every announcement — including a re-announcement of the same fd number,
+/// which a node rebuild can easily produce and which still needs re-binding
+/// because the socket behind the number is a new one.
+#[derive(Clone, Copy)]
+struct Announced {
+    version: u64,
+    fd: RawFd,
 }
 
-/// Install the node's fd-notification receiver. Replaces any prior install
-/// (the node is rebuilt on a BLE/mesh off→on cycle, yielding a fresh channel).
-pub fn install(receiver: Receiver<RawFd>) {
-    *rx().lock().unwrap() = Some(receiver);
+#[derive(Default)]
+struct Lane {
+    state: Mutex<Option<Announced>>,
+    changed: Condvar,
 }
 
-/// Pull the UDP transport's raw fd, blocking up to `timeout`. Returns `-1` on
-/// timeout or if no receiver is installed — the fd is only ever sent once per
-/// node lifetime (right after the transport starts), so callers poll this
-/// once at startup rather than in a loop.
-pub fn next_fd(timeout: Duration) -> RawFd {
-    let guard = rx().lock().unwrap();
-    match guard.as_ref() {
-        Some(receiver) => receiver.recv_timeout(timeout).unwrap_or(-1),
-        None => -1,
+impl Lane {
+    fn announce(&self, fd: RawFd) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let version = state.map_or(0, |a| a.version) + 1;
+        *state = Some(Announced { version, fd });
+        self.changed.notify_all();
+    }
+
+    /// Block until this lane's version exceeds `since_version`, or `timeout`
+    /// elapses. Returns the retained descriptor, or `None` on timeout.
+    fn wait(&self, since_version: u64, timeout: Duration) -> Option<Announced> {
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let (state, _) = self
+            .changed
+            .wait_timeout_while(state, timeout, |s| {
+                s.is_none_or(|a| a.version <= since_version)
+            })
+            .unwrap_or_else(|e| e.into_inner());
+        state.filter(|a| a.version > since_version)
+    }
+}
+
+type Lanes = Mutex<HashMap<String, Arc<Lane>>>;
+
+static LANES: OnceLock<Lanes> = OnceLock::new();
+
+/// Bumped by every [`install`]; a fan-out thread exits once it is no longer the
+/// current generation, so a node rebuild cannot leave two threads competing.
+static GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// How often a fan-out thread wakes to re-check whether it has been superseded.
+const FANOUT_POLL: Duration = Duration::from_millis(250);
+
+fn lanes() -> &'static Lanes {
+    LANES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn lane(instance: &str) -> Arc<Lane> {
+    let mut map = lanes().lock().unwrap_or_else(|e| e.into_inner());
+    Arc::clone(map.entry(instance.to_string()).or_default())
+}
+
+/// Install the node's socket-notification receiver, replacing any prior install
+/// (the node is rebuilt on a mesh off→on cycle, yielding a fresh channel and
+/// fresh descriptors).
+///
+/// Spawns a small fan-out thread that owns the receiver and files each arriving
+/// descriptor under its instance name. A thread rather than draining inside
+/// [`next_fd`] because there are two independent consumers — one per Kotlin
+/// radio, each on its own `HandlerThread` — and a shared single-consumer
+/// channel would let either swallow the other's announcement.
+pub fn install(receiver: Receiver<AppOwnedUdpSocket>) {
+    let generation = GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
+    std::thread::Builder::new()
+        .name("myco-udp-fd-fanout".to_string())
+        .spawn(move || fan_out(receiver, generation))
+        .expect("spawning the UDP fd fan-out thread");
+}
+
+fn fan_out(receiver: Receiver<AppOwnedUdpSocket>, generation: u64) {
+    loop {
+        if GENERATION.load(Ordering::SeqCst) != generation {
+            return; // superseded by a newer node
+        }
+        match receiver.recv_timeout(FANOUT_POLL) {
+            Ok(socket) => {
+                // A `Single` UDP config has no instance name; Myco's own config
+                // never produces one, but the seam allows it, so give it a key
+                // of its own rather than silently filing it under a lane.
+                let instance = socket.instance.unwrap_or_default();
+                tracing::info!(
+                    instance = %instance,
+                    fd = socket.fd,
+                    "UDP transport socket available to bind"
+                );
+                lane(&instance).announce(socket.fd);
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => return,
+        }
+    }
+}
+
+/// Wait for a UDP socket on `instance` newer than `since_version`, blocking up
+/// to `timeout`.
+///
+/// Returns `(version, fd)`, or `(since_version, -1)` if nothing newer arrived —
+/// which is also what a lane whose socket never bound gets. Never another
+/// lane's descriptor. Pass `0` the first time; pass back the returned version
+/// afterwards, so a socket announced before the caller existed is still seen
+/// exactly once, and a node restart's replacement socket is seen even when the
+/// kernel hands out the same fd number again.
+pub fn next_fd(instance: &str, since_version: u64, timeout: Duration) -> (u64, RawFd) {
+    match lane(instance).wait(since_version, timeout) {
+        Some(announced) => (announced.version, announced.fd),
+        None => (since_version, -1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc::channel;
+
+    /// The registry is process-global, so tests use instance names of their own
+    /// rather than the real `"lan"` / `"aware"` ones.
+    #[test]
+    fn each_lane_only_ever_sees_its_own_descriptor() {
+        let (tx, rx) = channel();
+        install(rx);
+
+        let send = |instance: &str, fd| {
+            tx.send(AppOwnedUdpSocket {
+                instance: Some(instance.to_string()),
+                fd,
+            })
+            .unwrap()
+        };
+        send("test-aware", 41);
+        send("test-lan", 42);
+
+        // Deliberately read back in the opposite order to delivery: which fd a
+        // lane gets is decided by the label, not by what arrived first.
+        let (lan_v, lan_fd) = next_fd("test-lan", 0, Duration::from_secs(2));
+        let (aware_v, aware_fd) = next_fd("test-aware", 0, Duration::from_secs(2));
+        assert_eq!(lan_fd, 42);
+        assert_eq!(aware_fd, 41);
+        assert_eq!((lan_v, aware_v), (1, 1));
+
+        // Nothing newer: the caller waits and is told nothing, rather than
+        // being handed the other lane's socket or the same one twice.
+        assert_eq!(
+            next_fd("test-lan", lan_v, Duration::from_millis(50)),
+            (lan_v, -1)
+        );
+        // A lane that never bound a socket is silent too.
+        assert_eq!(
+            next_fd("test-absent", 0, Duration::from_millis(50)),
+            (0, -1)
+        );
+
+        // A node restart re-announces, and is seen even when the fd number
+        // repeats — the version, not the number, is what says "re-bind this".
+        send("test-lan", 42);
+        assert_eq!(
+            next_fd("test-lan", lan_v, Duration::from_secs(2)),
+            (lan_v + 1, 42)
+        );
+
+        // A late consumer (a radio the user toggled on after the node started)
+        // still learns the retained descriptor rather than blocking forever.
+        assert_eq!(next_fd("test-aware", 0, Duration::from_millis(50)), (1, 41));
+
+        // Held until here so the fan-out thread does not exit on a disconnect
+        // before it has forwarded everything.
+        drop(tx);
     }
 }


### PR DESCRIPTION
Moves Myco off a long-stale FIPS branch onto current upstream, then fixes the
radio-layer reliability problems that became visible once it was there.

## Requires a matching FIPS branch

`Cargo.toml` points at `reference/fips`, a gitignored symlink to a local
checkout, so this **cannot be built without the matching FIPS branch**:

- repo `jmcorgan/fips`, branch `integration/platform`, tip `6580a806`

That branch is 16 commits on top of current `master`. It is structured so each
commit can be cherry-picked out as its own upstream PR — Myco is not waiting on
any of them to merge.

## What this is

**The rebase.** The FIPS version Myco was building against had drifted a long
way behind; the gap included fixes to path MTU, framing, peer identity and the
control plane. Everything Myco needs from the node is now carried as focused
changes on top of current master rather than as a private fork. Peer state,
peer discovery and `.fips` name resolution moved onto interfaces the node
already ships — the control socket, `dns_local_addr`, and an app-owned radio
seam — which deleted several hundred lines of Myco-side workaround.

**Wi-Fi Aware carries traffic for the first time.** It had been negotiating
data paths with nearby phones for months and moving zero bytes: the node had
one UDP socket and the LAN lane pinned it to the Wi-Fi network, after which
nothing addressed to an Aware link could route. Aware now has its own socket
pinned to its own network. On the bench it becomes the busiest link between two
phones, ahead of both Bluetooth and the LAN.

**Bluetooth reliability.** Four separate defects, all long-standing and all
invisible from inside the app:

- Failed dials leaked a socket holding a connection slot, until every later
  dial hung for its full timeout. Only a force-stop recovered it — which is the
  workaround this behaviour had trained into people.
- A phone could advertise a port nothing was listening on, making it
  permanently undialable while looking healthy from outside.
- Switching Bluetooth off and on (or airplane mode) left the app unable to see
  any BLE peer until restarted; nothing watched the adapter.
- One dead address absorbed most connection attempts and blocked every peer
  queued behind it.

**Mesh toggle left the previous node running.** Two nodes then shared one
radio, and the one answering questions about peers was not the one doing the
work — so the app could report zero peers while a connection was live.

## Validated on hardware

Three devices — Pixel 7 Pro, Samsung A52s, and a DC-1 tablet — not just built.

- A factory-fresh device joined the mesh, found a peer over Bluetooth, and
  pulled a complete nsite across it.
- Two phones peer over Wi-Fi Aware, and a dropped Aware path recovers in ~2.5s
  where it previously waited minutes for the next discovery sweep.
- Bluetooth recovers from an adapter cycle and from airplane mode, including
  the case where the app started with Bluetooth already off.
- Per-address backoff cut re-dials to one dead address from 15 per ten minutes
  to 5, measured against an untouched code path as a control.

FIPS CI is green on `integration/platform` (full matrix, including the
containerised integration suites).

## Also here

Dev tab work that came out of debugging the above: a transport icon per peer,
session age beside last-heard, honest radio state instead of `unknown`, and a
Settings warning when Bluetooth scanning is deaf because location services are
off — a phone-specific trap that cost hours to find and is invisible otherwise.

## Not done

- **Seamless BLE→Aware switchover.** A session cannot currently move between
  transports: the session key includes the transport, so a frame arriving on a
  different one is dropped. Options, costs and a recommendation are written up
  in `reference/transport-switchover.md`.
- BLE diagnostics on the Dev tab (`ble_adverts`, `ble_attempts`) are stubbed
  with `TODO(stage 2)` markers; nothing functional depends on them.
- One Aware data-path interface per chipset means a third Aware device in the
  room can take the slot and stall a pair.