### PR TITLE
Share files with any phone over a local-only hotspot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   page's address instead, and the other phone's own system opens it in its
   browser — nothing to install, nothing to type.
 - Nothing is transferred behind your back: every download and upload a guest
-  starts waits on the hotspot sheet as an explicit Allow / Deny, with the
-  file's name and size. The guest's browser simply waits for your answer; an
-  unanswered request is denied after 90 seconds, and stopping the hotspot
-  denies everything still waiting. The notification names the file that is
-  waiting so a request can't sit there unseen.
+  starts pops an accept-or-decline dialog on your phone — wherever in Myco you
+  are, not just on the hotspot sheet — with the file's name and size. The
+  guest's browser simply waits for your answer; an unanswered request is
+  denied after 90 seconds, and stopping the hotspot denies everything still
+  waiting. The notification names the file that is waiting so a request can't
+  sit there unseen.
+- Sending now works like AirDrop in both directions. "Send a file" on the
+  hotspot sheet pushes any document straight at the guest: their browser pops
+  an accept-or-decline dialog with the file's name and size, accepting saves
+  it as a normal download, and the sheet shows each offer's fate — waiting,
+  sent, or declined.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Received files land in `Download/Myco/`, so they show up in the Files app
   like any other download. The hotspot runs in a foreground service with a
   Stop action, so it survives leaving the tab and is always one tap to kill.
+- While the hotspot is on, bumping the phones hands the other phone the file
+  page directly: the NFC tag Myco already emulates for pairing serves the
+  page's address instead, and the other phone's own system opens it in its
+  browser — nothing to install, nothing to type.
+- Nothing is transferred behind your back: every download and upload a guest
+  starts waits on the hotspot sheet as an explicit Allow / Deny, with the
+  file's name and size. The guest's browser simply waits for your answer; an
+  unanswered request is denied after 90 seconds, and stopping the hotspot
+  denies everything still waiting. The notification names the file that is
+  waiting so a request can't sit there unseen.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - While the hotspot is on, bumping the phones hands the other phone the file
   page directly: the NFC tag Myco already emulates for pairing serves the
   page's address instead, and the other phone's own system opens it in its
-  browser — nothing to install, nothing to type.
+  browser — nothing to install, nothing to type. For the whole hotspot
+  session NFC does *only* that — pairing by bump is fully disabled, in both
+  directions (this phone neither presents a pair code nor acts on one it
+  reads), and comes back the moment the hotspot stops.
 - Nothing is transferred behind your back: every download and upload a guest
   starts pops an accept-or-decline dialog on your phone — wherever in Myco you
   are, not just on the hotspot sheet — with the file's name and size. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   heard from. Those answer different questions, and only the second was
   visible: a link re-establishing every few seconds looks perfectly healthy if
   all you can see is that it was heard from a moment ago.
+- Share files with **any** phone — no Myco on the other side. A new hotspot
+  bubble on the Circle tab (above the QR bubble) opens a local-only Wi-Fi
+  hotspot on this phone and a plain web page served from it. The other phone
+  scans one QR to join the hotspot, opens the shown address in its browser, and
+  can download the files you chose to share and upload files back to you.
+  Received files land in `Download/Myco/`, so they show up in the Files app
+  like any other download. The hotspot runs in a foreground service with a
+  Stop action, so it survives leaving the tab and is always one tap to kill.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an accept-or-decline dialog with the file's name and size, accepting saves
   it as a normal download, and the sheet shows each offer's fate — waiting,
   sent, or declined.
+- The file page only ever offers this session's files. Starting a hotspot
+  wipes the served list; only what you pick now, or receive now, shows up for
+  the guest — files from earlier sessions stay in `Download/Myco/`, visible
+  to you alone.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Myco is an offline-first, peer-to-peer Android app for sharing **nsites** (static web apps published on Nostr) over a Bluetooth LE mesh — no internet, no app store. Kotlin/Compose shell on top of a single Rust native library (`libmyco_core.so`).
+
+## Commands
+
+```bash
+just test        # host build + all Rust unit tests (default recipe; no Android toolchain needed)
+cargo test -p myco-core <name>       # run a single test / filter by name
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+just identity    # host smoke check: prints device identity via myco-core example
+
+just build       # debug APK (Gradle cross-compiles the Rust via the buildRustArm64 task)
+just ndk-build   # standalone cargo-ndk cross-compile into jniLibs (don't combine with just build — double-compiles)
+just install     # build + adb install -r
+cd android && ./gradlew testDebugUnitTest   # Kotlin unit tests (app/src/test)
+```
+
+Required before opening a PR (per CONTRIBUTING.md): `cargo fmt --check`, `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `./gradlew assembleDebug` if you touched `android/`. Run your branch through the 13-criteria checklist in `PR-REVIEW.md`.
+
+### The fips dependency
+
+The workspace depends on `fips` as a **path dependency at `reference/fips`** — a local, gitignored checkout (upstream: github.com/k0sti/fips) carrying local patches (app-owned TUN, injectable `BleIo`, per-peer PSM discovery, macOS `BleIo`). Nothing builds without it. The Android Gradle build additionally reads `MYCO_FIPS_REPO_PATH` to emit a `patch.crates-io` override; `patch.crates-io` builds perturb `Cargo.lock`, so watch for a dirty lockfile after Android builds. Details: `docs/how-to/build.md` §4.
+
+### Android constraints (LOCKED)
+
+- **arm64-v8a only**, no emulator target — BLE/L2CAP need physical devices.
+- **minSdk 29** — hard floor: L2CAP Connection-Oriented Channel APIs exist only on API 29+.
+- Android builds need cargo-ndk, Android SDK + NDK, JDK 17, and the `aarch64-linux-android` Rust target.
+
+## Architecture
+
+Four Rust crates build into the one `cdylib`, `libmyco_core.so`:
+
+- **`myco-core`** — the app crate and only cdylib. Owns device identity (one Nostr keypair, persisted on first launch), embeds the FIPS mesh node, and wires everything together: Tokio multi-thread runtime (`runtime.rs`), TUN packet bridge, `.fips` DNS interception, BLE/Wi-Fi Aware/AP lane bridges, peer diagnostics, and mesh gossip.
+- **`nsite-deck`** — reusable, transport-agnostic nsite host: gateway (manifest → path → sha256 → serve), sync/import engine, propagator. Reaches the outside world only through four trait seams in `seams.rs`: `RelayBackend`, `BlobStore`, `PeerSource`, `FanoutSink`. It names no concrete relay, store, or radio — keep it that way.
+- **`myco-relay`** — embedded NIP-01 relay implementing `RelayBackend` (ws on :4870). Hand-rolled store over rust-nostr `Event` types, deliberately no relay framework: manifests are replaceable/addressable (newest-per-slot, persisted to JSON); regular events (chat) are by-id, ephemeral, memory-only.
+- **`myco-blossom`** — embedded Blossom blob store implementing `BlobStore` (http on :24243). Content-addressed files named by sha256; verifies hash on write (atomic temp+rename), trusts the name on read.
+
+### The FFI boundary
+
+Kotlin ↔ Rust is a **JNI + JSON-over-strings Redux-style reducer**: `dispatch(actionJson) -> stateJson` over an opaque `jlong` handle, with a monotonic `rev` (`myco-core/src/jni_abi.rs` ↔ `android/.../core/NativeCore.kt`). There is no UniFFI/bindgen step. Actions live in `action.rs`, the state snapshot in `state.rs`. Kotlin owns UI, WebViews, the radios (BLE/NFC/Aware/AP), and the `VpnService`/TUN fd; Rust owns identity, the mesh node, and the content services.
+
+`jni_abi.rs` compiles **only for Android** — host `cargo test` never sees it, so JNI glue is verified only by the cargo-ndk build. Conversely, many `myco-core` modules are Android-only consumers marked `#[cfg_attr(not(target_os = "android"), allow(dead_code))]`; host tests drive `AppRuntime` directly. The Rust talks to the running fips node via its Unix-domain **control socket** (`control_client.rs`) — the only way to read peer state or push a platform-discovered peer once the node's rx loop owns it.
+
+### Android app (`android/app/src/main/java/app/myco/`)
+
+Compose bottom-nav shell (`ui/MycoApp.kt`: Apps · Circle · Discover · Settings · Dev). Each installed nsite renders in its own chrome-less WebView activity (`NsiteActivity`). Radios are their own packages: `ble/`, `nfc/`, `aware/`, `ap/`; pairing/share links in `share/`; the reducer client in `core/`.
+
+## Testing philosophy
+
+Host `cargo test` uses in-memory mocks (`nsite-deck/src/testing.rs`: `MemRelay`, `MemBlobs`) and is necessary but **not sufficient** for pairing/BLE/NFC/mesh changes — those regress only on physical devices, usually two paired ones. When core logic can't be host-tested, say so in the PR and describe the manual on-device test. See `docs/how-to/run-two-device-demo.md`.
+
+## Conventions
+
+- Single-trunk: branch off `main`, PR back into `main`, squash WIP commits.
+- One logical change per PR; no drive-by reformatting or out-of-footprint cleanups.
+- Design-affecting changes update the matching `docs/design/` page; user-visible changes update `README.md`; release notes go in `CHANGELOG.md` under `[Unreleased]`.
+- Many docs in `docs/design/` and `docs/how-to/` were written in forward-looking "proposal voice" before the code existed and mark items **TBD / open** — where a doc and the tree disagree, the tree (justfile, Cargo.toml, build.gradle.kts) is current. `docs/design/concepts.md` is the glossary; start there for terminology (npub/node_addr, `.fips` vs `.nsite`, Pillars of Propagation).

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -138,6 +138,8 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.8.4")
     // QR generation for share-an-nsite (encodes the nsite id + pairing info)…
     implementation("com.google.zxing:core:3.5.3")
+    // Embedded HTTP server for the file-share hotspot's upload/download page.
+    implementation("org.nanohttpd:nanohttpd:2.3.1")
     // …and an in-app camera scanner to read one back.
     implementation("com.journeyapps:zxing-android-embedded:4.3.0")
     testImplementation("junit:junit:4.13.2")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -115,6 +115,13 @@
             android:exported="false"
             android:foregroundServiceType="connectedDevice" />
 
+        <!-- File-share hotspot: a local-only hotspot plus the file web page it
+             serves to whoever joins (started from the Circle tab). -->
+        <service
+            android:name=".hotspot.HotspotService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
+
         <!-- HCE for NFC tap-to-pair: emulates a tag serving this device's
              myco://pair code while the QR/present screen is open. -->
         <service

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -418,6 +418,13 @@ class MainActivity : ComponentActivity() {
         // without this an unrelated URL tag would fall through to openNsite(). Raw
         // nsite links are entered via QR/paste, never NFC.
         if (uri.scheme != NsiteShare.SCHEME) return
+        // While the file-share hotspot runs, a bump's only job is handing over
+        // the page URL — reading the peer's pair tag here would start a pairing
+        // anyway, from this side. Drop exactly that; hotspot off, pairing resumes.
+        if (PairPresent.hotspotActive && NsiteShare.parsePairUri(uri.toString()) != null) {
+            android.util.Log.i("MycoNfc", "ignoring pair tag — hotspot owns NFC")
+            return
+        }
         runOnUiThread { handleScannedText(uri.toString()) }
     }
 
@@ -584,6 +591,16 @@ class MainActivity : ComponentActivity() {
     private fun handleDeepLink(intent: Intent?) {
         val data = intent?.data ?: return
         if (data.scheme != NsiteShare.SCHEME) return
+        // The passive-dispatch twin of the reader-mode gate in handleNfcTag:
+        // while the hotspot owns NFC, a peer's pair tag delivered by the OS as
+        // an NDEF intent must not start a pairing. QR-scanned and browsed
+        // myco:// links arrive with other actions and stay unaffected.
+        if (intent.action == NfcAdapter.ACTION_NDEF_DISCOVERED &&
+            PairPresent.hotspotActive && NsiteShare.parsePairUri(data.toString()) != null
+        ) {
+            android.util.Log.i("MycoNfc", "ignoring pair tap — hotspot owns NFC")
+            return
+        }
         handleScannedText(data.toString())
     }
 

--- a/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
+++ b/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
@@ -6,6 +6,8 @@ import java.io.FileInputStream
 import java.io.InputStream
 import java.net.URLDecoder
 import java.net.URLEncoder
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -28,14 +30,24 @@ class FileShareServer(
     port: Int,
 ) : NanoHTTPD(port) {
 
+    /** Approved-download tokens: token → (file id, expiry). Single-use. */
+    private val downloadTokens = ConcurrentHashMap<String, Pair<String, Long>>()
+
     override fun serve(session: IHTTPSession): Response = try {
         when {
             session.method == Method.GET && session.uri == "/" -> {
                 val sent = session.parameters["sent"]?.firstOrNull()?.toIntOrNull()
                 page(banner = sent?.let { "Received $it file${if (it == 1) "" else "s"}." })
             }
+            // Approval is asked for FIRST, via fetch — so a denial can be a
+            // dialog on the page instead of a navigation the browser saves as
+            // a "rejected" file. Approval mints a one-time token; the real GET
+            // spends it and streams without asking again.
+            session.method == Method.POST && session.uri.startsWith(FILE_PREFIX) &&
+                session.uri.endsWith(REQUEST_SUFFIX) ->
+                requestDownload(session.uri.removePrefix(FILE_PREFIX).removeSuffix(REQUEST_SUFFIX))
             session.method == Method.GET && session.uri.startsWith(FILE_PREFIX) ->
-                download(session.uri.removePrefix(FILE_PREFIX))
+                download(session.uri.removePrefix(FILE_PREFIX), session)
             session.method == Method.PUT && session.uri.startsWith(UPLOAD_PREFIX) ->
                 uploadPut(session)
             session.method == Method.POST && session.uri == "/upload" -> upload(session)
@@ -54,14 +66,45 @@ class FileShareServer(
         newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, "error\n")
     }
 
-    private fun download(id: String): Response {
+    /** Ask the owner about one download; blocks this request thread until the
+     *  dialog is answered. Allowed → a short-lived single-use token the page
+     *  navigates with; denied → 403 the page turns into a dialog. */
+    private fun requestDownload(id: String): Response {
         val entry = files.list().firstOrNull { it.id == id }
             ?: return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "gone\n")
-        // Blocks this request thread until the owner taps Allow — the guest's
-        // browser sits on a spinning tab, then the download starts (or 403s).
         val allowed = TransferGate.request(TransferGate.Direction.DOWNLOAD, entry.name, entry.size)
         Log.i(TAG, "download '${entry.name}' ${if (allowed) "allowed" else "denied"}")
-        if (!allowed) return denied()
+        if (!allowed) {
+            return newFixedLengthResponse(Response.Status.FORBIDDEN, "application/json", "{\"ok\":false}")
+        }
+        val token = UUID.randomUUID().toString()
+        downloadTokens[token] = id to System.currentTimeMillis() + TOKEN_TTL_MS
+        return newFixedLengthResponse(
+            Response.Status.OK, "application/json",
+            JSONObject().put("ok", true).put("token", token).toString(),
+        )
+    }
+
+    /** Spend a token minted by [requestDownload]. */
+    private fun consumeToken(token: String?, id: String): Boolean {
+        if (token == null) return false
+        val now = System.currentTimeMillis()
+        downloadTokens.entries.removeIf { it.value.second < now }
+        val v = downloadTokens.remove(token) ?: return false
+        return v.first == id
+    }
+
+    private fun download(id: String, session: IHTTPSession): Response {
+        val entry = files.list().firstOrNull { it.id == id }
+            ?: return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "gone\n")
+        if (!consumeToken(session.parameters["t"]?.firstOrNull(), id)) {
+            // No-JS fallback: gate here, like before. The denial is an HTML
+            // page (no attachment header), so even a plain navigation renders
+            // it instead of saving a "rejected" file.
+            val allowed = TransferGate.request(TransferGate.Direction.DOWNLOAD, entry.name, entry.size)
+            Log.i(TAG, "download '${entry.name}' ${if (allowed) "allowed" else "denied"} (no-token path)")
+            if (!allowed) return deniedPage()
+        }
         val (stream, size) = files.open(id)
             ?: return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "gone\n")
         val resp = if (size > 0) {
@@ -136,8 +179,11 @@ class FileShareServer(
     }
 
     private fun page(banner: String?): Response {
+        // No `download` attribute: saving is driven by the Content-Disposition
+        // header, so a no-JS denial (an HTML page) renders instead of being
+        // saved as a "rejected" file.
         val rows = files.list().joinToString("\n") { e ->
-            """<li><a href="$FILE_PREFIX${e.id}" download>${esc(e.name)}</a> <span>${human(e.size)}</span></li>"""
+            """<li><a href="$FILE_PREFIX${e.id}">${esc(e.name)}</a> <span>${human(e.size)}</span></li>"""
         }
         val listing = if (rows.isEmpty()) "<p class=\"empty\">No files shared yet.</p>" else "<ul>\n$rows\n</ul>"
         val note = banner?.let { "<p class=\"banner\">${esc(it)}</p>" } ?: ""
@@ -193,6 +239,47 @@ class FileShareServer(
                 } catch (_) {}
               }
               location.href = '/?sent=' + sent;
+            });
+            </script>
+            <div class="overlay" id="statusOverlay">
+              <div class="dialog">
+                <p id="statusText"></p>
+                <div class="actions" id="statusActions" style="display:none">
+                  <button id="statusOk">OK</button>
+                </div>
+              </div>
+            </div>
+            <script>
+            // Downloads ask the phone's owner first (POST …/request blocks on
+            // their dialog). Denial becomes THIS dialog — never a saved file;
+            // approval navigates with a one-time token and streams instantly.
+            const sOverlay = document.getElementById('statusOverlay');
+            const sText = document.getElementById('statusText');
+            const sActions = document.getElementById('statusActions');
+            document.getElementById('statusOk').addEventListener('click', () => sOverlay.classList.remove('show'));
+            function showStatus(text, dismissible) {
+              sText.textContent = text;
+              sActions.style.display = dismissible ? 'flex' : 'none';
+              sOverlay.classList.add('show');
+            }
+            document.querySelectorAll('a[href^="$FILE_PREFIX"]').forEach(a => {
+              a.addEventListener('click', async (e) => {
+                e.preventDefault();
+                const href = a.getAttribute('href');
+                showStatus("Waiting for the OK on the other phone…", false);
+                try {
+                  const r = await fetch(href + '$REQUEST_SUFFIX', {method: 'POST'});
+                  if (r.ok) {
+                    const data = await r.json();
+                    sOverlay.classList.remove('show');
+                    window.location.href = href + '?t=' + data.token;
+                  } else {
+                    showStatus("The phone's owner declined this download.", true);
+                  }
+                } catch (err) {
+                  showStatus("Connection lost — try again.", true);
+                }
+              });
             });
             </script>
             <div class="overlay" id="offerOverlay">
@@ -299,6 +386,19 @@ class FileShareServer(
         "The phone's owner did not approve this transfer.\n",
     )
 
+    /** Denial for a plain navigation (no-JS): a page, never a saved file. */
+    private fun deniedPage(): Response = newFixedLengthResponse(
+        Response.Status.FORBIDDEN, MIME_HTML,
+        """
+        <!doctype html>
+        <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Not approved</title>
+        <p style="font-family: system-ui, sans-serif; margin: 2rem;">
+          The phone's owner did not approve this transfer. <a href="/">Back</a>
+        </p>
+        """.trimIndent(),
+    )
+
     private fun esc(s: String): String = s
         .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
 
@@ -315,6 +415,11 @@ class FileShareServer(
         private const val FILE_PREFIX = "/files/"
         private const val UPLOAD_PREFIX = "/upload/"
         private const val OFFER_PREFIX = "/offer/"
+        private const val REQUEST_SUFFIX = "/request"
+
+        /** How long an approved-download token stays spendable. Generous — it
+         *  only bridges the page's redirect after the owner already said yes. */
+        private const val TOKEN_TTL_MS = 60_000L
     }
 }
 

--- a/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
+++ b/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
@@ -1,0 +1,200 @@
+package app.myco.hotspot
+
+import android.util.Log
+import fi.iki.elonen.NanoHTTPD
+import java.io.FileInputStream
+import java.io.InputStream
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+/**
+ * The web page a hotspot guest lands on: a plain-HTML file list with download
+ * links and an upload form. Served on every interface (the guest reaches it
+ * via the hotspot's gateway address); state lives in [SharedFiles].
+ *
+ * Framework-free HTML with one inline script: the form submits each picked
+ * file as a raw `PUT /upload/<urlencoded-name>`, because NanoHTTPD 2.3.1's
+ * multipart parser surfaces only the first of several same-named file parts
+ * and mangles non-ASCII filenames (it decodes part headers as ASCII). The
+ * multipart POST stays as the no-JS fallback.
+ */
+class FileShareServer(
+    private val files: SharedFiles,
+    port: Int,
+) : NanoHTTPD(port) {
+
+    override fun serve(session: IHTTPSession): Response = try {
+        when {
+            session.method == Method.GET && session.uri == "/" -> {
+                val sent = session.parameters["sent"]?.firstOrNull()?.toIntOrNull()
+                page(banner = sent?.let { "Received $it file${if (it == 1) "" else "s"}." })
+            }
+            session.method == Method.GET && session.uri.startsWith(FILE_PREFIX) ->
+                download(session.uri.removePrefix(FILE_PREFIX))
+            session.method == Method.PUT && session.uri.startsWith(UPLOAD_PREFIX) ->
+                uploadPut(session)
+            session.method == Method.POST && session.uri == "/upload" -> upload(session)
+            else -> newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "not found\n")
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "request ${session.method} ${session.uri} failed", e)
+        newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, "error\n")
+    }
+
+    private fun download(id: String): Response {
+        val entry = files.list().firstOrNull { it.id == id }
+            ?: return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "gone\n")
+        val (stream, size) = files.open(id)
+            ?: return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "gone\n")
+        val resp = if (size > 0) {
+            newFixedLengthResponse(Response.Status.OK, SharedFiles.mimeFor(entry.name), stream, size)
+        } else {
+            newChunkedResponse(Response.Status.OK, SharedFiles.mimeFor(entry.name), stream)
+        }
+        // RFC 5987 filename* so non-ASCII names survive; quoted fallback for
+        // browsers that ignore it.
+        val encoded = URLEncoder.encode(entry.name, "UTF-8").replace("+", "%20")
+        resp.addHeader(
+            "Content-Disposition",
+            "attachment; filename=\"${entry.name.replace("\"", "_")}\"; filename*=UTF-8''$encoded",
+        )
+        return resp
+    }
+
+    /** The primary upload path: one raw body per file, its name in the URL. */
+    private fun uploadPut(session: IHTTPSession): Response {
+        val name = URLDecoder.decode(session.uri.removePrefix(UPLOAD_PREFIX), "UTF-8")
+            .substringAfterLast('/').substringAfterLast('\\').ifBlank { "upload.bin" }
+        // The socket does not EOF between keep-alive requests, so the copy must
+        // stop at Content-Length rather than reading to end-of-stream.
+        val len = session.headers["content-length"]?.toLongOrNull()
+            ?: return newFixedLengthResponse(Response.Status.BAD_REQUEST, MIME_PLAINTEXT, "length required\n")
+        val ok = files.saveUpload(name, BoundedInputStream(session.inputStream, len))
+        return if (ok) {
+            newFixedLengthResponse(Response.Status.OK, MIME_PLAINTEXT, "ok\n")
+        } else {
+            newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, "failed\n")
+        }
+    }
+
+    /** No-JS fallback (multipart form POST) — see the class doc's caveats. */
+    private fun upload(session: IHTTPSession): Response {
+        // parseBody spools each part to a temp file and fills `body` with
+        // field-name -> temp path ("file", "file2", …); parameters["file"]
+        // carries whatever client filenames the parser managed to decode.
+        val body = HashMap<String, String>()
+        session.parseBody(body)
+        val names = session.parameters["file"].orEmpty()
+        var saved = 0
+        var i = 0
+        while (true) {
+            val tmp = body[if (i == 0) "file" else "file${i + 1}"] ?: break
+            val clientName = names.getOrNull(i)?.substringAfterLast('/')?.substringAfterLast('\\')
+            i++
+            // An empty <input type=file> still submits one nameless, empty part.
+            if (clientName.isNullOrBlank() && java.io.File(tmp).length() == 0L) continue
+            val name = clientName?.takeIf { it.isNotBlank() } ?: "upload-$i.bin"
+            FileInputStream(tmp).use { if (files.saveUpload(name, it)) saved++ }
+        }
+        // Re-render instead of redirecting, so the confirmation and the fresh
+        // list arrive in the same response.
+        return page(banner = if (saved > 0) "Received $saved file${if (saved == 1) "" else "s"}." else "Nothing was uploaded.")
+    }
+
+    private fun page(banner: String?): Response {
+        val rows = files.list().joinToString("\n") { e ->
+            """<li><a href="$FILE_PREFIX${e.id}" download>${esc(e.name)}</a> <span>${human(e.size)}</span></li>"""
+        }
+        val listing = if (rows.isEmpty()) "<p class=\"empty\">No files shared yet.</p>" else "<ul>\n$rows\n</ul>"
+        val note = banner?.let { "<p class=\"banner\">${esc(it)}</p>" } ?: ""
+        val html = """
+            <!doctype html>
+            <html lang="en">
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>Myco file share</title>
+            <style>
+              body { font-family: system-ui, sans-serif; margin: 0 auto; max-width: 32rem; padding: 1.2rem; }
+              h1 { font-size: 1.3rem; } h2 { font-size: 1rem; margin-top: 1.6rem; }
+              ul { list-style: none; padding: 0; }
+              li { display: flex; justify-content: space-between; gap: 1rem; padding: .45rem 0; border-bottom: 1px solid #ddd; }
+              li span { color: #777; white-space: nowrap; }
+              a { word-break: break-all; }
+              .banner { background: #e6f4ea; border: 1px solid #b7dfc2; padding: .5rem .8rem; border-radius: .5rem; }
+              .empty { color: #777; }
+              form { margin-top: .6rem; }
+              button { margin-top: .6rem; padding: .45rem 1rem; }
+            </style>
+            <h1>Myco file share</h1>
+            $note
+            <h2>Download</h2>
+            $listing
+            <h2>Send files to this phone</h2>
+            <form method="post" action="/upload" enctype="multipart/form-data">
+              <input type="file" name="file" multiple>
+              <button type="submit">Upload</button>
+            </form>
+            <script>
+            // One raw PUT per file (see the server's uploadPut); the form's
+            // multipart POST remains as the no-JS fallback.
+            const form = document.querySelector('form');
+            form.addEventListener('submit', async (e) => {
+              e.preventDefault();
+              const files = form.querySelector('input[type=file]').files;
+              if (!files.length) return;
+              const btn = form.querySelector('button');
+              btn.disabled = true; btn.textContent = 'Uploading…';
+              let sent = 0;
+              for (const f of files) {
+                try {
+                  const r = await fetch('$UPLOAD_PREFIX' + encodeURIComponent(f.name), {method: 'PUT', body: f});
+                  if (r.ok) sent++;
+                } catch (_) {}
+              }
+              location.href = '/?sent=' + sent;
+            });
+            </script>
+            </html>
+        """.trimIndent()
+        val resp = newFixedLengthResponse(Response.Status.OK, MIME_HTML, html)
+        resp.addHeader("Cache-Control", "no-store")
+        return resp
+    }
+
+    private fun esc(s: String): String = s
+        .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+
+    private fun human(bytes: Long): String = when {
+        bytes >= 1L shl 30 -> "%.1f GB".format(bytes.toDouble() / (1L shl 30))
+        bytes >= 1L shl 20 -> "%.1f MB".format(bytes.toDouble() / (1L shl 20))
+        bytes >= 1L shl 10 -> "%.0f kB".format(bytes.toDouble() / (1L shl 10))
+        bytes > 0 -> "$bytes B"
+        else -> ""
+    }
+
+    companion object {
+        private const val TAG = "MycoFileShare"
+        private const val FILE_PREFIX = "/files/"
+        private const val UPLOAD_PREFIX = "/upload/"
+    }
+}
+
+/** Reads at most `remaining` bytes from `src`, then reports end-of-stream. */
+private class BoundedInputStream(
+    private val src: InputStream,
+    private var remaining: Long,
+) : InputStream() {
+    override fun read(): Int {
+        if (remaining <= 0) return -1
+        val b = src.read()
+        if (b >= 0) remaining--
+        return b
+    }
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+        if (remaining <= 0) return -1
+        val n = src.read(b, off, minOf(len.toLong(), remaining).toInt())
+        if (n > 0) remaining -= n
+        return n
+    }
+}

--- a/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
+++ b/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
@@ -6,20 +6,25 @@ import java.io.FileInputStream
 import java.io.InputStream
 import java.net.URLDecoder
 import java.net.URLEncoder
+import org.json.JSONArray
+import org.json.JSONObject
 
 /**
  * The web page a hotspot guest lands on: a plain-HTML file list with download
  * links and an upload form. Served on every interface (the guest reaches it
  * via the hotspot's gateway address); state lives in [SharedFiles].
  *
- * Framework-free HTML with one inline script: the form submits each picked
+ * Framework-free HTML with two inline scripts: the form submits each picked
  * file as a raw `PUT /upload/<urlencoded-name>`, because NanoHTTPD 2.3.1's
  * multipart parser surfaces only the first of several same-named file parts
- * and mangles non-ASCII filenames (it decodes part headers as ASCII). The
- * multipart POST stays as the no-JS fallback.
+ * and mangles non-ASCII filenames (it decodes part headers as ASCII) — the
+ * multipart POST stays as the no-JS fallback. The second script polls
+ * `/offers` for files the phone is pushing ([Outbox]) and pops an
+ * accept/decline dialog per offer, AirDrop-style.
  */
 class FileShareServer(
     private val files: SharedFiles,
+    private val outbox: Outbox,
     port: Int,
 ) : NanoHTTPD(port) {
 
@@ -34,6 +39,14 @@ class FileShareServer(
             session.method == Method.PUT && session.uri.startsWith(UPLOAD_PREFIX) ->
                 uploadPut(session)
             session.method == Method.POST && session.uri == "/upload" -> upload(session)
+            // The push half: the guest's page polls /offers, then accepts
+            // (GET, streams the file) or declines (POST) one by id.
+            session.method == Method.GET && session.uri == "/offers" -> offersJson()
+            session.method == Method.POST && session.uri.startsWith(OFFER_PREFIX) &&
+                session.uri.endsWith("/decline") ->
+                declineOffer(session.uri.removePrefix(OFFER_PREFIX).removeSuffix("/decline"))
+            session.method == Method.GET && session.uri.startsWith(OFFER_PREFIX) ->
+                sendOffer(session.uri.removePrefix(OFFER_PREFIX))
             else -> newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "not found\n")
         }
     } catch (e: Exception) {
@@ -56,14 +69,18 @@ class FileShareServer(
         } else {
             newChunkedResponse(Response.Status.OK, SharedFiles.mimeFor(entry.name), stream)
         }
-        // RFC 5987 filename* so non-ASCII names survive; quoted fallback for
-        // browsers that ignore it.
-        val encoded = URLEncoder.encode(entry.name, "UTF-8").replace("+", "%20")
+        attachAs(resp, entry.name)
+        return resp
+    }
+
+    /** RFC 5987 filename* so non-ASCII names survive; quoted fallback for
+     *  browsers that ignore it. */
+    private fun attachAs(resp: Response, name: String) {
+        val encoded = URLEncoder.encode(name, "UTF-8").replace("+", "%20")
         resp.addHeader(
             "Content-Disposition",
-            "attachment; filename=\"${entry.name.replace("\"", "_")}\"; filename*=UTF-8''$encoded",
+            "attachment; filename=\"${name.replace("\"", "_")}\"; filename*=UTF-8''$encoded",
         )
-        return resp
     }
 
     /** The primary upload path: one raw body per file, its name in the URL. */
@@ -141,6 +158,12 @@ class FileShareServer(
               .empty { color: #777; }
               form { margin-top: .6rem; }
               button { margin-top: .6rem; padding: .45rem 1rem; }
+              .overlay { position: fixed; inset: 0; background: rgba(0,0,0,.45); display: none; align-items: center; justify-content: center; }
+              .overlay.show { display: flex; }
+              .dialog { background: #fff; color: #111; border-radius: .8rem; padding: 1.2rem; max-width: 20rem; margin: 1rem; box-shadow: 0 8px 30px rgba(0,0,0,.25); }
+              .dialog h2 { margin: 0 0 .5rem; }
+              .dialog .actions { display: flex; gap: .8rem; justify-content: flex-end; margin-top: 1rem; }
+              .dialog button { margin-top: 0; }
             </style>
             <h1>Myco file share</h1>
             <p class="empty">Every transfer waits for an OK on this phone — give it a moment.</p>
@@ -172,11 +195,103 @@ class FileShareServer(
               location.href = '/?sent=' + sent;
             });
             </script>
+            <div class="overlay" id="offerOverlay">
+              <div class="dialog">
+                <h2>Incoming file</h2>
+                <p id="offerText"></p>
+                <div class="actions">
+                  <button id="offerDecline">Decline</button>
+                  <button id="offerAccept">Accept</button>
+                </div>
+              </div>
+            </div>
+            <script>
+            // AirDrop-style receive: poll the phone for files it is offering;
+            // each one pops this accept/decline dialog. Accepting navigates to
+            // the offer URL, which the browser saves as a normal download.
+            const overlay = document.getElementById('offerOverlay');
+            const offerText = document.getElementById('offerText');
+            let current = null;
+            const handled = new Set();
+            function humanSize(b) {
+              if (b >= 1048576) return (b / 1048576).toFixed(1) + ' MB';
+              if (b >= 1024) return Math.round(b / 1024) + ' kB';
+              return b > 0 ? b + ' B' : '';
+            }
+            function settle(accepted) {
+              if (!current) return;
+              handled.add(current.id);
+              if (accepted) {
+                window.location.href = '/offer/' + current.id;
+              } else {
+                fetch('/offer/' + current.id + '/decline', {method: 'POST'});
+              }
+              overlay.classList.remove('show');
+              current = null;
+            }
+            document.getElementById('offerAccept').addEventListener('click', () => settle(true));
+            document.getElementById('offerDecline').addEventListener('click', () => settle(false));
+            async function pollOffers() {
+              try {
+                const r = await fetch('/offers');
+                const data = await r.json();
+                const next = data.offers.find(o => !handled.has(o.id));
+                if (next && !current) {
+                  current = next;
+                  const size = humanSize(next.size);
+                  offerText.textContent = 'The phone wants to send you "' + next.name + '"' +
+                    (size ? ' (' + size + ')' : '') + '.';
+                  overlay.classList.add('show');
+                }
+              } catch (e) {}
+              setTimeout(pollOffers, 2000);
+            }
+            pollOffers();
+            </script>
             </html>
         """.trimIndent()
         val resp = newFixedLengthResponse(Response.Status.OK, MIME_HTML, html)
         resp.addHeader("Cache-Control", "no-store")
         return resp
+    }
+
+    // --- host -> guest offers ---
+
+    private fun offersJson(): Response {
+        val arr = JSONArray()
+        outbox.waiting().forEach { o ->
+            arr.put(JSONObject().put("id", o.id).put("name", o.name).put("size", o.size))
+        }
+        val resp = newFixedLengthResponse(
+            Response.Status.OK, "application/json", JSONObject().put("offers", arr).toString(),
+        )
+        resp.addHeader("Cache-Control", "no-store")
+        return resp
+    }
+
+    /** The guest tapped Accept: stream the offered document. No [TransferGate]
+     *  here — the owner's consent *was* offering the file. */
+    private fun sendOffer(idStr: String): Response {
+        val id = idStr.toLongOrNull()
+            ?: return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "gone\n")
+        val (offer, stream) = outbox.accept(id)
+            ?: return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "gone\n")
+        Log.i(TAG, "offer '${offer.name}' accepted by the guest")
+        val resp = if (offer.size > 0) {
+            newFixedLengthResponse(Response.Status.OK, SharedFiles.mimeFor(offer.name), stream, offer.size)
+        } else {
+            newChunkedResponse(Response.Status.OK, SharedFiles.mimeFor(offer.name), stream)
+        }
+        attachAs(resp, offer.name)
+        return resp
+    }
+
+    private fun declineOffer(idStr: String): Response {
+        idStr.toLongOrNull()?.let {
+            Log.i(TAG, "offer #$it declined by the guest")
+            outbox.decline(it)
+        }
+        return newFixedLengthResponse(Response.Status.OK, MIME_PLAINTEXT, "ok\n")
     }
 
     private fun denied(): Response = newFixedLengthResponse(
@@ -199,6 +314,7 @@ class FileShareServer(
         private const val TAG = "MycoFileShare"
         private const val FILE_PREFIX = "/files/"
         private const val UPLOAD_PREFIX = "/upload/"
+        private const val OFFER_PREFIX = "/offer/"
     }
 }
 

--- a/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
+++ b/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
@@ -44,6 +44,11 @@ class FileShareServer(
     private fun download(id: String): Response {
         val entry = files.list().firstOrNull { it.id == id }
             ?: return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "gone\n")
+        // Blocks this request thread until the owner taps Allow — the guest's
+        // browser sits on a spinning tab, then the download starts (or 403s).
+        val allowed = TransferGate.request(TransferGate.Direction.DOWNLOAD, entry.name, entry.size)
+        Log.i(TAG, "download '${entry.name}' ${if (allowed) "allowed" else "denied"}")
+        if (!allowed) return denied()
         val (stream, size) = files.open(id)
             ?: return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "gone\n")
         val resp = if (size > 0) {
@@ -69,6 +74,15 @@ class FileShareServer(
         // stop at Content-Length rather than reading to end-of-stream.
         val len = session.headers["content-length"]?.toLongOrNull()
             ?: return newFixedLengthResponse(Response.Status.BAD_REQUEST, MIME_PLAINTEXT, "length required\n")
+        // Ask the owner *before* reading the body — TCP backpressure holds the
+        // guest's send while the request waits. A denial answers without ever
+        // consuming the body, so the connection must close rather than let the
+        // unread bytes garble the next keep-alive request.
+        val allowed = TransferGate.request(TransferGate.Direction.UPLOAD, name, len)
+        Log.i(TAG, "upload '$name' ($len B) ${if (allowed) "allowed" else "denied"}")
+        if (!allowed) {
+            return denied().apply { addHeader("Connection", "close") }
+        }
         val ok = files.saveUpload(name, BoundedInputStream(session.inputStream, len))
         return if (ok) {
             newFixedLengthResponse(Response.Status.OK, MIME_PLAINTEXT, "ok\n")
@@ -94,6 +108,9 @@ class FileShareServer(
             // An empty <input type=file> still submits one nameless, empty part.
             if (clientName.isNullOrBlank() && java.io.File(tmp).length() == 0L) continue
             val name = clientName?.takeIf { it.isNotBlank() } ?: "upload-$i.bin"
+            // The bytes are already in the temp file, but nothing is kept
+            // without the owner's OK.
+            if (!TransferGate.request(TransferGate.Direction.UPLOAD, name, java.io.File(tmp).length())) continue
             FileInputStream(tmp).use { if (files.saveUpload(name, it)) saved++ }
         }
         // Re-render instead of redirecting, so the confirmation and the fresh
@@ -126,6 +143,7 @@ class FileShareServer(
               button { margin-top: .6rem; padding: .45rem 1rem; }
             </style>
             <h1>Myco file share</h1>
+            <p class="empty">Every transfer waits for an OK on this phone — give it a moment.</p>
             $note
             <h2>Download</h2>
             $listing
@@ -143,7 +161,7 @@ class FileShareServer(
               const files = form.querySelector('input[type=file]').files;
               if (!files.length) return;
               const btn = form.querySelector('button');
-              btn.disabled = true; btn.textContent = 'Uploading…';
+              btn.disabled = true; btn.textContent = 'Waiting for the OK…';
               let sent = 0;
               for (const f of files) {
                 try {
@@ -160,6 +178,11 @@ class FileShareServer(
         resp.addHeader("Cache-Control", "no-store")
         return resp
     }
+
+    private fun denied(): Response = newFixedLengthResponse(
+        Response.Status.FORBIDDEN, MIME_PLAINTEXT,
+        "The phone's owner did not approve this transfer.\n",
+    )
 
     private fun esc(s: String): String = s
         .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")

--- a/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
+++ b/android/app/src/main/java/app/myco/hotspot/FileShareServer.kt
@@ -16,13 +16,13 @@ import org.json.JSONObject
  * links and an upload form. Served on every interface (the guest reaches it
  * via the hotspot's gateway address); state lives in [SharedFiles].
  *
- * Framework-free HTML with two inline scripts: the form submits each picked
- * file as a raw `PUT /upload/<urlencoded-name>`, because NanoHTTPD 2.3.1's
- * multipart parser surfaces only the first of several same-named file parts
- * and mangles non-ASCII filenames (it decodes part headers as ASCII) — the
- * multipart POST stays as the no-JS fallback. The second script polls
- * `/offers` for files the phone is pushing ([Outbox]) and pops an
- * accept/decline dialog per offer, AirDrop-style.
+ * Framework-free HTML styled to the app's AMOLED theme, with one inline
+ * script. Uploads go as one raw `PUT /upload/<urlencoded-name>` per picked
+ * file, because NanoHTTPD 2.3.1's multipart parser surfaces only the first of
+ * several same-named file parts and mangles non-ASCII filenames (it decodes
+ * part headers as ASCII) — a multipart POST form stays as the no-JS fallback.
+ * The script also polls `/offers` for files the phone is pushing ([Outbox])
+ * and pops an accept/decline dialog per offer, AirDrop-style.
  */
 class FileShareServer(
     private val files: SharedFiles,
@@ -183,54 +183,141 @@ class FileShareServer(
         // header, so a no-JS denial (an HTML page) renders instead of being
         // saved as a "rejected" file.
         val rows = files.list().joinToString("\n") { e ->
-            """<li><a href="$FILE_PREFIX${e.id}">${esc(e.name)}</a> <span>${human(e.size)}</span></li>"""
+            """<li><a href="$FILE_PREFIX${e.id}"><span class="fname">${esc(e.name)}</span><span class="fsize">${human(e.size)}</span></a></li>"""
         }
-        val listing = if (rows.isEmpty()) "<p class=\"empty\">No files shared yet.</p>" else "<ul>\n$rows\n</ul>"
+        val listing = if (rows.isEmpty()) {
+            "<p class=\"muted\">Nothing shared from the phone yet.</p>"
+        } else {
+            "<ul class=\"files\">\n$rows\n</ul>"
+        }
         val note = banner?.let { "<p class=\"banner\">${esc(it)}</p>" } ?: ""
+        // Styled to match the app's AMOLED theme (ui/theme/Theme.kt): black
+        // ground, white text, emerald 34D399 accent with black on-accent,
+        // 3F3F46 outlines, FF6B6B error — and the hotspot sheet's shapes
+        // (uppercase section labels, pill buttons, a green tethering mark).
         val html = """
             <!doctype html>
             <html lang="en">
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
+            <meta name="theme-color" content="#000000">
             <title>Myco file share</title>
             <style>
-              body { font-family: system-ui, sans-serif; margin: 0 auto; max-width: 32rem; padding: 1.2rem; }
-              h1 { font-size: 1.3rem; } h2 { font-size: 1rem; margin-top: 1.6rem; }
-              ul { list-style: none; padding: 0; }
-              li { display: flex; justify-content: space-between; gap: 1rem; padding: .45rem 0; border-bottom: 1px solid #ddd; }
-              li span { color: #777; white-space: nowrap; }
-              a { word-break: break-all; }
-              .banner { background: #e6f4ea; border: 1px solid #b7dfc2; padding: .5rem .8rem; border-radius: .5rem; }
-              .empty { color: #777; }
-              form { margin-top: .6rem; }
-              button { margin-top: .6rem; padding: .45rem 1rem; }
-              .overlay { position: fixed; inset: 0; background: rgba(0,0,0,.45); display: none; align-items: center; justify-content: center; }
+              :root { --bg:#000; --fg:#fff; --muted:#9ca3af; --accent:#34d399; --on-accent:#000;
+                      --outline:#3f3f46; --error:#ff6b6b; --surface:#101012; }
+              * { box-sizing: border-box; }
+              body { font-family: system-ui, sans-serif; background: var(--bg); color: var(--fg);
+                     margin: 0 auto; max-width: 30rem; padding: 1.4rem 1.2rem 3rem; }
+              header { display: flex; align-items: center; gap: .6rem; margin-bottom: .3rem; }
+              header svg { flex: none; }
+              h1 { font-size: 1.35rem; font-weight: 800; margin: 0; }
+              .hint { color: var(--muted); font-size: .85rem; margin: .3rem 0 1.2rem; }
+              .label { color: var(--muted); font-weight: 700; font-size: .72rem; letter-spacing: .08em;
+                       text-transform: uppercase; margin: 1.7rem 0 .5rem; }
+              .muted { color: var(--muted); font-size: .9rem; }
+              ul.files { list-style: none; margin: 0; padding: 0; }
+              ul.files li + li { border-top: 1px solid var(--outline); }
+              ul.files a { display: flex; justify-content: space-between; gap: 1rem; align-items: baseline;
+                           padding: .8rem .2rem; text-decoration: none; color: var(--fg); }
+              .fname { word-break: break-all; font-weight: 600; }
+              .fsize { color: var(--muted); white-space: nowrap; font-size: .85rem; }
+              .banner { background: #04241a; border: 1px solid #14532d; color: var(--accent);
+                        padding: .6rem .9rem; border-radius: .7rem; font-size: .9rem; }
+              .pick-list { list-style: none; margin: .4rem 0 0; padding: 0; }
+              .pick-list li { display: flex; justify-content: space-between; gap: 1rem;
+                              color: var(--muted); font-size: .85rem; padding: .25rem .2rem; }
+              .actions { display: flex; gap: .8rem; align-items: center; margin-top: .9rem; }
+              .btn { border-radius: 999px; padding: .65rem 1.4rem; font-size: .95rem; font-weight: 700;
+                     border: 1px solid transparent; font-family: inherit; cursor: pointer; }
+              .btn-primary { background: var(--accent); color: var(--on-accent); }
+              .btn-primary:disabled { background: #1f2937; color: #6b7280; }
+              .btn-outline { background: transparent; color: var(--accent); border-color: var(--outline); }
+              .btn-text-danger { background: none; border: none; color: var(--error); font-weight: 700;
+                                 font-family: inherit; font-size: .95rem; cursor: pointer; }
+              #fileInput { display: none; }
+              .overlay { position: fixed; inset: 0; background: rgba(0,0,0,.6); display: none;
+                         align-items: center; justify-content: center; }
               .overlay.show { display: flex; }
-              .dialog { background: #fff; color: #111; border-radius: .8rem; padding: 1.2rem; max-width: 20rem; margin: 1rem; box-shadow: 0 8px 30px rgba(0,0,0,.25); }
-              .dialog h2 { margin: 0 0 .5rem; }
-              .dialog .actions { display: flex; gap: .8rem; justify-content: flex-end; margin-top: 1rem; }
-              .dialog button { margin-top: 0; }
+              .dialog { background: var(--surface); color: var(--fg); border: 1px solid var(--outline);
+                        border-radius: 1rem; padding: 1.2rem 1.2rem 1rem; max-width: 20rem; margin: 1rem;
+                        box-shadow: 0 8px 30px rgba(0,0,0,.5); }
+              .dialog h2 { margin: 0 0 .5rem; font-size: 1.05rem; }
+              .dialog p { margin: 0; }
+              .dialog .actions { justify-content: flex-end; margin-top: 1rem; }
             </style>
-            <h1>Myco file share</h1>
-            <p class="empty">Every transfer waits for an OK on this phone — give it a moment.</p>
+            <header>
+              <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+                <circle cx="12" cy="14" r="2" fill="#34d399" stroke="none"/>
+                <path d="M8.5 10.5a5 5 0 0 1 7 0"/>
+                <path d="M5.7 7.7a9 9 0 0 1 12.6 0"/>
+              </svg>
+              <h1>Share files over hotspot</h1>
+            </header>
+            <p class="hint">Every transfer waits for an OK on the phone — give it a moment.</p>
             $note
-            <h2>Download</h2>
+            <div class="label">Download from the phone</div>
             $listing
-            <h2>Send files to this phone</h2>
-            <form method="post" action="/upload" enctype="multipart/form-data">
-              <input type="file" name="file" multiple>
-              <button type="submit">Upload</button>
-            </form>
+            <div class="label">Send files to the phone</div>
+            <input type="file" id="fileInput" multiple>
+            <ul class="pick-list" id="pickList"></ul>
+            <div class="actions">
+              <label for="fileInput" class="btn btn-outline">+ Choose files</label>
+              <button class="btn btn-primary" id="sendBtn" disabled>Send</button>
+            </div>
+            <noscript>
+              <p class="muted">JavaScript is off — transfers with approval need it. Basic upload:</p>
+              <form method="post" action="/upload" enctype="multipart/form-data">
+                <input type="file" name="file" multiple>
+                <button type="submit">Upload</button>
+              </form>
+            </noscript>
+            <div class="overlay" id="statusOverlay">
+              <div class="dialog">
+                <p id="statusText"></p>
+                <div class="actions" id="statusActions" style="display:none">
+                  <button class="btn btn-outline" id="statusOk">OK</button>
+                </div>
+              </div>
+            </div>
+            <div class="overlay" id="offerOverlay">
+              <div class="dialog">
+                <h2>Incoming file</h2>
+                <p id="offerText"></p>
+                <div class="actions">
+                  <button class="btn-text-danger" id="offerDecline">Decline</button>
+                  <button class="btn btn-primary" id="offerAccept">Accept</button>
+                </div>
+              </div>
+            </div>
             <script>
-            // One raw PUT per file (see the server's uploadPut); the form's
-            // multipart POST remains as the no-JS fallback.
-            const form = document.querySelector('form');
-            form.addEventListener('submit', async (e) => {
-              e.preventDefault();
-              const files = form.querySelector('input[type=file]').files;
+            function humanSize(b) {
+              if (b >= 1048576) return (b / 1048576).toFixed(1) + ' MB';
+              if (b >= 1024) return Math.round(b / 1024) + ' kB';
+              return b > 0 ? b + ' B' : '';
+            }
+
+            // --- picking + sending (one raw PUT per file; see uploadPut) ---
+            const fileInput = document.getElementById('fileInput');
+            const pickList = document.getElementById('pickList');
+            const sendBtn = document.getElementById('sendBtn');
+            fileInput.addEventListener('change', () => {
+              pickList.textContent = '';
+              for (const f of fileInput.files) {
+                const li = document.createElement('li');
+                const name = document.createElement('span');
+                name.textContent = f.name;
+                const size = document.createElement('span');
+                size.textContent = humanSize(f.size);
+                li.append(name, size);
+                pickList.append(li);
+              }
+              sendBtn.disabled = fileInput.files.length === 0;
+            });
+            sendBtn.addEventListener('click', async () => {
+              const files = fileInput.files;
               if (!files.length) return;
-              const btn = form.querySelector('button');
-              btn.disabled = true; btn.textContent = 'Waiting for the OK…';
+              sendBtn.disabled = true;
+              sendBtn.textContent = 'Waiting for the OK…';
               let sent = 0;
               for (const f of files) {
                 try {
@@ -240,19 +327,8 @@ class FileShareServer(
               }
               location.href = '/?sent=' + sent;
             });
-            </script>
-            <div class="overlay" id="statusOverlay">
-              <div class="dialog">
-                <p id="statusText"></p>
-                <div class="actions" id="statusActions" style="display:none">
-                  <button id="statusOk">OK</button>
-                </div>
-              </div>
-            </div>
-            <script>
-            // Downloads ask the phone's owner first (POST …/request blocks on
-            // their dialog). Denial becomes THIS dialog — never a saved file;
-            // approval navigates with a one-time token and streams instantly.
+
+            // --- status dialog (download approval / denial) ---
             const sOverlay = document.getElementById('statusOverlay');
             const sText = document.getElementById('statusText');
             const sActions = document.getElementById('statusActions');
@@ -262,6 +338,9 @@ class FileShareServer(
               sActions.style.display = dismissible ? 'flex' : 'none';
               sOverlay.classList.add('show');
             }
+            // Downloads ask the phone's owner first (POST …/request blocks on
+            // their dialog). Denial becomes THIS dialog — never a saved file;
+            // approval navigates with a one-time token and streams instantly.
             document.querySelectorAll('a[href^="$FILE_PREFIX"]').forEach(a => {
               a.addEventListener('click', async (e) => {
                 e.preventDefault();
@@ -281,30 +360,12 @@ class FileShareServer(
                 }
               });
             });
-            </script>
-            <div class="overlay" id="offerOverlay">
-              <div class="dialog">
-                <h2>Incoming file</h2>
-                <p id="offerText"></p>
-                <div class="actions">
-                  <button id="offerDecline">Decline</button>
-                  <button id="offerAccept">Accept</button>
-                </div>
-              </div>
-            </div>
-            <script>
-            // AirDrop-style receive: poll the phone for files it is offering;
-            // each one pops this accept/decline dialog. Accepting navigates to
-            // the offer URL, which the browser saves as a normal download.
+
+            // --- AirDrop-style receive: poll for files the phone is offering ---
             const overlay = document.getElementById('offerOverlay');
             const offerText = document.getElementById('offerText');
             let current = null;
             const handled = new Set();
-            function humanSize(b) {
-              if (b >= 1048576) return (b / 1048576).toFixed(1) + ' MB';
-              if (b >= 1024) return Math.round(b / 1024) + ' kB';
-              return b > 0 ? b + ' B' : '';
-            }
             function settle(accepted) {
               if (!current) return;
               handled.add(current.id);

--- a/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
+++ b/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
@@ -80,6 +80,9 @@ class HotspotService : Service() {
         startForegroundCompat()
         starting = true
         publish(HotspotView(phase = HotspotPhase.STARTING))
+        // From this moment NFC belongs to the hotspot: pairing-by-bump is off,
+        // and once the page address is known a bump serves that instead.
+        PairPresent.beginHotspot()
         // The Wi-Fi chip cannot host an AP interface next to the Aware (NAN)
         // session the mesh's Aware lane holds — seen on Pixel 9 as HalDevMgr
         // "bestIfaceCreationProposal is null" followed by ERROR_INCOMPATIBLE_MODE.

--- a/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
+++ b/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
@@ -176,7 +176,7 @@ class HotspotService : Service() {
     /** Bind the file page, walking a few ports in case one is taken. */
     private fun startServer(): FileShareServer? {
         for (port in BASE_PORT until BASE_PORT + PORT_TRIES) {
-            val srv = FileShareServer(SharedFiles.get(this), port)
+            val srv = FileShareServer(SharedFiles.get(this), Outbox.get(this), port)
             try {
                 srv.start(SOCKET_READ_TIMEOUT_MS, false)
                 return srv
@@ -273,6 +273,8 @@ class HotspotService : Service() {
         // Fail waiting transfers first, so their server threads unblock and the
         // server's stop() isn't held up by sockets mid-approval.
         TransferGate.denyAll()
+        // The session's outgoing offers die with it.
+        Outbox.get(this).clear()
         server?.let { runCatching { it.stop() } }
         server = null
         reservation?.let { runCatching { it.close() } }

--- a/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
+++ b/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
@@ -231,18 +231,45 @@ class HotspotService : Service() {
         // Several survivors would be pathological; prefer a softap-ish name.
         val pick = candidates.minByOrNull { (name, _) ->
             if (AP_IFACE_PREFIXES.any(name::startsWith)) 0 else 1
-        } ?: return null
+        } ?: run {
+            // DIAG: which side failed — enumeration or the known-set exclusion?
+            val all = runCatching {
+                NetworkInterface.getNetworkInterfaces().toList()
+                    .filter { runCatching { it.isUp }.getOrDefault(false) }
+                    .flatMap { i -> i.inetAddresses.toList().filterIsInstance<Inet4Address>().map { "${i.name}=${it.hostAddress}" } }
+            }.getOrElse { listOf("enum threw: $it") }
+            Log.i(TAG, "DIAG no candidate; ifaces=$all known=$known")
+            return null
+        }
         Log.i(TAG, "hotspot address ${pick.second.hostAddress} on ${pick.first}")
         return pick.second.hostAddress
     }
 
-    /** IPv4 addresses of every Network the app can see (see [hotspotIpv4]). */
+    /**
+     * IPv4 addresses of every Network that is positively NOT the hotspot:
+     * anything that may reach the internet (client Wi-Fi — capability, not
+     * validation, so an offline `!FIPS` AP still counts), cellular, or a VPN
+     * (the mesh TUN). Networks outside those classes are left OUT of the set
+     * on purpose: some Android builds surface the local-only hotspot itself
+     * as a Network to its owner (seen on this Pixel once a guest joined), and
+     * excluding by "any known network" then swallowed the AP address.
+     */
     private fun knownNetworkV4(): Set<String> {
         val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as android.net.ConnectivityManager
         @Suppress("DEPRECATION") // enumerating all networks is exactly the point
         return cm.allNetworks.flatMap { n ->
-            cm.getLinkProperties(n)?.linkAddresses.orEmpty()
-                .mapNotNull { (it.address as? Inet4Address)?.hostAddress }
+            val caps = cm.getNetworkCapabilities(n)
+            val notHotspot = caps != null && (
+                caps.hasCapability(android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET) ||
+                    caps.hasTransport(android.net.NetworkCapabilities.TRANSPORT_CELLULAR) ||
+                    caps.hasTransport(android.net.NetworkCapabilities.TRANSPORT_VPN)
+                )
+            if (!notHotspot) {
+                emptyList()
+            } else {
+                cm.getLinkProperties(n)?.linkAddresses.orEmpty()
+                    .mapNotNull { (it.address as? Inet4Address)?.hostAddress }
+            }
         }.toSet()
     }
 

--- a/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
+++ b/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
@@ -20,11 +20,18 @@ import app.myco.MainActivity
 import app.myco.R
 import app.myco.aware.AwareRadio
 import app.myco.aware.AwareService
+import app.myco.nfc.PairPresent
 import java.net.Inet4Address
 import java.net.NetworkInterface
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 /**
  * Foreground service owning the **file-share hotspot**: a
@@ -48,6 +55,8 @@ class HotspotService : Service() {
     private var pausedAware = false
     private var lohsRetries = 0
     private val handler = Handler(Looper.getMainLooper())
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private var approvalsJob: Job? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -140,7 +149,28 @@ class HotspotService : Service() {
         Log.i(TAG, "hotspot '$ssid' up, file page on port ${srv.listeningPort}")
         publish(HotspotView(phase = HotspotPhase.ON, ssid = ssid, passphrase = pass))
         updateNotification("Hotspot “$ssid” is on")
+        watchApprovals(ssid)
         awaitOwnAddress(srv.listeningPort, tries = IP_POLL_TRIES)
+    }
+
+    /** Keep the notification pointing at the most urgent thing: a transfer
+     *  waiting for the owner's OK beats the idle "hotspot is on" line, because
+     *  the guest's request times out to a deny if nobody notices it. */
+    private fun watchApprovals(ssid: String) {
+        approvalsJob?.cancel()
+        approvalsJob = scope.launch {
+            TransferGate.pending.collect { reqs ->
+                val first = reqs.firstOrNull()
+                updateNotification(
+                    when {
+                        first == null -> "Hotspot “$ssid” is on"
+                        first.direction == TransferGate.Direction.DOWNLOAD ->
+                            "Guest asks for “${first.name}” — open Myco to allow"
+                        else -> "Guest sends “${first.name}” — open Myco to accept"
+                    },
+                )
+            }
+        }
     }
 
     /** Bind the file page, walking a few ports in case one is taken. */
@@ -166,7 +196,11 @@ class HotspotService : Service() {
     private fun awaitOwnAddress(port: Int, tries: Int) {
         val ip = hotspotIpv4()
         if (ip != null) {
-            publish(_view.value.copy(url = "http://$ip:$port"))
+            val url = "http://$ip:$port"
+            publish(_view.value.copy(url = url))
+            // From here a bump hands any phone the page: the emulated NFC tag
+            // serves the URL and the reader's OS opens it in its browser.
+            PairPresent.beginUrl(url)
             return
         }
         if (tries <= 0 || reservation == null) {
@@ -233,6 +267,12 @@ class HotspotService : Service() {
 
     private fun shutdown(finalView: HotspotView = HotspotView()) {
         handler.removeCallbacksAndMessages(null)
+        approvalsJob?.cancel()
+        approvalsJob = null
+        PairPresent.stopUrl()
+        // Fail waiting transfers first, so their server threads unblock and the
+        // server's stop() isn't held up by sockets mid-approval.
+        TransferGate.denyAll()
         server?.let { runCatching { it.stop() } }
         server = null
         reservation?.let { runCatching { it.close() } }
@@ -253,6 +293,7 @@ class HotspotService : Service() {
 
     override fun onDestroy() {
         if (reservation != null || server != null || starting) shutdown()
+        scope.cancel()
         super.onDestroy()
     }
 

--- a/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
+++ b/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
@@ -1,0 +1,363 @@
+package app.myco.hotspot
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import app.myco.MainActivity
+import app.myco.R
+import app.myco.aware.AwareRadio
+import app.myco.aware.AwareService
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Foreground service owning the **file-share hotspot**: a
+ * [WifiManager.startLocalOnlyHotspot] reservation (the OS picks the SSID and
+ * WPA2 passphrase) plus the [FileShareServer] a joined guest browses to.
+ *
+ * A local-only hotspot dies with its reservation, so the reservation must live
+ * somewhere that survives the Circle sheet being dismissed and the app being
+ * backgrounded — that is this service. `connectedDevice` is the right FGS type:
+ * the whole point is a live link to a nearby device, and the app holds
+ * CHANGE_WIFI_STATE, which qualifies it for that type.
+ *
+ * State is published like the radios do it ([app.myco.ap.ApRadio]): a
+ * process-wide [StateFlow] the Circle sheet collects.
+ */
+class HotspotService : Service() {
+
+    private var reservation: WifiManager.LocalOnlyHotspotReservation? = null
+    private var server: FileShareServer? = null
+    private var starting = false
+    private var pausedAware = false
+    private var lohsRetries = 0
+    private val handler = Handler(Looper.getMainLooper())
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                shutdown()
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            else -> begin()
+        }
+        // NOT_STICKY: a hotspot the system killed is gone (the reservation died
+        // with the process) — restarting the service alone would show a lying
+        // "on" notification, and re-opening a hotspot unasked is not our call.
+        return START_NOT_STICKY
+    }
+
+    private fun begin() {
+        if (reservation != null || starting) return
+        startForegroundCompat()
+        starting = true
+        publish(HotspotView(phase = HotspotPhase.STARTING))
+        // The Wi-Fi chip cannot host an AP interface next to the Aware (NAN)
+        // session the mesh's Aware lane holds — seen on Pixel 9 as HalDevMgr
+        // "bestIfaceCreationProposal is null" followed by ERROR_INCOMPATIBLE_MODE.
+        // Pause Aware for the hotspot's lifetime (shutdown restores it) and give
+        // the HAL a beat to actually release the interface before asking for AP.
+        val prefs = getSharedPreferences("myco_prefs", MODE_PRIVATE)
+        val awareOn = prefs.getBoolean(MainActivity.PREF_AWARE, true) && AwareRadio.isSupported(this)
+        if (awareOn) {
+            Log.i(TAG, "pausing Wi-Fi Aware while the hotspot runs")
+            AwareService.stop(this)
+            pausedAware = true
+        }
+        lohsRetries = LOHS_RETRIES
+        handler.postDelayed({ requestLohs() }, if (awareOn) AWARE_RELEASE_MS else 0)
+    }
+
+    private fun requestLohs() {
+        if (!starting) return // stopped while waiting
+        val wifi = getSystemService(Context.WIFI_SERVICE) as WifiManager
+        try {
+            wifi.startLocalOnlyHotspot(object : WifiManager.LocalOnlyHotspotCallback() {
+                override fun onStarted(res: WifiManager.LocalOnlyHotspotReservation) {
+                    starting = false
+                    reservation = res
+                    onHotspotUp(res)
+                }
+
+                override fun onFailed(reason: Int) {
+                    // INCOMPATIBLE_MODE right after releasing Aware usually means
+                    // the NAN interface is still tearing down — retry, don't die.
+                    if (reason == WifiManager.LocalOnlyHotspotCallback.ERROR_INCOMPATIBLE_MODE &&
+                        lohsRetries-- > 0
+                    ) {
+                        Log.i(TAG, "hotspot refused (mode conflict), retrying…")
+                        handler.postDelayed({ requestLohs() }, LOHS_RETRY_MS)
+                        return
+                    }
+                    starting = false
+                    fail("The system refused to start a hotspot (code $reason). Turn off tethering and try again.")
+                }
+
+                override fun onStopped() {
+                    // The system tore it down (e.g. real tethering started).
+                    Log.i(TAG, "local-only hotspot stopped by the system")
+                    shutdown()
+                    stopSelf()
+                }
+            }, handler)
+        } catch (e: Exception) {
+            // SecurityException (permission/location off) or IllegalStateException.
+            starting = false
+            fail("Couldn't start the hotspot: ${e.message ?: e.javaClass.simpleName}")
+        }
+    }
+
+    private fun onHotspotUp(res: WifiManager.LocalOnlyHotspotReservation) {
+        val (ssid, pass) = credentials(res)
+        if (ssid == null || pass == null) {
+            fail("The hotspot started but its name/password could not be read.")
+            return
+        }
+        val srv = startServer() ?: run {
+            fail("The hotspot is up but the file page could not bind a port.")
+            return
+        }
+        server = srv
+        Log.i(TAG, "hotspot '$ssid' up, file page on port ${srv.listeningPort}")
+        publish(HotspotView(phase = HotspotPhase.ON, ssid = ssid, passphrase = pass))
+        updateNotification("Hotspot “$ssid” is on")
+        awaitOwnAddress(srv.listeningPort, tries = IP_POLL_TRIES)
+    }
+
+    /** Bind the file page, walking a few ports in case one is taken. */
+    private fun startServer(): FileShareServer? {
+        for (port in BASE_PORT until BASE_PORT + PORT_TRIES) {
+            val srv = FileShareServer(SharedFiles.get(this), port)
+            try {
+                srv.start(SOCKET_READ_TIMEOUT_MS, false)
+                return srv
+            } catch (e: Exception) {
+                Log.w(TAG, "port $port unavailable", e)
+            }
+        }
+        return null
+    }
+
+    /**
+     * The URL guests browse to needs this phone's address *on the hotspot
+     * interface*, which the reservation does not expose — poll the interface
+     * table until it shows up. It normally exists within a tick or two of
+     * [WifiManager.LocalOnlyHotspotCallback.onStarted].
+     */
+    private fun awaitOwnAddress(port: Int, tries: Int) {
+        val ip = hotspotIpv4()
+        if (ip != null) {
+            publish(_view.value.copy(url = "http://$ip:$port"))
+            return
+        }
+        if (tries <= 0 || reservation == null) {
+            Log.w(TAG, "hotspot interface address never appeared")
+            return
+        }
+        handler.postDelayed({ awaitOwnAddress(port, tries - 1) }, IP_POLL_MS)
+    }
+
+    private fun hotspotIpv4(): String? {
+        // Every *other* private IPv4 on this phone — client Wi-Fi, cell, VPN —
+        // belongs to a Network the app can see through ConnectivityManager; the
+        // local-only hotspot is deliberately not surfaced as one. So the hotspot
+        // address is the site-local IPv4 on an up interface that no known
+        // Network owns. Robust where name/address guessing is not: on Pixel 9
+        // the AP interface is plain "wlan2", and Android 13+ randomizes the
+        // subnet *and* the host part (seen: 10.221.103.240 — not a ".1").
+        val known = knownNetworkV4()
+        val candidates = runCatching {
+            NetworkInterface.getNetworkInterfaces().toList()
+                .filter { runCatching { it.isUp }.getOrDefault(false) }
+                .flatMap { i -> i.inetAddresses.toList().filterIsInstance<Inet4Address>().map { i.name to it } }
+                .filter { (_, a) -> a.isSiteLocalAddress && a.hostAddress.let { it != null && it !in known } }
+        }.getOrDefault(emptyList())
+        // Several survivors would be pathological; prefer a softap-ish name.
+        val pick = candidates.minByOrNull { (name, _) ->
+            if (AP_IFACE_PREFIXES.any(name::startsWith)) 0 else 1
+        } ?: return null
+        Log.i(TAG, "hotspot address ${pick.second.hostAddress} on ${pick.first}")
+        return pick.second.hostAddress
+    }
+
+    /** IPv4 addresses of every Network the app can see (see [hotspotIpv4]). */
+    private fun knownNetworkV4(): Set<String> {
+        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as android.net.ConnectivityManager
+        @Suppress("DEPRECATION") // enumerating all networks is exactly the point
+        return cm.allNetworks.flatMap { n ->
+            cm.getLinkProperties(n)?.linkAddresses.orEmpty()
+                .mapNotNull { (it.address as? Inet4Address)?.hostAddress }
+        }.toSet()
+    }
+
+    private fun credentials(res: WifiManager.LocalOnlyHotspotReservation): Pair<String?, String?> =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val c = res.softApConfiguration
+            val ssid = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                c.wifiSsid?.toString()?.removeSurrounding("\"")
+            } else {
+                @Suppress("DEPRECATION") c.ssid
+            }
+            ssid to c.passphrase
+        } else {
+            @Suppress("DEPRECATION") // pre-R: WifiConfiguration is all there is
+            res.wifiConfiguration.let { c ->
+                c?.SSID?.removeSurrounding("\"") to c?.preSharedKey
+            }
+        }
+
+    private fun fail(message: String) {
+        Log.w(TAG, "hotspot failed: $message")
+        shutdown(HotspotView(phase = HotspotPhase.ERROR, error = message))
+        stopSelf()
+    }
+
+    private fun shutdown(finalView: HotspotView = HotspotView()) {
+        handler.removeCallbacksAndMessages(null)
+        server?.let { runCatching { it.stop() } }
+        server = null
+        reservation?.let { runCatching { it.close() } }
+        reservation = null
+        starting = false
+        if (pausedAware) {
+            pausedAware = false
+            val prefs = getSharedPreferences("myco_prefs", MODE_PRIVATE)
+            if (prefs.getBoolean(MainActivity.PREF_AWARE, true)) {
+                Log.i(TAG, "hotspot done — resuming Wi-Fi Aware")
+                AwareService.start(this)
+            }
+        }
+        publish(finalView)
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        Log.i(TAG, "hotspot service stopped")
+    }
+
+    override fun onDestroy() {
+        if (reservation != null || server != null || starting) shutdown()
+        super.onDestroy()
+    }
+
+    // --- notification ---
+
+    private fun startForegroundCompat() {
+        startForeground(
+            NOTIF_ID,
+            buildNotification("Starting file-share hotspot…"),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+        )
+    }
+
+    private fun updateNotification(text: String) {
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(NOTIF_ID, buildNotification(text))
+    }
+
+    private fun buildNotification(text: String): Notification {
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(CHANNEL_ID, "Myco hotspot", NotificationManager.IMPORTANCE_LOW)
+        channel.description = "File-share hotspot"
+        nm.createNotificationChannel(channel)
+        val stop = Intent(this, HotspotService::class.java).setAction(ACTION_STOP)
+        val stopPi = PendingIntent.getService(
+            this, 0, stop,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Myco")
+            .setContentText(text)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setOngoing(true)
+            .addAction(0, "Stop", stopPi)
+            .build()
+    }
+
+    companion object {
+        private const val TAG = "MycoHotspot"
+        private const val NOTIF_ID = 4
+        private const val CHANNEL_ID = "myco_hotspot"
+        const val ACTION_START = "app.myco.hotspot.START"
+        const val ACTION_STOP = "app.myco.hotspot.STOP"
+
+        /** First port tried for the file page — high, memorable, and clear of
+         *  the embedded relay (4870), Blossom (24243), and the UDP lane (4871). */
+        private const val BASE_PORT = 8080
+        private const val PORT_TRIES = 4
+
+        /** NanoHTTPD per-socket read timeout. Generous: a phone camera-to-
+         *  browser flow can sit on the form a while between requests. */
+        private const val SOCKET_READ_TIMEOUT_MS = 30_000
+
+        private const val IP_POLL_MS = 500L
+        private const val IP_POLL_TRIES = 20
+
+        /** Grace for the HAL to release the Aware NAN interface before the AP
+         *  request, and the retry cadence if it is still holding it. */
+        private const val AWARE_RELEASE_MS = 1_000L
+        private const val LOHS_RETRY_MS = 1_500L
+        private const val LOHS_RETRIES = 2
+
+        private val AP_IFACE_PREFIXES = listOf("ap", "swlan", "softap", "wlan1")
+
+        private val _view = MutableStateFlow(HotspotView())
+
+        /** Hotspot + file-page state, for the Circle sheet. */
+        val view: StateFlow<HotspotView> = _view.asStateFlow()
+
+        private fun publish(v: HotspotView) {
+            _view.value = v
+        }
+
+        fun start(context: Context) {
+            context.startForegroundService(
+                Intent(context, HotspotService::class.java).setAction(ACTION_START),
+            )
+        }
+
+        fun stop(context: Context) {
+            context.startService(
+                Intent(context, HotspotService::class.java).setAction(ACTION_STOP),
+            )
+        }
+
+        /** What [WifiManager.startLocalOnlyHotspot] gates on: NEARBY_WIFI_DEVICES
+         *  on 33+ (declared neverForLocation), fine location below — the same
+         *  split as the Wi-Fi Aware lane. */
+        fun permissions(): List<String> =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                listOf(Manifest.permission.NEARBY_WIFI_DEVICES)
+            } else {
+                listOf(Manifest.permission.ACCESS_FINE_LOCATION)
+            }
+    }
+}
+
+enum class HotspotPhase { OFF, STARTING, ON, ERROR }
+
+/** What the Circle sheet renders. `url` arrives a beat after `ON` (the softap
+ *  interface has to surface its address first). */
+data class HotspotView(
+    val phase: HotspotPhase = HotspotPhase.OFF,
+    val ssid: String? = null,
+    val passphrase: String? = null,
+    val url: String? = null,
+    val error: String? = null,
+)

--- a/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
+++ b/android/app/src/main/java/app/myco/hotspot/HotspotService.kt
@@ -83,6 +83,9 @@ class HotspotService : Service() {
         // From this moment NFC belongs to the hotspot: pairing-by-bump is off,
         // and once the page address is known a bump serves that instead.
         PairPresent.beginHotspot()
+        // A fresh session offers nothing from previous ones: only files the
+        // owner picks now, or uploads received now, are served to guests.
+        SharedFiles.get(this).beginSession()
         // The Wi-Fi chip cannot host an AP interface next to the Aware (NAN)
         // session the mesh's Aware lane holds — seen on Pixel 9 as HalDevMgr
         // "bestIfaceCreationProposal is null" followed by ERROR_INCOMPATIBLE_MODE.

--- a/android/app/src/main/java/app/myco/hotspot/Outbox.kt
+++ b/android/app/src/main/java/app/myco/hotspot/Outbox.kt
@@ -1,0 +1,103 @@
+package app.myco.hotspot
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.util.Log
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Files this phone is actively *sending* to the hotspot guest — the push half
+ * of the AirDrop-style flow, as opposed to [SharedFiles]' browse-and-pull list.
+ *
+ * The owner picks files in the hotspot sheet; each becomes a WAITING offer.
+ * The guest's page polls `/offers`, pops an accept/decline dialog, and either
+ * fetches `/offer/<id>` (streams the document, marks it SENT) or declines it.
+ * Offers stream straight from their content URIs — the picker grant lives as
+ * long as the process, which outlives any hotspot session.
+ *
+ * Same singleton shape as [SharedFiles]: the service's server threads and the
+ * Compose sheet observe one instance.
+ */
+class Outbox private constructor(private val context: Context) {
+
+    enum class Status { WAITING, SENT, DECLINED }
+
+    data class Offer(
+        val id: Long,
+        val name: String,
+        val size: Long,
+        val uri: Uri,
+        val status: Status,
+    )
+
+    private val nextId = AtomicLong(1)
+    private val _offers = MutableStateFlow<List<Offer>>(emptyList())
+
+    /** Everything offered this session, for the sheet's status rows. */
+    val offers: StateFlow<List<Offer>> = _offers.asStateFlow()
+
+    /** Offer the picked documents to the guest. */
+    fun add(uris: List<Uri>) {
+        val fresh = uris.mapNotNull { uri ->
+            val (name, size) = nameAndSize(uri) ?: return@mapNotNull null
+            Offer(nextId.getAndIncrement(), name, size, uri, Status.WAITING)
+        }
+        if (fresh.isNotEmpty()) _offers.update { it + fresh }
+    }
+
+    /** What the guest's poll sees: only offers still waiting on them. */
+    fun waiting(): List<Offer> = _offers.value.filter { it.status == Status.WAITING }
+
+    /** The guest accepted: mark SENT and open the document for streaming. */
+    fun accept(id: Long): Pair<Offer, InputStream>? {
+        val offer = _offers.value.firstOrNull { it.id == id && it.status == Status.WAITING }
+            ?: return null
+        val stream = runCatching { context.contentResolver.openInputStream(offer.uri) }
+            .onFailure { Log.w(TAG, "offer '${offer.name}' unreadable", it) }
+            .getOrNull() ?: return null
+        setStatus(id, Status.SENT)
+        return offer.copy(status = Status.SENT) to stream
+    }
+
+    /** The guest declined the offer. */
+    fun decline(id: Long) {
+        setStatus(id, Status.DECLINED)
+    }
+
+    /** Hotspot stopped: the session's offers are void. */
+    fun clear() {
+        _offers.value = emptyList()
+    }
+
+    private fun setStatus(id: Long, status: Status) {
+        _offers.update { list -> list.map { if (it.id == id) it.copy(status = status) else it } }
+    }
+
+    private fun nameAndSize(uri: Uri): Pair<String, Long>? = runCatching {
+        context.contentResolver.query(
+            uri, arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE), null, null, null,
+        )?.use { c ->
+            if (!c.moveToFirst()) return null
+            val name = c.getString(0)?.takeIf { it.isNotBlank() } ?: "file"
+            name to (if (c.isNull(1)) 0L else c.getLong(1))
+        }
+    }.getOrNull()
+
+    companion object {
+        private const val TAG = "MycoOutbox"
+
+        @Volatile
+        private var instance: Outbox? = null
+
+        fun get(context: Context): Outbox =
+            instance ?: synchronized(this) {
+                instance ?: Outbox(context.applicationContext).also { instance = it }
+            }
+    }
+}

--- a/android/app/src/main/java/app/myco/hotspot/SharedFiles.kt
+++ b/android/app/src/main/java/app/myco/hotspot/SharedFiles.kt
@@ -1,0 +1,173 @@
+package app.myco.hotspot
+
+import android.content.ContentUris
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.provider.MediaStore
+import android.provider.OpenableColumns
+import android.util.Log
+import android.webkit.MimeTypeMap
+import java.io.InputStream
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * The files the hotspot file page serves and receives.
+ *
+ * Two sources, one list:
+ *
+ *  - **Received uploads** live in public `Download/Myco/` via [MediaStore], so
+ *    the phone's owner finds them in the Files app like any other download.
+ *    Under scoped storage an unprivileged query returns only rows this app
+ *    created — which is exactly the set we want to re-serve.
+ *  - **Picked shares** are documents the owner adds through the system picker
+ *    (SAF `OpenMultipleDocuments`). The read grant is session-scoped, which
+ *    matches the hotspot's lifetime; they are streamed from their content URIs,
+ *    never copied.
+ *
+ * Entry ids are `m<mediastore-id>` / `u<index>` — opaque to the web page.
+ * A process-wide singleton (like the radios) so the service's server threads
+ * and the Compose sheet observe the same list.
+ */
+class SharedFiles private constructor(private val context: Context) {
+
+    data class Entry(val id: String, val name: String, val size: Long)
+
+    private data class Picked(val uri: Uri, val name: String, val size: Long)
+
+    private val picked = ArrayList<Picked>()
+    private val lock = Any()
+
+    private val _entries = MutableStateFlow<List<Entry>>(emptyList())
+
+    /** Live list for the sheet; the server re-queries per request instead. */
+    val entries: StateFlow<List<Entry>> = _entries.asStateFlow()
+
+    /** Add documents picked with SAF to the served list (session-scoped). */
+    fun addUris(uris: List<Uri>) {
+        synchronized(lock) {
+            for (uri in uris) {
+                if (picked.any { it.uri == uri }) continue
+                val (name, size) = displayNameAndSize(uri) ?: continue
+                picked.add(Picked(uri, name, size))
+            }
+        }
+        refresh()
+    }
+
+    /** Everything currently served: received uploads first, then picked shares. */
+    fun list(): List<Entry> {
+        val fromStore = queryUploads()
+        val fromPicker = synchronized(lock) {
+            picked.mapIndexed { i, p -> Entry("u$i", p.name, p.size) }
+        }
+        return fromStore + fromPicker
+    }
+
+    /** Open an entry for serving. Returns the stream and its length (0 = unknown). */
+    fun open(id: String): Pair<InputStream, Long>? = runCatching {
+        when {
+            id.startsWith("m") -> {
+                val rowId = id.drop(1).toLongOrNull() ?: return null
+                val uri = ContentUris.withAppendedId(collection, rowId)
+                val size = queryUploads().firstOrNull { it.id == id }?.size ?: 0L
+                context.contentResolver.openInputStream(uri)?.let { it to size }
+            }
+            id.startsWith("u") -> {
+                val p = synchronized(lock) { picked.getOrNull(id.drop(1).toIntOrNull() ?: -1) }
+                    ?: return null
+                context.contentResolver.openInputStream(p.uri)?.let { it to p.size }
+            }
+            else -> null
+        }
+    }.getOrNull()
+
+    /**
+     * Persist an uploaded file into `Download/Myco/` and add it to the list.
+     * MediaStore uniquifies a colliding name itself ("x (1).png"). `IS_PENDING`
+     * keeps a half-written row invisible to other apps until the copy finishes.
+     */
+    fun saveUpload(name: String, src: InputStream): Boolean {
+        val values = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, name)
+            put(MediaStore.MediaColumns.MIME_TYPE, mimeFor(name))
+            put(MediaStore.MediaColumns.RELATIVE_PATH, RELATIVE_PATH)
+            put(MediaStore.MediaColumns.IS_PENDING, 1)
+        }
+        val resolver = context.contentResolver
+        val uri = resolver.insert(collection, values) ?: return false
+        return runCatching {
+            resolver.openOutputStream(uri)?.use { out -> src.copyTo(out) }
+                ?: error("no output stream for $uri")
+            values.clear()
+            values.put(MediaStore.MediaColumns.IS_PENDING, 0)
+            resolver.update(uri, values, null, null)
+            refresh()
+            true
+        }.getOrElse {
+            Log.w(TAG, "saving upload '$name' failed", it)
+            resolver.delete(uri, null, null)
+            false
+        }
+    }
+
+    fun refresh() {
+        _entries.value = runCatching { list() }.getOrDefault(emptyList())
+    }
+
+    private val collection: Uri = MediaStore.Downloads.EXTERNAL_CONTENT_URI
+
+    private fun queryUploads(): List<Entry> {
+        val projection = arrayOf(
+            MediaStore.MediaColumns._ID,
+            MediaStore.MediaColumns.DISPLAY_NAME,
+            MediaStore.MediaColumns.SIZE,
+        )
+        val rows = ArrayList<Entry>()
+        runCatching {
+            context.contentResolver.query(
+                collection, projection,
+                "${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ?", arrayOf("$RELATIVE_PATH%"),
+                "${MediaStore.MediaColumns.DISPLAY_NAME} ASC",
+            )?.use { c ->
+                while (c.moveToNext()) {
+                    rows.add(Entry("m${c.getLong(0)}", c.getString(1) ?: continue, c.getLong(2)))
+                }
+            }
+        }.onFailure { Log.w(TAG, "querying uploads failed", it) }
+        return rows
+    }
+
+    private fun displayNameAndSize(uri: Uri): Pair<String, Long>? = runCatching {
+        context.contentResolver.query(
+            uri, arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE), null, null, null,
+        )?.use { c ->
+            if (!c.moveToFirst()) return null
+            val name = c.getString(0)?.takeIf { it.isNotBlank() } ?: "file"
+            name to (if (c.isNull(1)) 0L else c.getLong(1))
+        }
+    }.getOrNull()
+
+    companion object {
+        private const val TAG = "MycoSharedFiles"
+        private const val RELATIVE_PATH = "Download/Myco"
+
+        fun mimeFor(name: String): String =
+            MimeTypeMap.getSingleton()
+                .getMimeTypeFromExtension(name.substringAfterLast('.', "").lowercase())
+                ?: "application/octet-stream"
+
+        @Volatile
+        private var instance: SharedFiles? = null
+
+        fun get(context: Context): SharedFiles =
+            instance ?: synchronized(this) {
+                instance ?: SharedFiles(context.applicationContext).also {
+                    instance = it
+                    it.refresh()
+                }
+            }
+    }
+}

--- a/android/app/src/main/java/app/myco/hotspot/SharedFiles.kt
+++ b/android/app/src/main/java/app/myco/hotspot/SharedFiles.kt
@@ -16,16 +16,17 @@ import kotlinx.coroutines.flow.asStateFlow
 /**
  * The files the hotspot file page serves and receives.
  *
- * Two sources, one list:
+ * Two sources, one list — both scoped to the **current hotspot session**
+ * ([beginSession] wipes the slate when a hotspot starts, so a guest is never
+ * offered anything the owner didn't put up *this* time):
  *
  *  - **Received uploads** live in public `Download/Myco/` via [MediaStore], so
- *    the phone's owner finds them in the Files app like any other download.
- *    Under scoped storage an unprivileged query returns only rows this app
- *    created — which is exactly the set we want to re-serve.
+ *    the phone's owner finds them in the Files app like any other download —
+ *    and keeps them across sessions. Only the rows created this session are
+ *    re-served, though; earlier sessions' files stay private to the owner.
  *  - **Picked shares** are documents the owner adds through the system picker
- *    (SAF `OpenMultipleDocuments`). The read grant is session-scoped, which
- *    matches the hotspot's lifetime; they are streamed from their content URIs,
- *    never copied.
+ *    (SAF `OpenMultipleDocuments`). They are streamed from their content URIs,
+ *    never copied, and forgotten at the next session start.
  *
  * Entry ids are `m<mediastore-id>` / `u<index>` — opaque to the web page.
  * A process-wide singleton (like the radios) so the service's server threads
@@ -38,12 +39,25 @@ class SharedFiles private constructor(private val context: Context) {
     private data class Picked(val uri: Uri, val name: String, val size: Long)
 
     private val picked = ArrayList<Picked>()
+
+    /** Entry ids (`m<rowid>`) of uploads received during the current hotspot
+     *  session — the only MediaStore rows [list] serves. */
+    private val sessionUploads = HashSet<String>()
     private val lock = Any()
 
     private val _entries = MutableStateFlow<List<Entry>>(emptyList())
 
     /** Live list for the sheet; the server re-queries per request instead. */
     val entries: StateFlow<List<Entry>> = _entries.asStateFlow()
+
+    /** A hotspot session is starting: nothing from before is on offer. */
+    fun beginSession() {
+        synchronized(lock) {
+            picked.clear()
+            sessionUploads.clear()
+        }
+        refresh()
+    }
 
     /** Add documents picked with SAF to the served list (session-scoped). */
     fun addUris(uris: List<Uri>) {
@@ -57,9 +71,10 @@ class SharedFiles private constructor(private val context: Context) {
         refresh()
     }
 
-    /** Everything currently served: received uploads first, then picked shares. */
+    /** Everything currently served: this session's uploads, then picked shares. */
     fun list(): List<Entry> {
-        val fromStore = queryUploads()
+        val session = synchronized(lock) { sessionUploads.toSet() }
+        val fromStore = queryUploads().filter { it.id in session }
         val fromPicker = synchronized(lock) {
             picked.mapIndexed { i, p -> Entry("u$i", p.name, p.size) }
         }
@@ -104,6 +119,7 @@ class SharedFiles private constructor(private val context: Context) {
             values.clear()
             values.put(MediaStore.MediaColumns.IS_PENDING, 0)
             resolver.update(uri, values, null, null)
+            synchronized(lock) { sessionUploads.add("m${ContentUris.parseId(uri)}") }
             refresh()
             true
         }.getOrElse {

--- a/android/app/src/main/java/app/myco/hotspot/TransferGate.kt
+++ b/android/app/src/main/java/app/myco/hotspot/TransferGate.kt
@@ -1,0 +1,73 @@
+package app.myco.hotspot
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Per-file consent for the hotspot file page: every transfer a guest starts —
+ * downloading a shared file, sending one over — parks here until the phone's
+ * owner taps Allow or Deny in the hotspot sheet. The guest's own consent is the
+ * click that started the transfer; this is the owner's half.
+ *
+ * [request] is called from the web server's request threads and **blocks**
+ * them; the HTTP response only starts once the owner decides. Undecided
+ * requests are denied after [APPROVAL_TIMEOUT_S] so an unattended phone never
+ * leaks a file, and a stopping hotspot denies everything still waiting
+ * ([denyAll]). A process-wide singleton like the rest of the hotspot state.
+ */
+object TransferGate {
+
+    enum class Direction { DOWNLOAD, UPLOAD }
+
+    data class Pending(val id: Long, val direction: Direction, val name: String, val size: Long)
+
+    private val nextId = AtomicLong(1)
+    private val waiters = ConcurrentHashMap<Long, CompletableFuture<Boolean>>()
+    private val _pending = MutableStateFlow<List<Pending>>(emptyList())
+
+    /** What the sheet renders, oldest first. */
+    val pending: StateFlow<List<Pending>> = _pending.asStateFlow()
+
+    /** Block until the owner decides (or the timeout denies). Server threads only. */
+    fun request(
+        direction: Direction,
+        name: String,
+        size: Long,
+        timeoutSeconds: Long = APPROVAL_TIMEOUT_S,
+    ): Boolean {
+        val id = nextId.getAndIncrement()
+        val decision = CompletableFuture<Boolean>()
+        waiters[id] = decision
+        // update {} (CAS) — concurrent request threads must not lose each
+        // other's list edits.
+        _pending.update { it + Pending(id, direction, name, size) }
+        return try {
+            decision.get(timeoutSeconds, TimeUnit.SECONDS)
+        } catch (e: Exception) {
+            false // timeout (or interrupt) is a deny
+        } finally {
+            waiters.remove(id)
+            _pending.update { list -> list.filterNot { it.id == id } }
+        }
+    }
+
+    /** The owner tapped Allow/Deny on one row. Unknown ids are ignored (the
+     *  request may have just timed out). */
+    fun decide(id: Long, allow: Boolean) {
+        waiters[id]?.complete(allow)
+    }
+
+    /** Hotspot stopping: fail every transfer still waiting. */
+    fun denyAll() {
+        waiters.values.forEach { it.complete(false) }
+    }
+
+    /** How long a guest's transfer waits for the owner before it is denied. */
+    private const val APPROVAL_TIMEOUT_S = 90L
+}

--- a/android/app/src/main/java/app/myco/hotspot/WifiQr.kt
+++ b/android/app/src/main/java/app/myco/hotspot/WifiQr.kt
@@ -1,0 +1,21 @@
+package app.myco.hotspot
+
+/**
+ * The `WIFI:` QR payload (the ZXing convention every stock camera app
+ * understands): scanning one offers to join the network directly, no typing.
+ * A local-only hotspot is always WPA2-PSK, so `T:WPA` is fixed.
+ *
+ * Plain Kotlin (no Android types) so the escaping is host-unit-testable.
+ */
+object WifiQr {
+    /** Backslash-escape the characters the WIFI: format reserves. */
+    fun escape(value: String): String = buildString {
+        for (c in value) {
+            if (c in "\\;,\":") append('\\')
+            append(c)
+        }
+    }
+
+    fun payload(ssid: String, passphrase: String): String =
+        "WIFI:T:WPA;S:${escape(ssid)};P:${escape(passphrase)};;"
+}

--- a/android/app/src/main/java/app/myco/nfc/PairHostApduService.kt
+++ b/android/app/src/main/java/app/myco/nfc/PairHostApduService.kt
@@ -37,7 +37,7 @@ class PairHostApduService : HostApduService() {
                     SW_OK
                 }
                 fileId.contentEquals(NDEF_FILE_ID) -> {
-                    val uri = PairPresent.payload.value
+                    val uri = PairPresent.effective
                     if (uri.isNullOrEmpty()) {
                         android.util.Log.i("MycoNfc", "HCE select NDEF but no payload")
                         SW_ERROR

--- a/android/app/src/main/java/app/myco/nfc/PairPresent.kt
+++ b/android/app/src/main/java/app/myco/nfc/PairPresent.kt
@@ -16,7 +16,10 @@ import app.myco.share.PairSecrets
  * low-sensitivity (the npub is already public), and the `pairSecret` is single-use
  * (consumed on first accept, then rotated — see [PairSecrets]), so a captured tag
  * can't be replayed to pair. It is deliberately limited to the moments the user is
- * on the Circle tab, never the whole time the app is open.
+ * on the Circle tab, never the whole time the app is open. The one exception is
+ * the file-share hotspot's page URL ([beginUrl]): it presents for as long as the
+ * hotspot runs, which is fine — the URL is only reachable by devices the user
+ * just let onto that hotspot, and every transfer is gated on the owner anyway.
  *
  * [onChanged] lets the Activity re-claim/release foreground HCE when presenting
  * flips. [presenting] is backed by Compose snapshot state so UI gates (auto-accept
@@ -26,10 +29,19 @@ object PairPresent {
     /** The `myco://pair/...` URI currently being emulated, or null when not presenting. */
     val payload = mutableStateOf<String?>(null)
 
-    private val presentingState = mutableStateOf(false)
+    /** While set, this URI is presented *instead of* the pairing payload — the
+     *  file-share hotspot parks its page's `http://…` address here so a bump
+     *  hands any phone the URL (the reader's OS opens it in the browser; no
+     *  Myco needed on that side). Pairing-by-bump resumes when it clears. */
+    private val urlOverride = mutableStateOf<String?>(null)
+
+    private val pairPresenting = mutableStateOf(false)
 
     /** True while we're emulating a card. Read it from composition to observe flips. */
-    val presenting: Boolean get() = presentingState.value
+    val presenting: Boolean get() = pairPresenting.value || urlOverride.value != null
+
+    /** What the emulated tag actually serves right now ([PairHostApduService]). */
+    val effective: String? get() = urlOverride.value ?: payload.value
 
     /** Set by the Activity to react when presenting starts/stops (toggle HCE). */
     @Volatile
@@ -38,7 +50,7 @@ object PairPresent {
     /** Begin presenting: mint a fresh single-use secret and build the payload. */
     fun begin(context: Context, ownNpub: String, deviceName: String) {
         rotate(context, ownNpub, deviceName)
-        presentingState.value = true
+        pairPresenting.value = true
         onChanged?.invoke()
     }
 
@@ -47,7 +59,7 @@ object PairPresent {
      *  share-an-app surface, which mints its own one-time secret in the share URI. */
     fun beginRaw(uri: String) {
         payload.value = uri
-        presentingState.value = true
+        pairPresenting.value = true
         onChanged?.invoke()
     }
 
@@ -57,8 +69,21 @@ object PairPresent {
         payload.value = NsiteShare.buildPairUri(ownNpub, deviceName, PairSecrets.issue(context))
     }
 
+    /** Present `uri` to every bump until [stopUrl] — outlives the Circle tab. */
+    fun beginUrl(uri: String) {
+        urlOverride.value = uri
+        onChanged?.invoke()
+    }
+
+    fun stopUrl() {
+        urlOverride.value = null
+        onChanged?.invoke()
+    }
+
+    /** Stop pair-presentment (leaving the Circle tab). A hotspot URL keeps
+     *  presenting — its lifetime belongs to the hotspot, not the tab. */
     fun stop() {
-        presentingState.value = false
+        pairPresenting.value = false
         payload.value = null
         onChanged?.invoke()
     }

--- a/android/app/src/main/java/app/myco/nfc/PairPresent.kt
+++ b/android/app/src/main/java/app/myco/nfc/PairPresent.kt
@@ -29,19 +29,27 @@ object PairPresent {
     /** The `myco://pair/...` URI currently being emulated, or null when not presenting. */
     val payload = mutableStateOf<String?>(null)
 
-    /** While set, this URI is presented *instead of* the pairing payload — the
-     *  file-share hotspot parks its page's `http://…` address here so a bump
-     *  hands any phone the URL (the reader's OS opens it in the browser; no
-     *  Myco needed on that side). Pairing-by-bump resumes when it clears. */
+    /** While the file-share hotspot runs, it owns the NFC surface outright:
+     *  the tag serves the page's `http://…` address (the reader's OS opens it
+     *  in the browser; no Myco needed on that side) — and until that address
+     *  is known it serves *nothing*, never the pairing payload. Pairing by
+     *  bump is disabled for the whole hotspot session and resumes when it
+     *  stops. */
+    private val hotspotActiveState = mutableStateOf(false)
     private val urlOverride = mutableStateOf<String?>(null)
 
     private val pairPresenting = mutableStateOf(false)
 
+    /** True while the hotspot owns the NFC surface — read by the tag-dispatch
+     *  paths to drop a peer's `myco://pair` tag instead of pairing on it. */
+    val hotspotActive: Boolean get() = hotspotActiveState.value
+
     /** True while we're emulating a card. Read it from composition to observe flips. */
-    val presenting: Boolean get() = pairPresenting.value || urlOverride.value != null
+    val presenting: Boolean get() = pairPresenting.value || hotspotActiveState.value
 
     /** What the emulated tag actually serves right now ([PairHostApduService]). */
-    val effective: String? get() = urlOverride.value ?: payload.value
+    val effective: String?
+        get() = if (hotspotActiveState.value) urlOverride.value else payload.value
 
     /** Set by the Activity to react when presenting starts/stops (toggle HCE). */
     @Volatile
@@ -69,13 +77,24 @@ object PairPresent {
         payload.value = NsiteShare.buildPairUri(ownNpub, deviceName, PairSecrets.issue(context))
     }
 
+    /** The hotspot is starting: take the NFC surface away from pairing now,
+     *  before the page URL is even known — a bump in that window must hand
+     *  over nothing rather than a pair code. */
+    fun beginHotspot() {
+        hotspotActiveState.value = true
+        onChanged?.invoke()
+    }
+
     /** Present `uri` to every bump until [stopUrl] — outlives the Circle tab. */
     fun beginUrl(uri: String) {
+        hotspotActiveState.value = true
         urlOverride.value = uri
         onChanged?.invoke()
     }
 
+    /** The hotspot stopped: hand the NFC surface back to pairing. */
     fun stopUrl() {
+        hotspotActiveState.value = false
         urlOverride.value = null
         onChanged?.invoke()
     }

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -161,7 +161,9 @@ fun MycoApp(
     // issued is proof the peer read our live code. Consuming it is single-use, so a
     // replayed code can't pair again; those fall through to the manual inbox.
     androidx.compose.runtime.LaunchedEffect(state.pendingPairRequests) {
-        if (!PairPresent.presenting) return@LaunchedEffect
+        // Auto-accept is a *pairing* behavior: while the file-share hotspot owns
+        // the NFC surface no pair code is presented, so nothing may pair silently.
+        if (!PairPresent.presenting || PairPresent.hotspotActive) return@LaunchedEffect
         for (req in state.pendingPairRequests) {
             if (PairSecrets.consume(context, req.secret)) {
                 state = client.dispatch(NativeActions.acceptPairRequest(req.npub, req.name))

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -62,6 +63,7 @@ import app.myco.ui.radioWarnings
 import app.myco.core.AppCoreClient
 import app.myco.core.AppState
 import app.myco.core.NativeActions
+import app.myco.hotspot.TransferGate
 import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
 import app.myco.share.PairSecrets
@@ -297,6 +299,49 @@ fun MycoApp(
         PairConnectedDialog(theirName = name, onDone = { justConnected = null })
     }
 
+    // A hotspot guest started a transfer — pop the AirDrop-style accept/reject
+    // dialog wherever in the app you are (their browser is blocked on this
+    // answer; unanswered requests deny themselves after 90s). One at a time,
+    // oldest first; deciding it reveals the next.
+    val pendingTransfers by TransferGate.pending.collectAsState()
+    pendingTransfers.firstOrNull()?.let { req ->
+        val size = if (req.size > 0) " (${formatSize(req.size)})" else ""
+        AlertDialog(
+            // No outside-tap/back dismissal: an accidental swipe must not
+            // silently deny (or leave a guest hanging) — the buttons decide.
+            onDismissRequest = {},
+            title = {
+                Text(
+                    when (req.direction) {
+                        TransferGate.Direction.UPLOAD -> "Incoming file"
+                        TransferGate.Direction.DOWNLOAD -> "Share this file?"
+                    },
+                )
+            },
+            text = {
+                Text(
+                    when (req.direction) {
+                        TransferGate.Direction.UPLOAD ->
+                            "The other phone wants to send you “${req.name}”$size. " +
+                                "Accepted files land in Download/Myco."
+                        TransferGate.Direction.DOWNLOAD ->
+                            "The other phone asks to download “${req.name}”$size."
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { TransferGate.decide(req.id, true) }) {
+                    Text(if (req.direction == TransferGate.Direction.UPLOAD) "Accept" else "Send")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { TransferGate.decide(req.id, false) }) {
+                    Text("Decline", color = MaterialTheme.colorScheme.error)
+                }
+            },
+        )
+    }
+
     // A request only auto-accepts while you're on the Circle tab (presenting). If
     // it arrives while you're elsewhere — another tab, or Myco was launched by the
     // tap — prompt to accept/ignore instead of silently pairing.
@@ -521,4 +566,11 @@ fun KeyVal(label: String, value: String, valueColor: Color = MaterialTheme.color
             style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
         )
     }
+}
+
+/** Human file size for the transfer-consent dialog. */
+private fun formatSize(bytes: Long): String = when {
+    bytes >= 1L shl 20 -> "%.1f MB".format(bytes.toDouble() / (1L shl 20))
+    bytes >= 1L shl 10 -> "%.0f kB".format(bytes.toDouble() / (1L shl 10))
+    else -> "$bytes B"
 }

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -1,5 +1,8 @@
 package app.myco.ui.screens
 
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -33,6 +36,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MarkEmailUnread
 import androidx.compose.material.icons.filled.PersonRemove
 import androidx.compose.material.icons.filled.QrCode2
+import androidx.compose.material.icons.filled.WifiTethering
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -44,6 +48,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -61,6 +66,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -68,6 +74,9 @@ import app.myco.core.AppCoreClient
 import app.myco.core.AppState
 import app.myco.core.CircleContact
 import app.myco.core.NativeActions
+import app.myco.hotspot.HotspotPhase
+import app.myco.hotspot.HotspotService
+import app.myco.hotspot.SharedFiles
 import app.myco.nfc.NfcState
 import app.myco.nfc.NfcStatus
 import app.myco.nfc.PairPresent
@@ -86,8 +95,9 @@ private enum class Badge { NONE, PLUS, SENT }
  * "Add to circle" screen is merged in here). Top to bottom: who you appear as,
  * a tap-to-connect (NFC) hint, **Nearby** people (tap a bubble to add), and your
  * **Circle** as bubbles (green ring = online). A QR bubble (bottom-right) opens
- * scan / show / paste. While this screen is open the device presents over NFC, so
- * two phones both here pair on a single bump.
+ * scan / show / paste; the hotspot bubble above it shares files with *any* phone
+ * over a local-only hotspot ([HotspotSheet]). While this screen is open the
+ * device presents over NFC, so two phones both here pair on a single bump.
  */
 @OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -103,6 +113,22 @@ fun CircleScreen(
     var sheetFor by remember { mutableStateOf<CircleContact?>(null) }
     var confirmRemove by remember { mutableStateOf<CircleContact?>(null) }
     var cancelInvite by remember { mutableStateOf<String?>(null) }
+
+    // File-share hotspot: the sheet views state the HotspotService owns, so it
+    // survives dismissing the sheet and leaving the tab.
+    var hotspotSheet by remember { mutableStateOf(false) }
+    val hotspot by HotspotService.view.collectAsState()
+    val sharedFiles by SharedFiles.get(context).entries.collectAsState()
+    val hotspotPerms = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        if (grants.values.all { it }) HotspotService.start(context)
+    }
+    val pickShareFiles = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenMultipleDocuments()
+    ) { uris ->
+        if (uris.isNotEmpty()) SharedFiles.get(context).addUris(uris)
+    }
 
     // NFC availability, re-checked on resume (e.g. back from NFC settings).
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -293,21 +319,62 @@ fun CircleScreen(
             item { Spacer(Modifier.height(72.dp)) } // room for the FAB
         }
 
-        // QR bubble — scan / show / paste.
-        Surface(
-            shape = CircleShape,
-            color = MaterialTheme.colorScheme.primary,
-            shadowElevation = 6.dp,
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(24.dp)
-                .size(56.dp)
-                .clickable(onClick = onOpenQr),
+        Column(
+            modifier = Modifier.align(Alignment.BottomEnd).padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Box(contentAlignment = Alignment.Center) {
-                Icon(Icons.Filled.QrCode2, contentDescription = "Scan or show a code", tint = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.size(26.dp))
+            // Hotspot bubble — share files with any phone over a local hotspot.
+            val hotspotLive = hotspot.phase == HotspotPhase.ON || hotspot.phase == HotspotPhase.STARTING
+            Surface(
+                shape = CircleShape,
+                color = if (hotspotLive) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.surfaceVariant,
+                border = if (hotspotLive) null else androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                shadowElevation = 4.dp,
+                modifier = Modifier
+                    .size(48.dp)
+                    .clickable(onClick = { hotspotSheet = true }),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        Icons.Filled.WifiTethering,
+                        contentDescription = "Share files over hotspot",
+                        tint = if (hotspotLive) MaterialTheme.colorScheme.onTertiary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            }
+            // QR bubble — scan / show / paste.
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primary,
+                shadowElevation = 6.dp,
+                modifier = Modifier
+                    .size(56.dp)
+                    .clickable(onClick = onOpenQr),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(Icons.Filled.QrCode2, contentDescription = "Scan or show a code", tint = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.size(26.dp))
+                }
             }
         }
+    }
+
+    if (hotspotSheet) {
+        HotspotSheet(
+            view = hotspot,
+            shared = sharedFiles,
+            onStart = {
+                val needed = HotspotService.permissions().filter {
+                    ContextCompat.checkSelfPermission(context, it) != PackageManager.PERMISSION_GRANTED
+                }
+                if (needed.isEmpty()) HotspotService.start(context)
+                else hotspotPerms.launch(needed.toTypedArray())
+            },
+            onStop = { HotspotService.stop(context) },
+            onAddFiles = { pickShareFiles.launch(arrayOf("*/*")) },
+            onDismiss = { hotspotSheet = false },
+        )
     }
 
     if (editing) {

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -76,6 +76,7 @@ import app.myco.core.CircleContact
 import app.myco.core.NativeActions
 import app.myco.hotspot.HotspotPhase
 import app.myco.hotspot.HotspotService
+import app.myco.hotspot.Outbox
 import app.myco.hotspot.SharedFiles
 import app.myco.nfc.NfcState
 import app.myco.nfc.NfcStatus
@@ -128,6 +129,12 @@ fun CircleScreen(
         ActivityResultContracts.OpenMultipleDocuments()
     ) { uris ->
         if (uris.isNotEmpty()) SharedFiles.get(context).addUris(uris)
+    }
+    // "Send a file": each pick becomes an offer the guest's page must accept.
+    val pickSendFiles = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenMultipleDocuments()
+    ) { uris ->
+        if (uris.isNotEmpty()) Outbox.get(context).add(uris)
     }
 
     // NFC availability, re-checked on resume (e.g. back from NFC settings).
@@ -373,6 +380,7 @@ fun CircleScreen(
             },
             onStop = { HotspotService.stop(context) },
             onAddFiles = { pickShareFiles.launch(arrayOf("*/*")) },
+            onSendFiles = { pickSendFiles.launch(arrayOf("*/*")) },
             onDismiss = { hotspotSheet = false },
         )
     }

--- a/android/app/src/main/java/app/myco/ui/screens/HotspotSheet.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/HotspotSheet.kt
@@ -35,10 +35,11 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
 import app.myco.hotspot.HotspotPhase
 import app.myco.hotspot.HotspotView
+import app.myco.hotspot.Outbox
 import app.myco.hotspot.SharedFiles
-import app.myco.hotspot.TransferGate
 import app.myco.hotspot.WifiQr
 import app.myco.share.NsiteShare
 
@@ -59,6 +60,7 @@ fun HotspotSheet(
     onStart: () -> Unit,
     onStop: () -> Unit,
     onAddFiles: () -> Unit,
+    onSendFiles: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
@@ -111,7 +113,7 @@ fun HotspotSheet(
                     Text("Starting the hotspot…", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
 
-                HotspotPhase.ON -> HotspotOn(view, shared, onStop, onAddFiles)
+                HotspotPhase.ON -> HotspotOn(view, shared, onStop, onAddFiles, onSendFiles)
             }
         }
     }
@@ -123,23 +125,11 @@ private fun HotspotOn(
     shared: List<SharedFiles.Entry>,
     onStop: () -> Unit,
     onAddFiles: () -> Unit,
+    onSendFiles: () -> Unit,
 ) {
     val ssid = view.ssid.orEmpty()
     val pass = view.passphrase.orEmpty()
     val wifiQr = remember(ssid, pass) { NsiteShare.qrBitmap(WifiQr.payload(ssid, pass)) }
-
-    // Transfers the guest started, parked on this phone's Allow/Deny. First,
-    // because a waiting guest is the most time-critical thing on this sheet.
-    val pending by TransferGate.pending.collectAsState()
-    if (pending.isNotEmpty()) {
-        StepLabel("WAITING FOR YOUR OK")
-        Spacer(Modifier.height(8.dp))
-        pending.forEach { req ->
-            ApprovalRow(req)
-            Spacer(Modifier.height(6.dp))
-        }
-        Spacer(Modifier.height(12.dp))
-    }
 
     StepLabel("1 · JOIN THIS PHONE'S WI-FI")
     Spacer(Modifier.height(10.dp))
@@ -188,6 +178,31 @@ private fun HotspotOn(
     }
 
     Spacer(Modifier.height(18.dp))
+    StepLabel("SEND TO THE OTHER PHONE")
+    Spacer(Modifier.height(6.dp))
+    // Push a file AirDrop-style: it pops an accept/decline dialog on their page.
+    val offers by Outbox.get(LocalContext.current).offers.collectAsState()
+    offers.forEach { offer ->
+        Text(
+            offer.name + sizeSuffix(offer.size) + when (offer.status) {
+                Outbox.Status.WAITING -> " — waiting for them…"
+                Outbox.Status.SENT -> " — sent ✓"
+                Outbox.Status.DECLINED -> " — they declined"
+            },
+            color = when (offer.status) {
+                Outbox.Status.DECLINED -> MaterialTheme.colorScheme.error
+                else -> MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            style = MaterialTheme.typography.bodySmall,
+            maxLines = 1,
+        )
+    }
+    if (offers.isNotEmpty()) Spacer(Modifier.height(6.dp))
+    Button(onClick = onSendFiles) {
+        Text("Send a file")
+    }
+
+    Spacer(Modifier.height(18.dp))
     StepLabel("SHARED FROM THIS PHONE")
     Spacer(Modifier.height(6.dp))
     Text(
@@ -209,44 +224,6 @@ private fun HotspotOn(
         }
         TextButton(onClick = onStop) {
             Text("Stop hotspot", color = MaterialTheme.colorScheme.error, fontWeight = FontWeight.Bold)
-        }
-    }
-}
-
-/** One transfer awaiting consent: what and which way, then Allow / Deny. */
-@Composable
-private fun ApprovalRow(req: TransferGate.Pending) {
-    Surface(
-        shape = RoundedCornerShape(14.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(Modifier.weight(1f)) {
-                Text(
-                    req.name,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                )
-                Text(
-                    when (req.direction) {
-                        TransferGate.Direction.DOWNLOAD -> "wants to download" + sizeSuffix(req.size)
-                        TransferGate.Direction.UPLOAD -> "wants to send you this" + sizeSuffix(req.size)
-                    },
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-            TextButton(onClick = { TransferGate.decide(req.id, false) }) {
-                Text("Deny", color = MaterialTheme.colorScheme.error)
-            }
-            Button(onClick = { TransferGate.decide(req.id, true) }) {
-                Text("Allow")
-            }
         }
     }
 }

--- a/android/app/src/main/java/app/myco/ui/screens/HotspotSheet.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/HotspotSheet.kt
@@ -164,7 +164,8 @@ private fun HotspotOn(
         Mono(view.url, big = true)
         Spacer(Modifier.height(4.dp))
         Text(
-            "…or bump the phones — the page opens in their browser.",
+            "…or bump the phones — the page opens in their browser. " +
+                "While the hotspot is on, bumping shares this page instead of pairing.",
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.bodySmall,
             textAlign = TextAlign.Center,

--- a/android/app/src/main/java/app/myco/ui/screens/HotspotSheet.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/HotspotSheet.kt
@@ -26,6 +26,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import app.myco.hotspot.HotspotPhase
 import app.myco.hotspot.HotspotView
 import app.myco.hotspot.SharedFiles
+import app.myco.hotspot.TransferGate
 import app.myco.hotspot.WifiQr
 import app.myco.share.NsiteShare
 
@@ -125,6 +128,19 @@ private fun HotspotOn(
     val pass = view.passphrase.orEmpty()
     val wifiQr = remember(ssid, pass) { NsiteShare.qrBitmap(WifiQr.payload(ssid, pass)) }
 
+    // Transfers the guest started, parked on this phone's Allow/Deny. First,
+    // because a waiting guest is the most time-critical thing on this sheet.
+    val pending by TransferGate.pending.collectAsState()
+    if (pending.isNotEmpty()) {
+        StepLabel("WAITING FOR YOUR OK")
+        Spacer(Modifier.height(8.dp))
+        pending.forEach { req ->
+            ApprovalRow(req)
+            Spacer(Modifier.height(6.dp))
+        }
+        Spacer(Modifier.height(12.dp))
+    }
+
     StepLabel("1 · JOIN THIS PHONE'S WI-FI")
     Spacer(Modifier.height(10.dp))
     QrCodeCard(wifiQr, contentDescription = "Scan to join the hotspot")
@@ -156,6 +172,13 @@ private fun HotspotOn(
         )
         Spacer(Modifier.height(4.dp))
         Mono(view.url, big = true)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "…or bump the phones — the page opens in their browser.",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.Center,
+        )
     } else {
         Text(
             "Finding this phone's address…",
@@ -188,6 +211,51 @@ private fun HotspotOn(
             Text("Stop hotspot", color = MaterialTheme.colorScheme.error, fontWeight = FontWeight.Bold)
         }
     }
+}
+
+/** One transfer awaiting consent: what and which way, then Allow / Deny. */
+@Composable
+private fun ApprovalRow(req: TransferGate.Pending) {
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    req.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                )
+                Text(
+                    when (req.direction) {
+                        TransferGate.Direction.DOWNLOAD -> "wants to download" + sizeSuffix(req.size)
+                        TransferGate.Direction.UPLOAD -> "wants to send you this" + sizeSuffix(req.size)
+                    },
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            TextButton(onClick = { TransferGate.decide(req.id, false) }) {
+                Text("Deny", color = MaterialTheme.colorScheme.error)
+            }
+            Button(onClick = { TransferGate.decide(req.id, true) }) {
+                Text("Allow")
+            }
+        }
+    }
+}
+
+private fun sizeSuffix(bytes: Long): String = when {
+    bytes >= 1L shl 20 -> " · %.1f MB".format(bytes.toDouble() / (1L shl 20))
+    bytes >= 1L shl 10 -> " · %.0f kB".format(bytes.toDouble() / (1L shl 10))
+    bytes > 0 -> " · $bytes B"
+    else -> ""
 }
 
 @Composable

--- a/android/app/src/main/java/app/myco/ui/screens/HotspotSheet.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/HotspotSheet.kt
@@ -1,0 +1,218 @@
+package app.myco.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.WifiTethering
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import app.myco.hotspot.HotspotPhase
+import app.myco.hotspot.HotspotView
+import app.myco.hotspot.SharedFiles
+import app.myco.hotspot.WifiQr
+import app.myco.share.NsiteShare
+
+/**
+ * The file-share hotspot sheet, opened from the Circle tab's hotspot bubble.
+ *
+ * Off: explains and offers to start. On: the two steps a guest walks —
+ * (1) a `WIFI:` QR that joins this phone's hotspot, (2) the file page's
+ * address — plus what's being shared and the stop button. The sheet only
+ * *views* the hotspot; its lifetime belongs to
+ * [app.myco.hotspot.HotspotService], so dismissing the sheet changes nothing.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HotspotSheet(
+    view: HotspotView,
+    shared: List<SharedFiles.Entry>,
+    onStart: () -> Unit,
+    onStop: () -> Unit,
+    onAddFiles: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(start = 20.dp, end = 20.dp, bottom = 28.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.WifiTethering,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.width(8.dp))
+                Text("Share files over hotspot", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            }
+            Spacer(Modifier.height(14.dp))
+
+            when (view.phase) {
+                HotspotPhase.OFF, HotspotPhase.ERROR -> {
+                    if (view.phase == HotspotPhase.ERROR && view.error != null) {
+                        Text(
+                            view.error,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center,
+                        )
+                        Spacer(Modifier.height(12.dp))
+                    }
+                    Text(
+                        "Opens a Wi-Fi hotspot on this phone and a web page on it. " +
+                            "Anyone who joins — no Myco needed — can download the files " +
+                            "you share and send you files back.",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Button(onClick = onStart) {
+                        Text(if (view.phase == HotspotPhase.ERROR) "Try again" else "Start hotspot")
+                    }
+                }
+
+                HotspotPhase.STARTING -> {
+                    CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                    Spacer(Modifier.height(12.dp))
+                    Text("Starting the hotspot…", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+
+                HotspotPhase.ON -> HotspotOn(view, shared, onStop, onAddFiles)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HotspotOn(
+    view: HotspotView,
+    shared: List<SharedFiles.Entry>,
+    onStop: () -> Unit,
+    onAddFiles: () -> Unit,
+) {
+    val ssid = view.ssid.orEmpty()
+    val pass = view.passphrase.orEmpty()
+    val wifiQr = remember(ssid, pass) { NsiteShare.qrBitmap(WifiQr.payload(ssid, pass)) }
+
+    StepLabel("1 · JOIN THIS PHONE'S WI-FI")
+    Spacer(Modifier.height(10.dp))
+    QrCodeCard(wifiQr, contentDescription = "Scan to join the hotspot")
+    Spacer(Modifier.height(8.dp))
+    Text(
+        "Scan with the other phone's camera — or join manually:",
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodySmall,
+        textAlign = TextAlign.Center,
+    )
+    Spacer(Modifier.height(4.dp))
+    Mono("$ssid · $pass")
+    Spacer(Modifier.height(4.dp))
+    Text(
+        "This network is offline on purpose — if asked, choose to stay connected.",
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodySmall,
+        textAlign = TextAlign.Center,
+    )
+
+    Spacer(Modifier.height(18.dp))
+    StepLabel("2 · OPEN THE FILE PAGE")
+    Spacer(Modifier.height(8.dp))
+    if (view.url != null) {
+        Text(
+            "In the browser there, go to:",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Spacer(Modifier.height(4.dp))
+        Mono(view.url, big = true)
+    } else {
+        Text(
+            "Finding this phone's address…",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+
+    Spacer(Modifier.height(18.dp))
+    StepLabel("SHARED FROM THIS PHONE")
+    Spacer(Modifier.height(6.dp))
+    Text(
+        when {
+            shared.isEmpty() -> "Nothing shared yet — files sent to you land in Download/Myco."
+            else -> shared.joinToString(", ") { it.name }
+        },
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodySmall,
+        textAlign = TextAlign.Center,
+        maxLines = 3,
+    )
+    Spacer(Modifier.height(10.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        OutlinedButton(onClick = onAddFiles) {
+            Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+            Spacer(Modifier.width(6.dp))
+            Text("Add files")
+        }
+        TextButton(onClick = onStop) {
+            Text("Stop hotspot", color = MaterialTheme.colorScheme.error, fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+@Composable
+private fun StepLabel(text: String) {
+    Text(
+        text,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontWeight = FontWeight.Bold,
+        style = MaterialTheme.typography.labelMedium,
+    )
+}
+
+@Composable
+private fun Mono(text: String, big: Boolean = false) {
+    Surface(
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Text(
+            text,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            style = (if (big) MaterialTheme.typography.titleMedium else MaterialTheme.typography.bodyMedium)
+                .copy(fontFamily = FontFamily.Monospace),
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/android/app/src/test/java/app/myco/hotspot/TransferGateTest.kt
+++ b/android/app/src/test/java/app/myco/hotspot/TransferGateTest.kt
@@ -1,0 +1,69 @@
+package app.myco.hotspot
+
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TransferGateTest {
+
+    private fun awaitPending(): TransferGate.Pending {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            TransferGate.pending.value.firstOrNull()?.let { return it }
+            Thread.sleep(10)
+        }
+        throw AssertionError("request never became pending")
+    }
+
+    private fun requestInBackground(): ArrayBlockingQueue<Boolean> {
+        val result = ArrayBlockingQueue<Boolean>(1)
+        thread {
+            result.put(
+                TransferGate.request(TransferGate.Direction.DOWNLOAD, "file.bin", 42, timeoutSeconds = 10),
+            )
+        }
+        return result
+    }
+
+    @Test
+    fun allowUnblocksTheTransfer() {
+        val result = requestInBackground()
+        TransferGate.decide(awaitPending().id, allow = true)
+        assertEquals(true, result.poll(5, TimeUnit.SECONDS))
+        assertTrue(TransferGate.pending.value.isEmpty())
+    }
+
+    @Test
+    fun denyUnblocksWithFalse() {
+        val result = requestInBackground()
+        TransferGate.decide(awaitPending().id, allow = false)
+        assertEquals(false, result.poll(5, TimeUnit.SECONDS))
+        assertTrue(TransferGate.pending.value.isEmpty())
+    }
+
+    @Test
+    fun timeoutIsADeny() {
+        assertEquals(
+            false,
+            TransferGate.request(TransferGate.Direction.UPLOAD, "slow.bin", 1, timeoutSeconds = 0),
+        )
+        assertTrue(TransferGate.pending.value.isEmpty())
+    }
+
+    @Test
+    fun denyAllFailsEveryWaiter() {
+        val a = requestInBackground()
+        val b = requestInBackground()
+        val deadline = System.currentTimeMillis() + 5_000
+        while (TransferGate.pending.value.size < 2 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10)
+        }
+        assertEquals(2, TransferGate.pending.value.size)
+        TransferGate.denyAll()
+        assertEquals(false, a.poll(5, TimeUnit.SECONDS))
+        assertEquals(false, b.poll(5, TimeUnit.SECONDS))
+    }
+}

--- a/android/app/src/test/java/app/myco/hotspot/WifiQrTest.kt
+++ b/android/app/src/test/java/app/myco/hotspot/WifiQrTest.kt
@@ -1,0 +1,30 @@
+package app.myco.hotspot
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WifiQrTest {
+
+    @Test
+    fun plainCredentialsPassThrough() {
+        assertEquals(
+            "WIFI:T:WPA;S:AndroidShare_1234;P:hunter22;;",
+            WifiQr.payload("AndroidShare_1234", "hunter22"),
+        )
+    }
+
+    @Test
+    fun reservedCharactersAreEscaped() {
+        // Every reserved char of the WIFI: format: \ ; , " :
+        assertEquals("""a\\b\;c\,d\"e\:f""", WifiQr.escape("""a\b;c,d"e:f"""))
+        assertEquals(
+            """WIFI:T:WPA;S:my\;net;P:p\:a\,s\"s\\w;;""",
+            WifiQr.payload("""my;net""", """p:a,s"s\w"""),
+        )
+    }
+
+    @Test
+    fun unicodeSurvivesUnchanged() {
+        assertEquals("WIFI:T:WPA;S:Ünïcode ✓;P:pässwörd;;", WifiQr.payload("Ünïcode ✓", "pässwörd"))
+    }
+}


### PR DESCRIPTION
Share files with **any** phone nearby — no Myco on the other side, no internet,
no app store. A hotspot bubble on the Circle tab (above the QR bubble) opens a
local-only Wi-Fi hotspot and serves a web page from the phone, styled to the
app's own AMOLED theme so both sides of the exchange look like Myco. The other
phone joins by scanning a Wi-Fi QR with its stock camera — or by bumping the
phones, which hands its browser the page directly over NFC — and can then
exchange files in both directions, AirDrop-style, with every transfer gated on
an explicit accept.

## What it does

- **Hotspot + file page.** `HotspotService` (a `connectedDevice` foreground
  service) owns a `startLocalOnlyHotspot` reservation and an embedded HTTP
  server. The sheet shows a `WIFI:` join QR, the page URL, and a stop action;
  the hotspot survives leaving the tab. The page mirrors the app's look —
  black ground, emerald accent, the sheet's section labels and pill buttons —
  with a Choose-files picker, a selection list, and a Send button.
- **Bump to open.** While the hotspot runs, the NDEF tag Myco already emulates
  for tap-to-pair serves the page URL instead — the reader phone's OS opens it
  in its browser. Pairing by bump is fully disabled for the session, in both
  directions (this phone neither presents a pair code nor acts on one it
  reads), and resumes when the hotspot stops.
- **Both directions, both consents.** The guest's page can download shared
  files and upload files back; "Send a file" on the sheet pushes a document at
  the guest. Every guest-initiated transfer pops an accept/decline dialog on
  the phone (anywhere in the app, with name and size); every pushed file pops
  one in the guest's browser. Denials are dialogs, never saved "rejected"
  files: downloads ask first via `POST /files/<id>/request` and only navigate
  with a one-time token once allowed. Unanswered requests deny after 90 s;
  stopping the hotspot denies everything still waiting.
- **Session-scoped.** Starting a hotspot wipes the served list; only files
  picked now or received now are offered. Received files land in
  `Download/Myco/` via MediaStore and stay there for the owner across sessions.

## Decisions and trade-offs

- **Wi-Fi Aware pauses while the hotspot runs.** The Pixel 9's Wi-Fi chip
  refuses an AP interface next to the Aware NAN interface (`HalDevMgr`
  proposes nothing, LOHS fails `ERROR_INCOMPATIBLE_MODE`), so the service
  stops the Aware lane for the session and restores it on stop. BLE is
  untouched, so the mesh keeps its baseline transport.
- **Hotspot address discovery is capability-based.** The reservation doesn't
  expose the AP address, interface names are vendor-soup ("wlan2" on Pixel 9),
  Android 13+ randomizes subnet *and* host, and some builds surface the LOHS
  as a ConnectivityManager Network to its owner. The address is found as the
  site-local IPv4 owned by no internet-capable/cellular/VPN network; a DIAG
  log line dumps both sets whenever discovery comes up empty.
- **New dependency: NanoHTTPD 2.3.1.** Tiny and stable but unmaintained; two
  of its defects are already worked around (its multipart parser surfaces only
  the first of several same-named file parts and ASCII-mangles filenames, so
  uploads go as raw PUTs with the UTF-8 name in the URL, multipart kept as the
  no-JS fallback).
- No new permissions; one non-exported service in the manifest. No Rust
  changes — this is independent of #27 and either can land first (whichever
  goes second rebases a small CHANGELOG hunk).

## Testing

Host tests cover the pure logic: `WifiQrTest` (WIFI: payload escaping) and
`TransferGateTest` (allow/deny/timeout/deny-all semantics, including a
concurrent-request race on the pending list that the test caught). The rest is
Android-API-bound and was verified manually across two physical phones
(Pixel 9 Pro host), per CONTRIBUTING:

- join via QR, page loads; uploads and downloads round-trip byte-identical,
  including Unicode filenames and a 21 MB video
- bump opens the page in the second phone's browser; a synthetic
  `NDEF_DISCOVERED` pair tap during a session is ignored and pairing resumes
  after stop
- allow path streams after the dialog (2.2 MB in 0.3 s on the token, no second
  prompt); deny path returns a dialog on the page with nothing saved on either
  side; offer accept/decline both verified from the guest side
- session scoping: fresh session serves nothing, this session's upload appears,
  stop/start clears it, files remain in `Download/Myco/`

## Known follow-ups (deliberately out of scope)

- The server binds every interface; while a session runs the page is reachable
  from other networks the phone is on (shared-file *names* only — transfers
  stay consent-gated). Planned: reject requests from outside the AP subnet.
- Cap concurrently pending consents (each blocks a server thread for up to
  90 s; a hostile guest could pile them up).
- A README section for the feature, and possibly a short design note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
