### PR TITLE
Status panel behind the pill, and a device name that is actually yours

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -85,6 +85,7 @@ None yet. Field TODOs are tracked separately in `reference/FIX-TODOS.md`.
 | 260809-nyq | Myco deep linking (`myco://app/<host>/<path>`) + deferred open, and the myco-dumplings test nsite | 2026-08-09 | `feat/deep-links` | `.planning/quick/260809-nyq-myco-deep-linking-myco-app-host-path-def/SUMMARY.md` |
 | 260818-l65 | Status pill: bigger, red when mesh off, easier switch, and a Circle/Mesh status panel behind it (per-lane scanning + per-peer ping/uptime/last-seen) | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-l65-status-pill-panel/SUMMARY.md` |
 | 260818-dnm | Device name: default to the phone's own name, one-tap chips for it and the generated one, and a 2048-wide SHA-256-keyed generator (was 144 with a correlated hash) | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-dnm-device-name-defaults/SUMMARY.md` |
+| 260818-fgt | First-run gating: radios and permission prompts wait for the intro; peer labels resolve to the name the peer actually chose | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-fgt-first-run-gating/SUMMARY.md` |
 
 ## Deferred Items
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -84,6 +84,7 @@ None yet. Field TODOs are tracked separately in `reference/FIX-TODOS.md`.
 |----|------|------|--------|---------|
 | 260809-nyq | Myco deep linking (`myco://app/<host>/<path>`) + deferred open, and the myco-dumplings test nsite | 2026-08-09 | `feat/deep-links` | `.planning/quick/260809-nyq-myco-deep-linking-myco-app-host-path-def/SUMMARY.md` |
 | 260818-l65 | Status pill: bigger, red when mesh off, easier switch, and a Circle/Mesh status panel behind it (per-lane scanning + per-peer ping/uptime/last-seen) | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-l65-status-pill-panel/SUMMARY.md` |
+| 260818-dnm | Device name: default to the phone's own name, one-tap chips for it and the generated one, and a 2048-wide SHA-256-keyed generator (was 144 with a correlated hash) | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-dnm-device-name-defaults/SUMMARY.md` |
 
 ## Deferred Items
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -83,6 +83,7 @@ None yet. Field TODOs are tracked separately in `reference/FIX-TODOS.md`.
 | ID | Task | Date | Branch | Summary |
 |----|------|------|--------|---------|
 | 260809-nyq | Myco deep linking (`myco://app/<host>/<path>`) + deferred open, and the myco-dumplings test nsite | 2026-08-09 | `feat/deep-links` | `.planning/quick/260809-nyq-myco-deep-linking-myco-app-host-path-def/SUMMARY.md` |
+| 260818-l65 | Status pill: bigger, red when mesh off, easier switch, and a Circle/Mesh status panel behind it (per-lane scanning + per-peer ping/uptime/last-seen) | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-l65-status-pill-panel/SUMMARY.md` |
 
 ## Deferred Items
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -86,6 +86,7 @@ None yet. Field TODOs are tracked separately in `reference/FIX-TODOS.md`.
 | 260818-l65 | Status pill: bigger, red when mesh off, easier switch, and a Circle/Mesh status panel behind it (per-lane scanning + per-peer ping/uptime/last-seen) | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-l65-status-pill-panel/SUMMARY.md` |
 | 260818-dnm | Device name: default to the phone's own name, one-tap chips for it and the generated one, and a 2048-wide SHA-256-keyed generator (was 144 with a correlated hash) | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-dnm-device-name-defaults/SUMMARY.md` |
 | 260818-fgt | First-run gating: radios and permission prompts wait for the intro; peer labels resolve to the name the peer actually chose | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-fgt-first-run-gating/SUMMARY.md` |
+| 260818-adv | Broadcast the chosen device name in the BLE scan response so Nearby shows it before pairing; fixed inbound-BLE advert attribution via transport_addr | 2026-08-18 | `feat/status-pill-panel` | `.planning/quick/260818-adv-advertised-names/SUMMARY.md` |
 
 ## Deferred Items
 

--- a/.planning/quick/260818-adv-advertised-names/SUMMARY.md
+++ b/.planning/quick/260818-adv-advertised-names/SUMMARY.md
@@ -62,15 +62,36 @@ attribution for inbound peers too, which was silently missing before.
   response)` and `ble0/77:B5:98:5E:D1:E6 advertises name 'orchid eero'` — both
   directions confirmed on the wire.
 
+## Correction: the address key was the wrong key
+
+The first working build advertised and received fine and still showed nothing,
+because the join ran on the BLE address. That only ever attaches a name to a
+peer *currently carried over BLE* — and a device is routinely discovered by
+advert and then connected over the LAN lane, which is exactly what both test
+devices were doing. Its peer row is keyed by node address, not by MAC.
+
+So the advertiser now says who it is: the scan response carries a 6-byte
+`node_addr` prefix ahead of the name, and `advert_names` is keyed on that.
+48 bits is ample against accidental collision in a room and leaves 21 bytes for
+the name. No address mapping is needed at all, and the join works whatever
+transport ends up carrying the peer.
+
+The `transport_addr` work stays — it is a genuine fix for RSSI attribution on
+inbound BLE peers, which was silently missing.
+
+Confirmed on device: tablet logs `name 'DC-1' as 6B+name in scan response` and
+`ble0/7E:80:31:62:69:92 (a16d353c9f25…) advertises name 'orchid eero'`, and the
+A52's Dev peer row on the tablet now reads `advert name  orchid eero` while
+every other peer (older builds) reads `—`.
+
 ## Not verified
 
-The rendered label. Both test devices' chosen names are indistinguishable from
-what the generator produces for their npubs (the A52's *is* `orchid eero`), so
-the Nearby bubble looks identical whether the advertised name was used or not.
-Proving it on screen needs one device renamed to something the generator cannot
-emit — `DC-1` qualifies, and the tablet already advertises it, but the A52 was
-locked. Check the A52's Nearby list for `DC-1`: if it appears, the whole path
-renders.
+The rendered Nearby bubble. On the tablet the A52's chosen name is identical to
+what the generator produces for its npub (`orchid eero`), so the bubble looks
+the same either way — the `advert name` forensic row is what proves the join.
+The unambiguous direction is the A52 showing the tablet as `DC-1`, which the
+generator cannot emit; the A52 was locked and needs a relaunch on this build,
+since it pushes its name and node address from `onResume`.
 
 Also unchanged: this is BLE-only. A peer found over Wi-Fi Aware or the LAN
 still carries no advertised name.

--- a/.planning/quick/260818-adv-advertised-names/SUMMARY.md
+++ b/.planning/quick/260818-adv-advertised-names/SUMMARY.md
@@ -95,3 +95,31 @@ since it pushes its name and node address from `onResume`.
 
 Also unchanged: this is BLE-only. A peer found over Wi-Fi Aware or the LAN
 still carries no advertised name.
+
+## Follow-up: a rename didn't reach the radio
+
+Renaming from Settings or the Circle dialog wrote the preference and told the
+core, but never touched `BleRadio` — only `onResume` and the first-run dialog
+pushed the name in. So a rename took effect on the next app foreground, not on
+save, and the old name kept going out over the air. That is the surface a
+rename is usually aimed at.
+
+`applyDeviceName()` is now the single way to change the name and moves all
+three publish points together: the preference, the core (which stamps pair
+events), and the radio (which broadcasts it). All four call sites go through
+it — Settings chips, Settings save, the Circle rename dialog, and the first-run
+dialog — and `onResume` re-asserts through the same function.
+
+### Rendering confirmed
+
+The tablet's Nearby list showed `riley` and `DC-1`. Neither is producible by
+the generator, which only ever emits lowercase `colour name`, so both can only
+have arrived over the air.
+
+One peer advertised `DC-1` while its Circle name, learned from its signed pair
+event, was `frank`. That divergence is this exact bug seen from the other side:
+a device renamed on a build predating the fix keeps broadcasting the old name
+until it next foregrounds. It should resolve once that device runs this build.
+Worth re-checking — if a peer still shows a stale advertised name after
+restarting on this build, the join is attributing to the wrong row and that is
+a different problem.

--- a/.planning/quick/260818-adv-advertised-names/SUMMARY.md
+++ b/.planning/quick/260818-adv-advertised-names/SUMMARY.md
@@ -1,0 +1,76 @@
+---
+id: 260818-adv
+slug: advertised-names
+date: 2026-08-18
+status: complete
+branch: feat/status-pill-panel
+---
+
+# Quick: broadcast the chosen name so Nearby can show it
+
+## The channel
+
+The primary BLE advert is full — 27 of its 31 legacy bytes carry flags, the
+128-bit FIPS service UUID and the 2-byte PSM service data — and the PSM must
+stay there, because a scan response needs an active-scan round-trip that drops
+asymmetrically across chipsets. So the name goes in the **scan response's own
+31 bytes**, under a new 16-bit service-data UUID (`0x9C91`, the PSM key's
+neighbour). The trade is deliberate: a dropped scan response is fatal for a PSM
+and merely cosmetic for a name, which just falls back to the generated one.
+
+`BleRadio.localName` is process-global rather than per-radio, because the app
+asserts the name on every resume and that can precede the radio's existence.
+Setting it while advertising re-issues the advert, since the scan response is
+fixed at start time.
+
+## The path
+
+Received names land in `advert_names` — a Myco-owned, BLE-address-keyed map
+with its own JNI entry point (`bleDeliverAdvertName`), deliberately *not* the
+fips bridge's `deliver_scan`: the name has no bearing on routing and fips must
+stay clean. Same shape as `lane_observation`. `merge_peers` joins it onto rows
+by BLE address; `peerLabel` places it below every name learned from signed pair
+traffic and above the npub-derived floor.
+
+**The name is unauthenticated** — a plaintext broadcast anyone in range can
+forge, and now readable by any scanner near you, which matters more since the
+default is the phone's own name. The ordering in `peerLabel` is what keeps it
+from ever displacing a signed name; that ordering is load-bearing, not
+cosmetic.
+
+## The bug this exposed
+
+The first build advertised and received correctly but nothing showed, because
+`merge_peers` could only attribute an advert to a peer row when the
+connect-attempt log had learned that BLE address — and that log only records
+dials *we* made. Both live BLE peers had connected inbound, so their rows had
+no `ble_addr`, no RSSI, and no advertised name.
+
+fips was already reporting the answer and Myco was discarding it:
+`show_peers`'s `transport_addr` is the peer's live link address, formatted for
+BLE as exactly the `adapter/AA:BB:CC:DD:EE:FF` key the adverts arrive under. It
+now rides `PeerView` and sets `ble_addr` on BLE rows directly. This fixes RSSI
+attribution for inbound peers too, which was silently missing before.
+
+## Verification
+
+- New unit tests: advert-name join by address (and no borrowing across rows);
+  inbound-BLE peer keyed by its link address, with RSSI and name both landing
+  and a socket address correctly keying into nothing.
+- `cargo test -p myco-core` — 91 pass.
+- On device: tablet logs `advertising PSM 196 …, name 'DC-1' (in scan
+  response)` and `ble0/77:B5:98:5E:D1:E6 advertises name 'orchid eero'` — both
+  directions confirmed on the wire.
+
+## Not verified
+
+The rendered label. Both test devices' chosen names are indistinguishable from
+what the generator produces for their npubs (the A52's *is* `orchid eero`), so
+the Nearby bubble looks identical whether the advertised name was used or not.
+Proving it on screen needs one device renamed to something the generator cannot
+emit — `DC-1` qualifies, and the tablet already advertises it, but the A52 was
+locked. Check the A52's Nearby list for `DC-1`: if it appears, the whole path
+renders.
+
+Also unchanged: this is BLE-only. A peer found over Wi-Fi Aware or the LAN
+still carries no advertised name.

--- a/.planning/quick/260818-dnm-device-name-defaults/SUMMARY.md
+++ b/.planning/quick/260818-dnm-device-name-defaults/SUMMARY.md
@@ -1,0 +1,49 @@
+---
+id: 260818-dnm
+slug: device-name-defaults
+date: 2026-08-18
+status: complete
+branch: feat/status-pill-panel
+---
+
+# Quick: phone name as the default, generated name one tap away
+
+## What changed
+
+**`DeviceName.phoneName(context)`** reads the name the user already gave this
+handset: `Settings.Global.DEVICE_NAME` first (no permission, API 25), then the
+Bluetooth adapter name via `BluetoothManager` (wrapped — it throws until
+`BLUETOOTH_CONNECT` is granted, which on a first run it is not), then the legacy
+`Settings.Secure "bluetooth_name"`. Null when none of them has anything usable.
+
+**`current()` now prefers it**: override → phone name → generated. The phone
+name is far more recognisable across a table, and this is the trade for it
+often carrying a real name.
+
+**`suggestions()`** returns both, de-duplicated, and the new `NameSuggestions`
+chip row puts each one tap away — so the pseudonymous option costs a tap rather
+than typing. Wired into the Settings ▸ Identity editor (a tap saves outright,
+there is nothing left to confirm) and the Circle rename dialog (a tap fills the
+field, because Save is that dialog's commit and skipping it would leave Cancel
+meaning nothing). The Settings "Reset" button is gone — it was the same idea
+with a worse name, and the chips say what they will do.
+
+**The generator got wider and better keyed.** 12 × 12 = 144 combinations is why
+duplicates showed up: by the birthday bound a room of 14 devices was even money
+for a collision. Now 32 × 64 = 2048, which needs ~53. The key moved from
+`String.hashCode()` to SHA-256 with disjoint digest bytes per list — the old
+code drew both the colour and the name from correlated bits of one 32-bit value,
+so the space was smaller in practice than the lists implied.
+
+## Verification
+
+- New `DeviceNameTest`: determinism, the empty-npub case, shape (two lowercase
+  words), a circle-sized run with no collision, and 1000 npubs filling >700 of
+  the 2048 buckets (a correlated hash fails that while the lists stay the same).
+- `:app:testDebugUnitTest`, `:app:assembleDebug` — pass. Installed on both
+  attached devices.
+
+## Not done
+
+- The first-run gating discussed alongside this (radios and permission prompts
+  firing in `onCreate` before the intro) is NOT implemented — still open.

--- a/.planning/quick/260818-fgt-first-run-gating/SUMMARY.md
+++ b/.planning/quick/260818-fgt-first-run-gating/SUMMARY.md
@@ -1,0 +1,57 @@
+---
+id: 260818-fgt
+slug: first-run-gating
+date: 2026-08-18
+status: complete
+branch: feat/status-pill-panel
+---
+
+# Quick: first-run gating + peer names people actually chose
+
+## First-run gating
+
+`MainActivity.onCreate` started every lane unconditionally, before `setContent`.
+On a cold install that meant the LAN browse up, the Bluetooth and Wi-Fi Aware
+permission dialogs stacked, and the system's "Myco wants to set up a VPN
+connection" prompt on top — four system dialogs over a splash animation, before
+the app had said what it is.
+
+That block is now `startEnabledLanes()`, called from `onCreate` only when
+`PREF_INTRO_SEEN` is already set, and from the intro's `onFinished` on the first
+run. Returning launches are byte-for-byte what they were. A replayed intro takes
+the same branch and is a no-op — `ApRadio.ensureStarted`, both services' `start`
+and `startNode` are all idempotent.
+
+No consent card was added: the ask was for the gate.
+
+## Peer names
+
+`peerLabel(state, npub)` resolves a peer to the name **they** chose, checking
+the sources that actually carry one, most-recently-confirmed first: their Circle
+entry, the pair request they sent us, the invite we sent them. The npub-derived
+name is the floor, not the default. Replaces `DeviceName.generated(peer.npub)`
+at every display site — Circle NEARBY bubbles and their sort key, invite
+bubbles, the Dev peer list, the speedtest labels, and both sections of the
+status sheet (where lane rows had been showing fips's `display_name`, which is
+an abbreviated npub, not a chosen name).
+
+### The gap, stated plainly
+
+A peer we are merely connected to and have exchanged no pair traffic with has
+told us nothing but an npub, so it still shows the generated name. There is no
+channel to fix that with today:
+
+- the BLE advert is 27 of its 31 legacy bytes already (flags + the 128-bit FIPS
+  service UUID + the 2-byte PSM service data), so a name does not fit;
+- fips's `display_name` is a local alias/hosts lookup, never sent by the far
+  side.
+
+Covering it needs a name exchange over the mesh on connect — which broadcasts a
+possibly-real name (the new default is the phone's own name) to every unpaired
+device in BLE range. That is a product decision, not a bug fix, and is left
+open.
+
+## Verification
+
+`:app:testDebugUnitTest`, `:app:assembleDebug` — pass. Installed on both
+attached devices. First-run behaviour not yet re-verified from a clean install.

--- a/.planning/quick/260818-fgt-first-run-gating/SUMMARY.md
+++ b/.planning/quick/260818-fgt-first-run-gating/SUMMARY.md
@@ -55,3 +55,28 @@ open.
 
 `:app:testDebugUnitTest`, `:app:assembleDebug` — pass. Installed on both
 attached devices. First-run behaviour not yet re-verified from a clean install.
+
+## Follow-up: the first-run name question
+
+The chips alone were not enough — they only lived in Settings and the Circle
+rename dialog, so a clean install silently adopted the phone's own name without
+ever showing it. `FirstRunNameDialog` now asks once, between the intro and the
+radios: the phone name prefilled, both suggestions as chips, free text if
+neither fits. Gated on its own `name_chosen` pref rather than `intro_seen`, so
+replaying the intro doesn't re-ask and an upgrade from a build that never asked
+still gets it once.
+
+Order is deliberate — name first, lanes second. The permission dialogs would
+otherwise stack on top of it, and the name is what every pair request carries,
+so it should be settled before anything can send one.
+
+### Verified on a clean install (tablet, DC_1)
+
+- `Displayed` at 17:20:12, no services and no dialogs until the intro was
+  tapped — the gate holds.
+- Name dialog appeared with `DC-1` prefilled; answering it wrote
+  `device_name=DC-1` and `name_chosen=true`.
+- Only then: notifications + nearby-devices prompts, VPN consent, then
+  `BleService` and `MycoVpnService`, 6 peers.
+- `NEARBY_WIFI_DEVICES` came out `granted=false` — the Aware lane was left
+  without its permission on this run. Not investigated.

--- a/.planning/quick/260818-l65-status-pill-panel/PLAN.md
+++ b/.planning/quick/260818-l65-status-pill-panel/PLAN.md
@@ -1,0 +1,52 @@
+---
+id: 260818-l65
+slug: status-pill-panel
+date: 2026-08-18
+mode: quick
+branch: feat/status-pill-panel
+---
+
+# Quick: status pill status panel
+
+Make the top-right `PeersPill` a real status affordance: bigger, red when the mesh
+is off, an easier switch to hit, and tappable to open a panel that answers "what is
+my mesh actually doing right now" — per transport, per peer.
+
+## Scope
+
+**Rust (myco-core)**
+
+1. `control_client.rs` — add `srtt_ms: Option<f64>` to `PeerView`, read from the
+   `show_peers` row's `mmp.srtt_ms` (fips emits it only when MMP has a measurement,
+   so absent stays `None`; never a fabricated 0).
+2. `state.rs` — add `srtt_ms: Option<f64>` to `PeerDiagnosticView` (serialises as
+   `srttMs`).
+3. `peer_diagnostics.rs` — carry it through `merge_peers` from the matching
+   `PeerView`; `None` on advert-only / circle-only rows.
+
+**Kotlin (android)**
+
+4. `AppCoreClient.kt` — parse `srttMs` onto `PeerDiagnostic`.
+5. New `ui/TransportIcons.kt` — hoist `TransportIcon` out of `DevScreen` so both
+   the Dev tab and the new panel draw the same three glyphs. DevScreen's private
+   copy is deleted and it imports the shared one.
+6. `MycoApp.kt` — `PeersPill`: larger metrics, `errorContainer` colouring when the
+   mesh is off, a 48dp-tall switch hit target, and the rest of the pill clickable
+   to open the panel.
+7. New `ui/MeshStatusSheet.kt` — a `ModalBottomSheet` with two sections:
+   - **Circle** — each paired contact, reachable now or not.
+   - **Mesh** — one block per transport (`ble` / `aware` / network), each showing
+     whether that lane is scanning right now (tri-state: unknown when the app
+     could not observe it) and the peers currently carried on it, with ping
+     (srtt), connected time, and last seen ("now" under 10s).
+
+## Non-goals
+
+- No new fips changes — `mmp.srtt_ms` is already on the control-socket wire.
+- No change to how peers are discovered or dialled.
+
+## Verification
+
+- `cargo test -p myco-core`
+- `cargo fmt --all --check` / `cargo clippy`
+- Android: `./gradlew :app:compileDebugKotlin` (or assembleDebug)

--- a/.planning/quick/260818-l65-status-pill-panel/SUMMARY.md
+++ b/.planning/quick/260818-l65-status-pill-panel/SUMMARY.md
@@ -1,0 +1,59 @@
+---
+id: 260818-l65
+slug: status-pill-panel
+date: 2026-08-18
+status: complete
+branch: feat/status-pill-panel
+commits:
+  - c09103456ed5625fc640c4a648672181235919f5
+  - 38019e251ffbc6a78137185be5087298a834065b
+---
+
+# Quick: status pill status panel — complete
+
+## What changed
+
+**Rust — the ping was already on the wire, Myco was dropping it.**
+fips's `show_peers` row carries an inline `mmp` block whose `srtt_ms` is MMP's
+smoothed RTT for that link. `control_client.rs` never read it. It now lands on
+`PeerView.srtt_ms`, rides `merge_peers` onto `PeerDiagnosticView.srtt_ms`, and
+serialises as `srttMs`. Optional the whole way: fips omits the key until MMP has
+actually measured the link, and an unmeasured link has to read as "no ping"
+rather than a confident `0ms`. `PeerView` drops its `Eq` derive (f64).
+
+**Kotlin — the pill.**
+- Grows (18dp icon, `titleSmall` counts, more padding).
+- Whole surface goes `errorContainer` when the mesh is off, and the switch's own
+  track goes `error` — "off" reads from across the room now.
+- The switch's touch target is a 52×48dp box (was 36×20) — Material's minimum;
+  the drawn slider is unchanged, since `scale` is a draw transform only.
+- Tapping the counts opens the new panel.
+
+**Kotlin — the panel (`MeshStatusSheet.kt`).**
+A `ModalBottomSheet` in two sections:
+- **Circle** — every paired contact, reachable-now or offline, with the link
+  numbers when a direct peer row exists (a member reachable over several hops
+  has none, and that is not a fault).
+- **Mesh** — one block per lane (Bluetooth / Wi-Fi Aware / Network), each with
+  its scan state and the peers it carries. Scan state is tri-state: `off`,
+  `scanning`, `idle`, or `unknown` when the app could not observe it. The
+  routed lane's "scanning" is the mDNS browse from `ApRadio`.
+- Peer rows show `ping · up · seen`. Under ten seconds, last-seen is "now" — a
+  1s/2s/3s counter flickering reads as a fault when it is the healthy case.
+- The sheet runs its own 1Hz ticker: ages come from the wall clock, not the
+  snapshot, so they would freeze whenever two polls compared equal.
+
+**Shared `TransportIcon`** moved from `DevScreen` to `ui/TransportIcons.kt` (now
+with a `size` parameter) so the Dev tab and the panel draw the same glyphs.
+
+## Verification
+
+- `cargo test -p myco-core` — pass, including two new tests (`srtt_ms` parsed
+  from an observed row; absent `srtt_ms` and absent `mmp` both read as `None`)
+  and one merge test (`srtt` rides the `PeerView`, `None` on a circle-only row).
+- `cargo fmt --all --check` — clean.
+- `./gradlew :app:compileDebugKotlin`, `:app:testDebugUnitTest` — pass.
+
+## Not done
+
+- No on-device check of the panel's numbers against a second phone yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The status pill opens. Tapping the counts brings up a panel with the two
+  questions people actually have — can I reach my Circle, and what are the
+  radios doing. Circle members are listed reachable-first (alphabetically
+  inside each group, so the list never reshuffles under your thumb), with the
+  offline ones folded behind a single line. Each radio lane says whether it is
+  scanning and lists the peers it is carrying, with ping, how long the session
+  has held, and when it was last heard from — "now" for anything inside ten
+  seconds, because a counter flickering 1s/2s/3s reads as a fault when it is
+  the healthy case. A lane whose scan state cannot be observed says `unknown`
+  rather than `idle`, and a radio the phone does not have is left out entirely.
+- Peers show a ping. FIPS has been measuring a smoothed round-trip time per
+  link all along and Myco was discarding it at the boundary. A link that has
+  never been timed shows no ping rather than a confident `0ms`.
+- Myco asks what to call this device, once, on first run — and defaults to the
+  name the phone already has. "Arjen's S21" is far easier to pick out across a
+  table than "green sammy", but it usually carries a real name and it travels
+  in every pair request, so it is shown before it is used rather than adopted
+  silently. The pseudonymous generated name sits beside it as a single tap.
+- That chosen name now rides the Bluetooth advert, so people see it in Nearby
+  before pairing rather than a name derived from your public key. It is a
+  plaintext broadcast anyone in range can forge, so it never displaces a name
+  learned from a signed pair request — it only fills the gap where there was no
+  name at all.
+- Wherever a peer is named it is now the name they chose: Nearby, the Circle,
+  the Dev peer list, the speedtest. The key-derived name is the floor rather
+  than the default.
 - Wi-Fi Aware carries mesh traffic for the first time. The fast lane had been
   negotiating a data path with nearby phones for months and never moving a
   byte over it: the mesh node had one UDP socket, and the LAN lane pinned it to
@@ -37,6 +63,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Nothing starts and nothing is asked for until the intro has played. A cold
+  install used to bring up the LAN browse and then stack the Bluetooth prompt,
+  the Wi-Fi Aware prompt and the system's "Myco wants to set up a VPN
+  connection" dialog over the splash animation, before the app had said what it
+  is. Every one of those now arrives after the intro. Later launches are
+  unchanged.
+- The status pill is bigger, and turns red outright when the mesh is off — a
+  grey slider was not enough to notice across a room. Its whole left third
+  toggles the mesh rather than the slider alone: the slider swallowed every tap
+  that landed beside it, which is what made this fiddly, not the target being
+  small.
+- The generated device name has 2048 combinations instead of 144, which is why
+  duplicates kept turning up — a room of fourteen phones was already even money
+  for a collision. The colour and the name are now drawn from independent parts
+  of a real hash rather than from correlated bits of one small one.
 - The mesh node is rebuilt on current FIPS. The version Myco had been building
   against had drifted a long way behind, and the gap included fixes to path
   MTU, framing, peer identity and the control plane. Everything Myco needs from
@@ -51,6 +92,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Renaming your device changes what goes out over the air. The rename wrote the
+  preference and told the mesh node but never told the radio, so the old name
+  kept being broadcast until the app was next brought to the foreground — which
+  is exactly the surface a rename is usually aimed at.
+- A peer that connected to us, rather than being dialled by us, is attributed
+  its own Bluetooth adverts again. Only outbound dials were recorded, so an
+  inbound peer had no address on file and its signal strength — and now the name
+  it advertises — went missing.
 - Bluetooth works again after being switched off and on. Turning the radio off
   and back on — or leaving and returning from airplane mode — left the app
   permanently unable to see any Bluetooth peer until it was force-stopped,

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -44,6 +44,7 @@ import androidx.lifecycle.lifecycleScope
 import app.myco.ap.ApRadio
 import app.myco.aware.AwareRadio
 import app.myco.aware.AwareService
+import app.myco.ble.BleRadio
 import app.myco.ble.BleService
 import app.myco.BuildConfig
 import app.myco.core.AppCoreClient
@@ -204,6 +205,7 @@ class MainActivity : ComponentActivity() {
                         FirstRunNameDialog(ownNpub = npub) { picked ->
                             DeviceName.set(this@MainActivity, picked)
                             core.dispatch(NativeActions.setDeviceName(picked))
+                            BleRadio.localName = picked
                             prefs.edit().putBoolean(PREF_NAME_CHOSEN, true).apply()
                             askName = false
                             // Deferred from the intro on a first run; a no-op
@@ -416,7 +418,12 @@ class MainActivity : ComponentActivity() {
         // here (not just onCreate) in case the device identity wasn't ready yet at
         // first launch; set_device_name is idempotent.
         core.state().ownNpub.takeIf { it.isNotEmpty() }?.let {
-            core.dispatch(NativeActions.setDeviceName(DeviceName.current(this, it)))
+            val name = DeviceName.current(this, it)
+            core.dispatch(NativeActions.setDeviceName(name))
+            // Same name into the radio, so peers who have never paired with us
+            // still see it in their Nearby list. Re-advertises only when it
+            // actually changed.
+            BleRadio.localName = name
         }
         // Deep links followed before the app existed (possibly in a previous process)
         // get their chance every time Myco comes back to the foreground.

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -206,6 +206,7 @@ class MainActivity : ComponentActivity() {
                             DeviceName.set(this@MainActivity, picked)
                             core.dispatch(NativeActions.setDeviceName(picked))
                             BleRadio.localName = picked
+                            BleRadio.localNodeAddrHex = core.state().nodeAddrHex
                             prefs.edit().putBoolean(PREF_NAME_CHOSEN, true).apply()
                             askName = false
                             // Deferred from the intro on a first run; a no-op
@@ -421,9 +422,12 @@ class MainActivity : ComponentActivity() {
             val name = DeviceName.current(this, it)
             core.dispatch(NativeActions.setDeviceName(name))
             // Same name into the radio, so peers who have never paired with us
-            // still see it in their Nearby list. Re-advertises only when it
-            // actually changed.
+            // still see it in their Nearby list. The node address rides with
+            // it: the name has to say whose it is, since the peer hearing it
+            // may end up carrying us over a different transport entirely.
+            // Re-advertises only when either actually changed.
             BleRadio.localName = name
+            BleRadio.localNodeAddrHex = core.state().nodeAddrHex
         }
         // Deep links followed before the app existed (possibly in a previous process)
         // get their chance every time Myco comes back to the foreground.

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -59,6 +59,7 @@ import app.myco.share.PendingDeepLinks
 import app.myco.ui.MycoApp
 import app.myco.ui.intro.IntroMode
 import app.myco.ui.FirstRunNameDialog
+import app.myco.ui.applyDeviceName
 import app.myco.ui.intro.IntroScreen
 import app.myco.ui.theme.MycoTheme
 import app.myco.vpn.MycoVpnService
@@ -203,10 +204,7 @@ class MainActivity : ComponentActivity() {
                         // JNI and takes the core's locks.
                         val npub = remember { core.state().ownNpub }
                         FirstRunNameDialog(ownNpub = npub) { picked ->
-                            DeviceName.set(this@MainActivity, picked)
-                            core.dispatch(NativeActions.setDeviceName(picked))
-                            BleRadio.localName = picked
-                            BleRadio.localNodeAddrHex = core.state().nodeAddrHex
+                            applyDeviceName(this@MainActivity, core, npub, picked)
                             prefs.edit().putBoolean(PREF_NAME_CHOSEN, true).apply()
                             askName = false
                             // Deferred from the intro on a first run; a no-op
@@ -419,15 +417,13 @@ class MainActivity : ComponentActivity() {
         // here (not just onCreate) in case the device identity wasn't ready yet at
         // first launch; set_device_name is idempotent.
         core.state().ownNpub.takeIf { it.isNotEmpty() }?.let {
-            val name = DeviceName.current(this, it)
-            core.dispatch(NativeActions.setDeviceName(name))
-            // Same name into the radio, so peers who have never paired with us
-            // still see it in their Nearby list. The node address rides with
-            // it: the name has to say whose it is, since the peer hearing it
-            // may end up carrying us over a different transport entirely.
-            // Re-advertises only when either actually changed.
-            BleRadio.localName = name
-            BleRadio.localNodeAddrHex = core.state().nodeAddrHex
+            // Re-assert rather than set: passing the stored override back
+            // through resolves to the same name, and every publish site is
+            // idempotent. This is the belt to the rename sites' braces, for a
+            // radio that started after the last rename.
+            val stored = getSharedPreferences("myco_prefs", MODE_PRIVATE)
+                .getString("device_name", "").orEmpty()
+            applyDeviceName(this, core, it, stored)
         }
         // Deep links followed before the app existed (possibly in a previous process)
         // get their chance every time Myco comes back to the foreground.

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -124,34 +124,16 @@ class MainActivity : ComponentActivity() {
         // (Device name is asserted in onResume, which also covers identity not yet
         // being ready at this point.)
 
-        // The `!FIPS` AP lane: watch Wi-Fi and browse the LAN for fips-node
-        // mDNS adverts, feeding them to the node (Dev panel shows results).
-        // Passive and permissionless; process-wide, so idempotent across
-        // Activity recreation.
-        ApRadio.ensureStarted(this)
-
-        // BLE on by default, and remembered thereafter.
-        if (prefs.getBoolean(PREF_BLE, true)) {
-            if (bleCorePermsGranted()) BleService.start(this) else requestBlePermissionsIfNeeded()
-        }
-
-        // Wi-Fi Aware is ON by default; resume it unless the user turned it off,
-        // and only where the hardware supports it.
-        if (prefs.getBoolean(PREF_AWARE, true) && AwareRadio.isSupported(this)) {
-            if (awarePermsGranted()) AwareService.start(this) else requestAwarePermissionsIfNeeded()
-        }
-
-        // The mesh adapter (app-owned TUN) is ON by default — it's how this device
-        // reaches the mesh, so it's effectively required. Bring it up at launch,
-        // prompting for the one-time VPN consent the first time it's needed.
-        // The fips node's lifecycle follows this master "Enable" switch (the
-        // radio toggles only gate their radios), so start it here too — the
-        // dispatch is idempotent with the radio services' own startNode calls.
-        if (prefs.getBoolean(PREF_MESH, true)) {
-            core.dispatch(NativeActions.startNode())
-            val consent = VpnService.prepare(this)
-            if (consent == null) startMeshNow() else vpnConsentLauncher.launch(consent)
-        }
+        // Nothing starts and nothing is asked for until the intro has been seen
+        // once. On a cold install this block would otherwise run before the
+        // first frame: LAN browse up, the Bluetooth and Wi-Fi Aware permission
+        // dialogs stacked, and the system's "Myco wants to set up a VPN
+        // connection" prompt on top of them — four system dialogs over a splash
+        // animation, before the app has said what it is. Every one of them now
+        // arrives after the intro, which is the first thing that explains
+        // anything. Returning launches are unchanged: the flag is set, so this
+        // runs here exactly as it always did.
+        if (prefs.getBoolean(PREF_INTRO_SEEN, false)) startEnabledLanes()
 
         setContent {
             MycoTheme {
@@ -208,7 +190,16 @@ class MainActivity : ComponentActivity() {
                             onFrost = { frost = it },
                             onFinished = {
                                 introShowing = false
+                                val firstRun = !prefs.getBoolean(PREF_INTRO_SEEN, false)
                                 prefs.edit().putBoolean(PREF_INTRO_SEEN, true).apply()
+                                // First run: onCreate deliberately started
+                                // nothing, so this is where the radios come up
+                                // and the permission prompts are allowed to
+                                // appear. A replayed intro clears the flag too
+                                // and so takes this branch as well, which is a
+                                // no-op — every call in there is idempotent and
+                                // the lanes are already running.
+                                if (firstRun) startEnabledLanes()
                             },
                         )
                     }
@@ -220,6 +211,46 @@ class MainActivity : ComponentActivity() {
     }
 
     // --- mesh adapter (app-owned TUN) ---
+
+    /**
+     * Bring up every lane the user has left enabled, and ask for whatever
+     * permission each one still needs.
+     *
+     * Called from `onCreate` on every launch after the first, and from the
+     * intro's completion on the first — see the gate at its `onCreate` call
+     * site for why. Idempotent: each service's `start` is, `ApRadio` is
+     * process-wide, and `startNode` is a no-op on a running node.
+     */
+    private fun startEnabledLanes() {
+        // The `!FIPS` AP lane: watch Wi-Fi and browse the LAN for fips-node
+        // mDNS adverts, feeding them to the node (Dev panel shows results).
+        // Passive and permissionless; process-wide, so idempotent across
+        // Activity recreation.
+        ApRadio.ensureStarted(this)
+
+        // BLE on by default, and remembered thereafter.
+        if (prefs.getBoolean(PREF_BLE, true)) {
+            if (bleCorePermsGranted()) BleService.start(this) else requestBlePermissionsIfNeeded()
+        }
+
+        // Wi-Fi Aware is ON by default; resume it unless the user turned it off,
+        // and only where the hardware supports it.
+        if (prefs.getBoolean(PREF_AWARE, true) && AwareRadio.isSupported(this)) {
+            if (awarePermsGranted()) AwareService.start(this) else requestAwarePermissionsIfNeeded()
+        }
+
+        // The mesh adapter (app-owned TUN) is ON by default — it's how this device
+        // reaches the mesh, so it's effectively required. Bring it up at launch,
+        // prompting for the one-time VPN consent the first time it's needed.
+        // The fips node's lifecycle follows this master "Enable" switch (the
+        // radio toggles only gate their radios), so start it here too — the
+        // dispatch is idempotent with the radio services' own startNode calls.
+        if (prefs.getBoolean(PREF_MESH, true)) {
+            core.dispatch(NativeActions.startNode())
+            val consent = VpnService.prepare(this)
+            if (consent == null) startMeshNow() else vpnConsentLauncher.launch(consent)
+        }
+    }
 
     /**
      * The mesh master switch. Takes the node **and the BLE radio** with it.

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -57,6 +57,7 @@ import app.myco.share.NsiteShare
 import app.myco.share.PendingDeepLinks
 import app.myco.ui.MycoApp
 import app.myco.ui.intro.IntroMode
+import app.myco.ui.FirstRunNameDialog
 import app.myco.ui.intro.IntroScreen
 import app.myco.ui.theme.MycoTheme
 import app.myco.vpn.MycoVpnService
@@ -160,6 +161,16 @@ class MainActivity : ComponentActivity() {
                 // without being able to read it. Modifier.blur is a no-op
                 // below API 31, where the wash carries it alone.
                 var frost by remember { mutableFloatStateOf(if (introShowing) 1f else 0f) }
+                // The name question, asked exactly once. Raised here rather than
+                // only from the intro's completion so an upgrade from a build
+                // that never asked still gets it on its next launch, with the
+                // intro already behind it.
+                var askName by rememberSaveable {
+                    mutableStateOf(
+                        !prefs.getBoolean(PREF_NAME_CHOSEN, false) &&
+                            prefs.getBoolean(PREF_INTRO_SEEN, false),
+                    )
+                }
 
                 Box(Modifier.fillMaxSize()) {
                     Box(Modifier.blur(14.dp * frost)) {
@@ -184,6 +195,23 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
+                    // Sits above the app and below nothing: the intro is gone
+                    // by the time this can show.
+                    if (askName && !introShowing) {
+                        // Read once, not on every keystroke — state() crosses
+                        // JNI and takes the core's locks.
+                        val npub = remember { core.state().ownNpub }
+                        FirstRunNameDialog(ownNpub = npub) { picked ->
+                            DeviceName.set(this@MainActivity, picked)
+                            core.dispatch(NativeActions.setDeviceName(picked))
+                            prefs.edit().putBoolean(PREF_NAME_CHOSEN, true).apply()
+                            askName = false
+                            // Deferred from the intro on a first run; a no-op
+                            // when the lanes are already up.
+                            startEnabledLanes()
+                        }
+                    }
+
                     if (introShowing) {
                         IntroScreen(
                             mode = introMode,
@@ -193,13 +221,20 @@ class MainActivity : ComponentActivity() {
                                 val firstRun = !prefs.getBoolean(PREF_INTRO_SEEN, false)
                                 prefs.edit().putBoolean(PREF_INTRO_SEEN, true).apply()
                                 // First run: onCreate deliberately started
-                                // nothing, so this is where the radios come up
-                                // and the permission prompts are allowed to
-                                // appear. A replayed intro clears the flag too
-                                // and so takes this branch as well, which is a
-                                // no-op — every call in there is idempotent and
-                                // the lanes are already running.
-                                if (firstRun) startEnabledLanes()
+                                // nothing. Ask the name before the radios come
+                                // up rather than after — the permission dialogs
+                                // would sit on top of this one, and the name is
+                                // what every later pair request carries, so it
+                                // should be settled before anything can send
+                                // one. A replayed intro has already answered it
+                                // and falls through to starting the lanes,
+                                // which is a no-op there since every call in
+                                // startEnabledLanes is idempotent.
+                                if (firstRun && !prefs.getBoolean(PREF_NAME_CHOSEN, false)) {
+                                    askName = true
+                                } else if (firstRun) {
+                                    startEnabledLanes()
+                                }
                             },
                         )
                     }
@@ -826,5 +861,10 @@ class MainActivity : ComponentActivity() {
         const val PREF_EXIT_PROXY = "exit_proxy"
         /** Set once the intro has played all the way through. */
         const val PREF_INTRO_SEEN = "intro_seen"
+
+        /** Set once the first-run name question has been answered. Separate from
+         *  [PREF_INTRO_SEEN] so replaying the intro doesn't re-ask it, and so an
+         *  upgrade from a build that never asked still gets the question once. */
+        private const val PREF_NAME_CHOSEN = "name_chosen"
     }
 }

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -343,6 +343,15 @@ class BleRadio(context: Context) {
             }, DIAL_WATCHDOG_MS, TimeUnit.MILLISECONDS)
         }.getOrNull()
 
+    /** The first [bytes] bytes of a hex string, as bytes. Null if it is too
+     *  short or not hex — never a partially-decoded prefix. */
+    private fun hexPrefix(hex: String, bytes: Int): ByteArray? {
+        if (hex.length < bytes * 2) return null
+        return runCatching {
+            ByteArray(bytes) { i -> hex.substring(i * 2, i * 2 + 2).toInt(16).toByte() }
+        }.getOrNull()
+    }
+
     /** `s` as UTF-8, cut to at most [max] bytes on a character boundary. */
     private fun truncateUtf8(s: String, max: Int): ByteArray {
         var text = s
@@ -388,19 +397,33 @@ class BleRadio(context: Context) {
         // unchanged. Null when no name has been pushed yet — advertise nothing
         // rather than an empty string, so a scanner can tell "chose no name"
         // from "advertised a blank one".
+        // <6-byte node_addr prefix><UTF-8 name>. Both or neither: a name with
+        // nobody attached to it is unattributable, and an address with no name
+        // says nothing the peer row did not already know.
+        val nodePrefix = localNodeAddrHex?.let { hexPrefix(it, NODE_PREFIX_BYTES) }
         val nameBytes = localName?.let { truncateUtf8(it, MAX_NAME_BYTES) }
-        val scanResponse = nameBytes?.let {
+        val scanResponse = if (nodePrefix != null && nameBytes != null) {
             AdvertiseData.Builder()
                 .setIncludeDeviceName(false)
-                .addServiceData(NAME_SD_PARCEL_UUID, it)
+                .addServiceData(NAME_SD_PARCEL_UUID, nodePrefix + nameBytes)
                 .build()
+        } else {
+            null
         }
         val cb = object : AdvertiseCallback() {
             override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
                 advertiseRetries = 0
                 BleHealth.advertiserExhausted = false
+                // Reports what actually went out, not what was configured: the
+                // scan response is only built when BOTH the name and the node
+                // address are known, and a log that claimed otherwise sent me
+                // hunting on the receiving device for a name never sent.
                 Log.i(TAG, "advertising PSM $psm (in primary advert)" +
-                    (localName?.let { ", name '$it' (in scan response)" } ?: ""))
+                    if (scanResponse != null) {
+                        ", name '$localName' as ${nodePrefix?.size ?: 0}B+name in scan response"
+                    } else {
+                        ", no scan response (name=$localName nodeAddr=$localNodeAddrHex)"
+                    })
                 if (bridgeHandle != 0L) NativeCore.bleDeliverAdvertisingState(bridgeHandle, true)
             }
             override fun onStartFailure(errorCode: Int) {
@@ -545,15 +568,19 @@ class BleRadio(context: Context) {
             // — a scan response can simply not arrive — and pushing nothing is
             // how the display layer keeps showing the npub-derived name.
             result.scanRecord?.getServiceData(NAME_SD_PARCEL_UUID)
-                ?.takeIf { it.isNotEmpty() }
-                ?.let { bytes ->
-                    val advertised = String(bytes, Charsets.UTF_8)
-                    NativeCore.bleDeliverAdvertName(addr, advertised)
+                ?.takeIf { it.size > NODE_PREFIX_BYTES }
+                ?.let { blob ->
+                    val nodePrefix = blob.take(NODE_PREFIX_BYTES)
+                        .joinToString("") { "%02x".format(it) }
+                    val advertised = String(
+                        blob, NODE_PREFIX_BYTES, blob.size - NODE_PREFIX_BYTES, Charsets.UTF_8,
+                    )
+                    NativeCore.bleDeliverAdvertName(nodePrefix, advertised)
                     // Logged on change only. The push itself fires several
                     // times a second per peer, but a name that just appeared or
                     // just changed is the one thing worth seeing in a log.
-                    if (lastAdvertName.put(addr, advertised) != advertised) {
-                        Log.i(TAG, "$addr advertises name '$advertised'")
+                    if (lastAdvertName.put(nodePrefix, advertised) != advertised) {
+                        Log.i(TAG, "$addr ($nodePrefix…) advertises name '$advertised'")
                     }
                 }
         } else {
@@ -965,6 +992,21 @@ class BleRadio(context: Context) {
                 instance?.reAdvertiseForName()
             }
 
+        @Volatile
+        private var nodeAddrField: String? = null
+
+        /** Our own `node_addr`, hex. Advertised beside [localName] so a scanner
+         *  can attribute the name to the peer row that address keys, whatever
+         *  transport that peer is ultimately carried on. */
+        var localNodeAddrHex: String?
+            get() = nodeAddrField
+            set(value) {
+                val next = value?.trim()?.ifBlank { null }
+                if (next == nodeAddrField) return
+                nodeAddrField = next
+                instance?.reAdvertiseForName()
+            }
+
         /** FIPS service UUID — must match fips-core. */
         val FIPS_UUID: UUID = UUID.fromString("9c90b790-2cc5-42c0-9f87-c9cc40648f4c")
         val FIPS_PARCEL_UUID = ParcelUuid(FIPS_UUID)
@@ -975,17 +1017,28 @@ class BleRadio(context: Context) {
          *  128-bit FIPS UUID inside one 31-byte legacy advert. */
         val PSM_SD_PARCEL_UUID = ParcelUuid.fromString("00009c90-0000-1000-8000-00805f9b34fb")
 
-        /** Compact 16-bit service-data UUID carrying this device's chosen display
-         *  name in the SCAN RESPONSE (0x9C91 — the PSM key's neighbour). It rides
-         *  the scan response precisely because the PSM must not: a scan response
-         *  needs an active-scan round-trip that drops asymmetrically, which is
-         *  fatal for the PSM but merely cosmetic for a name. A name that never
-         *  arrives just leaves the peer showing its npub-derived one. */
+        /** Compact 16-bit service-data UUID carrying this device's identity-plus-
+         *  name blob in the SCAN RESPONSE (0x9C91 — the PSM key's neighbour). It
+         *  rides the scan response precisely because the PSM must not: a scan
+         *  response needs an active-scan round-trip that drops asymmetrically,
+         *  which is fatal for the PSM but merely cosmetic for a name. A name that
+         *  never arrives just leaves the peer showing its npub-derived one. */
         val NAME_SD_PARCEL_UUID = ParcelUuid.fromString("00009c91-0000-1000-8000-00805f9b34fb")
 
+        /** Leading bytes of our own `node_addr` prefixed to the advertised name.
+         *
+         *  The name has to say *whose* it is. Keying it on the BLE MAC instead
+         *  only works for a peer currently carried over BLE — but a device is
+         *  routinely discovered by advert and then connected over the LAN lane,
+         *  and its row is keyed by node address, not by MAC. Six bytes is 48 bits
+         *  of node address: ample against accidental collision in a room, and
+         *  cheap enough to leave the name most of the payload. */
+        const val NODE_PREFIX_BYTES = 6
+
         /** Longest name that fits the 31-byte scan response beside its 4-byte
-         *  service-data header. Cut on a UTF-8 boundary, never mid-character. */
-        private const val MAX_NAME_BYTES = 27
+         *  service-data header and the node-address prefix. Cut on a UTF-8
+         *  boundary, never mid-character. */
+        private const val MAX_NAME_BYTES = 31 - 4 - NODE_PREFIX_BYTES
     }
 }
 

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -119,6 +119,16 @@ class BleRadio(context: Context) {
     // Nearby Share/Fast Pair), we keep retrying on a backoff until a slot frees.
     private val retryExec = Executors.newSingleThreadScheduledExecutor()
     @Volatile private var advertisePsm = 0
+
+
+    /** Last advertised name seen per address, so the log fires on change only. */
+    private val lastAdvertName = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+    /** Re-issue the advert so a changed [localName] reaches the scan response,
+     *  which is fixed at start time. No-op unless we are actually advertising. */
+    private fun reAdvertiseForName() {
+        if (!stopped && advertiseCallback != null) startAdvertising(advertisePsm)
+    }
     private var advertiseRetries = 0
     // Scanner-retry state: a failed scan (Android throttles ~5 startScan/30s →
     // SCAN_FAILED_SCANNING_TOO_FREQUENTLY) used to be logged and abandoned, which
@@ -155,6 +165,13 @@ class BleRadio(context: Context) {
         // (screen off / app switch), far below the ~5 startScan/30s throttle;
         // if we do trip it, scheduleScanRetry re-arms with the 30s floor.
         if (scanCallback != null) startScanning()
+    }
+
+    init {
+        // There is only ever one radio per process (BleService guards it), and
+        // the app needs a handle on it to push the display name in without
+        // threading a reference through the service's start intents.
+        instance = this
     }
 
     fun bindBridge(handle: Long) {
@@ -326,6 +343,15 @@ class BleRadio(context: Context) {
             }, DIAL_WATCHDOG_MS, TimeUnit.MILLISECONDS)
         }.getOrNull()
 
+    /** `s` as UTF-8, cut to at most [max] bytes on a character boundary. */
+    private fun truncateUtf8(s: String, max: Int): ByteArray {
+        var text = s
+        while (text.toByteArray(Charsets.UTF_8).size > max) {
+            text = text.dropLast(1)
+        }
+        return text.toByteArray(Charsets.UTF_8)
+    }
+
     fun startAdvertising(psm: Int) {
         if (stopped) return
         advertisePsm = psm
@@ -357,11 +383,24 @@ class BleRadio(context: Context) {
             .addServiceUuid(FIPS_PARCEL_UUID)
             .addServiceData(PSM_SD_PARCEL_UUID, psmLe)
             .build()
+        // The chosen name goes in the scan response's own 31 bytes, so the
+        // primary advert above is untouched and the PSM's delivery guarantee is
+        // unchanged. Null when no name has been pushed yet — advertise nothing
+        // rather than an empty string, so a scanner can tell "chose no name"
+        // from "advertised a blank one".
+        val nameBytes = localName?.let { truncateUtf8(it, MAX_NAME_BYTES) }
+        val scanResponse = nameBytes?.let {
+            AdvertiseData.Builder()
+                .setIncludeDeviceName(false)
+                .addServiceData(NAME_SD_PARCEL_UUID, it)
+                .build()
+        }
         val cb = object : AdvertiseCallback() {
             override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
                 advertiseRetries = 0
                 BleHealth.advertiserExhausted = false
-                Log.i(TAG, "advertising PSM $psm (in primary advert)")
+                Log.i(TAG, "advertising PSM $psm (in primary advert)" +
+                    (localName?.let { ", name '$it' (in scan response)" } ?: ""))
                 if (bridgeHandle != 0L) NativeCore.bleDeliverAdvertisingState(bridgeHandle, true)
             }
             override fun onStartFailure(errorCode: Int) {
@@ -377,7 +416,11 @@ class BleRadio(context: Context) {
         }
         advertiseCallback = cb
         try {
-            adv.startAdvertising(settings, advData, cb)
+            if (scanResponse != null) {
+                adv.startAdvertising(settings, advData, scanResponse, cb)
+            } else {
+                adv.startAdvertising(settings, advData, cb)
+            }
         } catch (e: Exception) {
             Log.e(TAG, "startAdvertising failed", e)
             if (bridgeHandle != 0L) NativeCore.bleDeliverAdvertisingState(bridgeHandle, false)
@@ -496,6 +539,23 @@ class BleRadio(context: Context) {
             scanWithPsm.incrementAndGet()
             scanPsmAddrs.add(addr)
             NativeCore.bleDeliverScan(bridgeHandle, addr, psm, result.rssi)
+            // The peer's chosen name, when its scan response reached us. Pushed
+            // separately from the PSM: it is a Myco-layer label with no bearing
+            // on routing, so it never enters the fips bridge. Absent is normal
+            // — a scan response can simply not arrive — and pushing nothing is
+            // how the display layer keeps showing the npub-derived name.
+            result.scanRecord?.getServiceData(NAME_SD_PARCEL_UUID)
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { bytes ->
+                    val advertised = String(bytes, Charsets.UTF_8)
+                    NativeCore.bleDeliverAdvertName(addr, advertised)
+                    // Logged on change only. The push itself fires several
+                    // times a second per peer, but a name that just appeared or
+                    // just changed is the one thing worth seeing in a log.
+                    if (lastAdvertName.put(addr, advertised) != advertised) {
+                        Log.i(TAG, "$addr advertises name '$advertised'")
+                    }
+                }
         } else {
             // Counted, not logged: this fires several times a second per peer
             // while a scan response is outstanding. [logScanSummary] reports
@@ -591,6 +651,7 @@ class BleRadio(context: Context) {
     /** Tear everything down (called when the service stops). */
     fun shutdown() {
         stopped = true
+        if (instance === this) instance = null
         // The radio is being destroyed — on a mesh toggle a fresh one is built
         // in its place, and it must start with no verdict against it. This is
         // the one thing other than a real advert that clears the latch, and it
@@ -876,6 +937,34 @@ class BleRadio(context: Context) {
          *  no head-of-line batching of multiple packets into one giant frame. */
         private const val MESH_MTU_CAP = 1500
 
+        /** The live radio, or null when none is running. Set on construction and
+         *  cleared on [shutdown]. */
+        @Volatile
+        private var instance: BleRadio? = null
+
+        @Volatile
+        private var nameField: String? = null
+
+        /**
+         * The display name this device broadcasts for itself, or null to
+         * broadcast none.
+         *
+         * Process-global rather than per-radio because the app asserts the name
+         * on every resume, which can happen before [BleService] has built a
+         * radio at all — held here, it is simply read by the next advert. Set
+         * while already advertising, it re-issues the advert, since the scan
+         * response is fixed at start time and a rename that waited for the next
+         * radio restart would look broken to whoever just made it.
+         */
+        var localName: String?
+            get() = nameField
+            set(value) {
+                val next = value?.trim()?.ifBlank { null }
+                if (next == nameField) return
+                nameField = next
+                instance?.reAdvertiseForName()
+            }
+
         /** FIPS service UUID — must match fips-core. */
         val FIPS_UUID: UUID = UUID.fromString("9c90b790-2cc5-42c0-9f87-c9cc40648f4c")
         val FIPS_PARCEL_UUID = ParcelUuid(FIPS_UUID)
@@ -885,6 +974,18 @@ class BleRadio(context: Context) {
          *  Bluetooth base UUID). A 16-bit key keeps PSM service-data + the full
          *  128-bit FIPS UUID inside one 31-byte legacy advert. */
         val PSM_SD_PARCEL_UUID = ParcelUuid.fromString("00009c90-0000-1000-8000-00805f9b34fb")
+
+        /** Compact 16-bit service-data UUID carrying this device's chosen display
+         *  name in the SCAN RESPONSE (0x9C91 — the PSM key's neighbour). It rides
+         *  the scan response precisely because the PSM must not: a scan response
+         *  needs an active-scan round-trip that drops asymmetrically, which is
+         *  fatal for the PSM but merely cosmetic for a name. A name that never
+         *  arrives just leaves the peer showing its npub-derived one. */
+        val NAME_SD_PARCEL_UUID = ParcelUuid.fromString("00009c91-0000-1000-8000-00805f9b34fb")
+
+        /** Longest name that fits the 31-byte scan response beside its 4-byte
+         *  service-data header. Cut on a UTF-8 boundary, never mid-character. */
+        private const val MAX_NAME_BYTES = 27
     }
 }
 

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -109,6 +109,10 @@ data class PeerDiagnostic(
      *  The age from this is the session's, not the current FMP index's — the
      *  index rotates on every rekey (~120s) while the session survives. */
     val authenticatedAtMs: Long = 0L,
+    /** Smoothed round-trip time over this peer's link in milliseconds, as MMP
+     *  measured it; null when the link has never been timed (renders as an
+     *  em-dash, never "0ms"). */
+    val srttMs: Double? = null,
     val rssi: Int?,
     val psm: Int,
     /** "" | "incoming-waiting" | "outbound-waiting" | "paired". */
@@ -360,6 +364,7 @@ data class AppState(
                                 alsoReachableVia = alsoReachableVia,
                                 lastSeenMs = p.optLong("lastSeenMs"),
                                 authenticatedAtMs = p.optLong("authenticatedAtMs"),
+                                srttMs = if (p.isNull("srttMs")) null else p.optDouble("srttMs"),
                                 rssi = if (p.isNull("rssi")) null else p.optInt("rssi"),
                                 psm = p.optInt("psm"),
                                 pairState = p.optString("pairState"),

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -109,6 +109,12 @@ data class PeerDiagnostic(
      *  The age from this is the session's, not the current FMP index's — the
      *  index rotates on every rekey (~120s) while the session survives. */
     val authenticatedAtMs: Long = 0L,
+    /** The name this peer broadcasts for itself in its BLE scan response; empty
+     *  when it advertised none or was not found over BLE.
+     *
+     *  **Unauthenticated** — anyone in radio range can forge it. Ranks below
+     *  every name learned from signed pair traffic, never above. */
+    val advertisedName: String = "",
     /** Smoothed round-trip time over this peer's link in milliseconds, as MMP
      *  measured it; null when the link has never been timed (renders as an
      *  em-dash, never "0ms"). */
@@ -364,6 +370,7 @@ data class AppState(
                                 alsoReachableVia = alsoReachableVia,
                                 lastSeenMs = p.optLong("lastSeenMs"),
                                 authenticatedAtMs = p.optLong("authenticatedAtMs"),
+                                advertisedName = p.optString("advertisedName"),
                                 srttMs = if (p.isNull("srttMs")) null else p.optDouble("srttMs"),
                                 rssi = if (p.isNull("rssi")) null else p.optInt("rssi"),
                                 psm = p.optInt("psm"),

--- a/android/app/src/main/java/app/myco/core/NativeCore.kt
+++ b/android/app/src/main/java/app/myco/core/NativeCore.kt
@@ -55,6 +55,11 @@ internal object NativeCore {
         bridgeHandle: Long, connectId: Long, ok: Boolean, addr: String, sendMtu: Int, recvMtu: Int,
     ): Long
     external fun bleDeliverScan(bridgeHandle: Long, addr: String, psm: Int, rssi: Int)
+
+    /** A peer's self-advertised display name, read from its BLE scan response.
+     *  Takes no bridge handle: the name never enters the fips bridge, it lands
+     *  in Myco's own address-keyed record. Unauthenticated by nature. */
+    external fun bleDeliverAdvertName(addr: String, name: String)
     external fun bleChannelDeliverRecv(bridgeHandle: Long, chId: Long, data: ByteArray, len: Int): Boolean
     external fun bleChannelClosed(bridgeHandle: Long, chId: Long)
 

--- a/android/app/src/main/java/app/myco/share/DeviceName.kt
+++ b/android/app/src/main/java/app/myco/share/DeviceName.kt
@@ -1,46 +1,126 @@
 package app.myco.share
 
+import android.bluetooth.BluetoothManager
 import android.content.Context
+import android.provider.Settings
+import java.security.MessageDigest
 
 /**
- * This device's **memorable name** (colour + name, e.g. "green sammy"). It is
- * auto-generated deterministically from the device npub so the user has something
- * to recognise — and editable, persisted locally. The name only ever rides inside
- * `myco://pair` payloads and outgoing pair requests (the receiver shows it before
- * accepting), so a client-side override is the whole story; the core doesn't store
- * our own name.
+ * This device's **memorable name** — what nearby devices see when you pair.
+ *
+ * Three sources, in falling order of "would a person recognise this":
+ *
+ *  1. the user's own override, if they typed one;
+ *  2. the phone's own name (Settings ▸ About phone ▸ Device name) — the name
+ *     they already gave this handset, and the one it announces over Bluetooth
+ *     and Cast, so it is the name they expect to see;
+ *  3. a colour+name pair derived from the device npub, deterministic so the
+ *     same npub always reads the same on every screen that shows it.
+ *
+ * The name only ever rides inside `myco://pair` payloads and outgoing pair
+ * requests (the receiver shows it before accepting), so a client-side override
+ * is the whole story; the core doesn't store our own name.
+ *
+ * The phone name defaulting ahead of the generated one is a deliberate trade:
+ * it is far more recognisable across a table, but it often carries a real name
+ * ("Arjen's S21"), so [suggestions] always offers the pseudonymous generated
+ * name as a one-tap alternative rather than burying it behind typing.
  */
 object DeviceName {
     private const val PREFS = "myco_prefs"
     private const val KEY = "device_name"
 
+    /** Longest name we'll accept or emit — matches the editor's input cap. */
+    const val MAX_LENGTH = 40
+
     // Kept short and speakable — the name doubles as a say-it-out-loud check.
+    //
+    // 32 × 64 = 2048 combinations. The old 12 × 12 = 144 was the whole reason
+    // duplicates turned up: by the birthday bound a room of 14 devices was
+    // already even money for a collision, and a Circle of 20 was near-certain.
+    // At 2048 the same bet needs ~53 devices.
     private val COLORS = listOf(
         "green", "blue", "amber", "violet", "teal", "coral",
         "indigo", "rose", "olive", "cyan", "ruby", "slate",
+        "jade", "plum", "sand", "mint", "rust", "navy",
+        "lilac", "ochre", "moss", "peach", "cobalt", "umber",
+        "saffron", "crimson", "azure", "sage", "copper", "orchid",
+        "pewter", "hazel",
     )
     private val NAMES = listOf(
         "sammy", "james", "rosa", "otto", "lena", "milo",
         "ada", "kai", "nova", "finn", "juno", "remy",
+        "iris", "theo", "mika", "zola", "arlo", "nina",
+        "pablo", "suki", "dara", "elio", "mona", "yuri",
+        "bex", "cleo", "dario", "esme", "fenn", "gia",
+        "hugo", "ines", "jonas", "kira", "luca", "maya",
+        "nils", "orla", "pia", "quinn", "rune", "sana",
+        "tariq", "uma", "vera", "wren", "zane", "bruno",
+        "cora", "dev", "eero", "faye", "gus", "hana",
+        "ivo", "jules", "koa", "lars", "mira", "noor",
+        "oona", "piet", "rafa", "tess",
     )
 
-    /** A deterministic colour+name derived from the npub (same npub → same name). */
+    /**
+     * A deterministic colour+name derived from the npub (same npub → same name).
+     *
+     * Keyed on SHA-256 rather than `String.hashCode()`: the old hash fed one
+     * 32-bit value to both list lookups, so the colour and the name were drawn
+     * from correlated bits of the same number and the pair space was smaller
+     * than 32 × 64 in practice. Separate digest bytes make the two independent.
+     */
     fun generated(ownNpub: String): String {
         if (ownNpub.isEmpty()) return "new device"
-        val h = ownNpub.hashCode().toLong() and 0xffffffffL
-        val color = COLORS[(h % COLORS.size).toInt()]
-        val name = NAMES[((h / COLORS.size) % NAMES.size).toInt()]
-        return "$color $name"
+        val digest = MessageDigest.getInstance("SHA-256").digest(ownNpub.toByteArray())
+        fun byteAt(i: Int) = digest[i].toInt() and 0xff
+        // Two bytes per index so the modulo bias stays far below one part in a
+        // list length, and disjoint bytes so the two picks are independent.
+        val color = ((byteAt(0) shl 8) or byteAt(1)) % COLORS.size
+        val name = ((byteAt(2) shl 8) or byteAt(3)) % NAMES.size
+        return "${COLORS[color]} ${NAMES[name]}"
     }
 
-    /** The user's override if set, otherwise the generated name. */
+    /**
+     * The phone's own name, as the user set it in Settings ▸ About phone.
+     *
+     * `Settings.Global.DEVICE_NAME` is the canonical one and needs no
+     * permission. Some OEM builds leave it unset, so fall back to the Bluetooth
+     * adapter name (the same string on most devices) and then to the legacy
+     * secure setting. Null when none of them has anything usable.
+     */
+    fun phoneName(context: Context): String? {
+        val resolver = context.contentResolver
+        val candidates = sequence {
+            yield(runCatching { Settings.Global.getString(resolver, Settings.Global.DEVICE_NAME) }.getOrNull())
+            // Throws SecurityException on API 31+ until BLUETOOTH_CONNECT is
+            // granted, which on a first run it is not — hence runCatching.
+            yield(
+                runCatching {
+                    context.getSystemService(BluetoothManager::class.java)?.adapter?.name
+                }.getOrNull(),
+            )
+            yield(runCatching { Settings.Secure.getString(resolver, "bluetooth_name") }.getOrNull())
+        }
+        return candidates.firstNotNullOfOrNull { it?.trim()?.take(MAX_LENGTH)?.ifBlank { null } }
+    }
+
+    /** The user's override if set, otherwise the phone's own name, otherwise generated. */
     fun current(context: Context, ownNpub: String): String {
         val override = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString(KEY, "") ?: ""
-        return override.ifBlank { generated(ownNpub) }
+        return override.ifBlank { phoneName(context) ?: generated(ownNpub) }
     }
+
+    /**
+     * The names worth offering as a single tap, best-first and de-duplicated.
+     *
+     * Always at least the generated name, so the pseudonymous option is never
+     * more than one tap away even on a phone whose own name is unreadable.
+     */
+    fun suggestions(context: Context, ownNpub: String): List<String> =
+        listOfNotNull(phoneName(context), generated(ownNpub)).distinct()
 
     fun set(context: Context, name: String) {
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit().putString(KEY, name.trim()).apply()
+            .edit().putString(KEY, name.trim().take(MAX_LENGTH)).apply()
     }
 }

--- a/android/app/src/main/java/app/myco/ui/DeviceNameControl.kt
+++ b/android/app/src/main/java/app/myco/ui/DeviceNameControl.kt
@@ -1,0 +1,42 @@
+package app.myco.ui
+
+import android.content.Context
+import app.myco.ble.BleRadio
+import app.myco.core.AppCoreClient
+import app.myco.core.NativeActions
+import app.myco.share.DeviceName
+
+/**
+ * Change this device's name, everywhere it is published.
+ *
+ * A name lives in three places and all three have to move together:
+ *
+ *  1. the local preference, which every screen reads back;
+ *  2. the core, which stamps it into outgoing pair events;
+ *  3. the BLE radio, which broadcasts it in the scan response so devices that
+ *     have never paired with us can still show it in their Nearby list.
+ *
+ * This exists because the third one kept being forgotten. The rename sites each
+ * did the first two and the radio only picked the change up on the next
+ * `onResume` — so renaming and staying in the app left the old name going out
+ * over the air, which is precisely the surface a rename is usually aimed at.
+ *
+ * Passing a blank name clears the override, and the name falls back to the
+ * phone's own or the generated one; the resolved value is what gets published
+ * and is returned.
+ */
+fun applyDeviceName(
+    context: Context,
+    client: AppCoreClient,
+    ownNpub: String,
+    name: String,
+): String {
+    DeviceName.set(context, name)
+    val resolved = DeviceName.current(context, ownNpub)
+    client.dispatch(NativeActions.setDeviceName(resolved))
+    BleRadio.localName = resolved
+    // Harmless to re-assert, and it is what the advertised name is keyed on —
+    // a radio that came up before the identity was ready has none yet.
+    BleRadio.localNodeAddrHex = client.state().nodeAddrHex
+    return resolved
+}

--- a/android/app/src/main/java/app/myco/ui/FirstRunNameDialog.kt
+++ b/android/app/src/main/java/app/myco/ui/FirstRunNameDialog.kt
@@ -1,0 +1,71 @@
+package app.myco.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import app.myco.share.DeviceName
+
+/**
+ * The one thing first run asks: what nearby devices should call you.
+ *
+ * It exists because the default is now this handset's own name, which is
+ * usually the most recognisable option and quite often carries a real one
+ * ("Arjen's S21"). Taking that silently would publish it to everyone you pair
+ * with before you knew it was the name being sent. Showing it once, with the
+ * pseudonymous generated name one tap away, is the whole point.
+ *
+ * Not dismissable by tapping outside: it is one decision on one screen, and a
+ * stray tap that skipped it would leave the real name in place by accident —
+ * exactly the outcome this is here to prevent.
+ */
+@Composable
+fun FirstRunNameDialog(ownNpub: String, onDone: (String) -> Unit) {
+    val context = LocalContext.current
+    val suggestions = remember(ownNpub) { DeviceName.suggestions(context, ownNpub) }
+    var name by remember(ownNpub) { mutableStateOf(suggestions.firstOrNull().orEmpty()) }
+
+    AlertDialog(
+        onDismissRequest = {},
+        title = { Text("What should people call you?") },
+        text = {
+            Column {
+                Text(
+                    "Nearby devices see this name when you pair, so they can tell it's " +
+                        "you. Your phone's own name is filled in — tap the other one if " +
+                        "you'd rather not share it, or type anything you like.",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(Modifier.height(14.dp))
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it.take(DeviceName.MAX_LENGTH) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(10.dp))
+                NameSuggestions(ownNpub, name) { name = it }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = name.isNotBlank(),
+                onClick = { onDone(name.trim()) },
+            ) { Text("Continue") }
+        },
+    )
+}

--- a/android/app/src/main/java/app/myco/ui/MeshStatusSheet.kt
+++ b/android/app/src/main/java/app/myco/ui/MeshStatusSheet.kt
@@ -183,7 +183,7 @@ private fun CircleSection(state: AppState, nowMs: Long) {
 private fun CircleLine(state: AppState, member: CircleContact, dot: Color, nowMs: Long) {
     val peer = state.peers.firstOrNull { it.npub == member.npub && it.npub.isNotEmpty() }
     PeerLine(
-        name = member.name.ifEmpty { "a device" },
+        name = peerLabel(state, member.npub),
         transport = peer?.transport.orEmpty(),
         dot = dot,
         peer = peer,
@@ -220,6 +220,7 @@ private fun MeshSection(
     GroupLabel("MESH — ${connected.size} PEER${if (connected.size == 1) "" else "S"}")
     SectionCard {
         LaneBlock(
+            state = state,
             transport = "ble",
             label = "Bluetooth",
             // Tri-state on purpose: the bridge can be absent or the radio never
@@ -239,6 +240,7 @@ private fun MeshSection(
         if (awareSupported) {
             Divider()
             LaneBlock(
+                state = state,
                 transport = "aware",
                 label = "Wi-Fi Aware",
                 scanning = when {
@@ -253,6 +255,7 @@ private fun MeshSection(
         }
         Divider()
         LaneBlock(
+            state = state,
             transport = "udp",
             label = "Network",
             // The routed lane's "scanning" is the mDNS browse that finds fips
@@ -269,6 +272,7 @@ private fun MeshSection(
 /** A lane header — icon, name, scan state — over the peers it is carrying. */
 @Composable
 private fun LaneBlock(
+    state: AppState,
     transport: String,
     label: String,
     scanning: Boolean?,
@@ -314,7 +318,15 @@ private fun LaneBlock(
         } else {
             peers.forEach { p ->
                 PeerLine(
-                    name = p.name.ifEmpty { p.npub.ifEmpty { p.nodeAddrHex.ifEmpty { p.bleAddr } } },
+                    // `p.name` is fips's own label, which is an abbreviated
+                    // npub rather than anything a person chose — resolve
+                    // through the names we have actually been told first, and
+                    // fall back to an address only for a row with no npub yet.
+                    name = if (p.npub.isNotEmpty()) {
+                        peerLabel(state, p.npub)
+                    } else {
+                        p.nodeAddrHex.ifEmpty { p.bleAddr }
+                    },
                     transport = "",
                     dot = StatusConnected,
                     peer = p,

--- a/android/app/src/main/java/app/myco/ui/MeshStatusSheet.kt
+++ b/android/app/src/main/java/app/myco/ui/MeshStatusSheet.kt
@@ -1,0 +1,353 @@
+package app.myco.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import app.myco.ap.ApRadio
+import app.myco.aware.AwareRadio
+import app.myco.core.AppState
+import app.myco.core.PeerDiagnostic
+import app.myco.ui.theme.StatusAlone
+import app.myco.ui.theme.StatusConnected
+import app.myco.ui.theme.StatusReachable
+import app.myco.ui.theme.StatusThin
+import kotlinx.coroutines.delay
+
+/**
+ * The panel behind the peers pill: what the mesh is actually doing, right now.
+ *
+ * Two questions, in the order they get asked. **Circle** answers "can I reach
+ * my people" — the reason the mesh exists. **Mesh** answers "why not" — one
+ * block per radio lane, each saying whether that lane is looking for anyone and
+ * which peers it is currently carrying.
+ *
+ * Every number here is observed, never inferred: a lane whose scan state the
+ * app could not read says "unknown" rather than "idle", and a link MMP has
+ * never timed shows no ping rather than `0ms`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MeshStatusSheet(state: AppState, meshEnabled: Boolean, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val apWifi by ApRadio.wifi.collectAsState()
+    val awareSupported = remember { AwareRadio.isSupported(context) }
+
+    // The shell's poll replaces `state` once a second, but two equal snapshots
+    // don't recompose — and the ages on this panel are derived from the wall
+    // clock, not from the snapshot, so they would freeze on a quiet mesh. This
+    // ticker is what keeps "seen 4s" counting while nothing else changes.
+    var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            nowMs = System.currentTimeMillis()
+            delay(1000)
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(start = 20.dp, end = 20.dp, bottom = 28.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            if (!meshEnabled) {
+                Text(
+                    "Mesh is off — no radio is scanning and no peer can reach you.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(bottom = 6.dp),
+                )
+            }
+
+            CircleSection(state, nowMs)
+            Spacer(Modifier.height(10.dp))
+            MeshSection(state, meshEnabled, awareSupported, apWifi.browsing, apWifi.connected, nowMs)
+        }
+    }
+}
+
+// ----- Circle -----
+
+/** Who you're paired with, and whether the mesh can reach them right now. */
+@Composable
+private fun CircleSection(state: AppState, nowMs: Long) {
+    val reachable = state.circle.count { it.npub in state.reachableNpubs }
+    GroupLabel("CIRCLE — $reachable/${state.circle.size} REACHABLE")
+    if (state.circle.isEmpty()) {
+        Hint("Nobody paired yet. Pair a device from the Circle tab.")
+        return
+    }
+    SectionCard {
+        state.circle.forEachIndexed { i, member ->
+            if (i > 0) Divider()
+            // Reachability is the Circle's own fact (a live mesh relay at any
+            // hop count); the peer row, when there is one, is what supplies the
+            // link numbers. A member reachable over several hops has no direct
+            // peer row at all, and that is not a fault.
+            val peer = state.peers.firstOrNull { it.npub == member.npub && it.npub.isNotEmpty() }
+            PeerLine(
+                name = member.name.ifEmpty { "a device" },
+                transport = peer?.transport.orEmpty(),
+                dot = if (member.npub in state.reachableNpubs) StatusReachable else StatusAlone,
+                status = if (member.npub in state.reachableNpubs) "reachable" else "offline",
+                peer = peer,
+                nowMs = nowMs,
+            )
+        }
+    }
+}
+
+// ----- Mesh -----
+
+/**
+ * One block per radio lane. The lane header carries its scan state, so "nobody
+ * is here" and "we are not looking" are never the same line.
+ */
+@Composable
+private fun MeshSection(
+    state: AppState,
+    meshEnabled: Boolean,
+    awareSupported: Boolean,
+    lanBrowsing: Boolean,
+    wifiConnected: Boolean,
+    nowMs: Long,
+) {
+    val connected = state.peers.filter { it.state == "connected" }
+    GroupLabel("MESH — ${connected.size} PEER${if (connected.size == 1) "" else "S"}")
+    SectionCard {
+        LaneBlock(
+            transport = "ble",
+            label = "Bluetooth",
+            // Tri-state on purpose: the bridge can be absent or the radio never
+            // started, and that is "unknown", not a confident "idle".
+            scanning = when {
+                !meshEnabled || !state.bleEnabled -> false
+                state.bleScanningKnown -> state.bleScanning
+                else -> null
+            },
+            off = !meshEnabled || !state.bleEnabled,
+            peers = connected.filter { it.transport == "ble" },
+            nowMs = nowMs,
+        )
+        Divider()
+        LaneBlock(
+            transport = "aware",
+            label = "Wi-Fi Aware",
+            scanning = when {
+                !meshEnabled || !state.wifiAwareEnabled -> false
+                state.wifiAwareScanningKnown -> state.wifiAwareScanning
+                else -> null
+            },
+            off = !meshEnabled || !state.wifiAwareEnabled || !awareSupported,
+            offLabel = if (!awareSupported) "unsupported" else "off",
+            peers = connected.filter { it.transport == "aware" },
+            nowMs = nowMs,
+        )
+        Divider()
+        LaneBlock(
+            transport = "udp",
+            label = "Network",
+            // The routed lane's "scanning" is the mDNS browse that finds fips
+            // nodes on the LAN or the !FIPS AP.
+            scanning = if (!meshEnabled) false else lanBrowsing,
+            off = !meshEnabled || !wifiConnected,
+            offLabel = if (!wifiConnected) "no wi-fi" else "off",
+            peers = connected.filter { it.transport !in setOf("ble", "aware", "") },
+            nowMs = nowMs,
+        )
+    }
+}
+
+/** A lane header — icon, name, scan state — over the peers it is carrying. */
+@Composable
+private fun LaneBlock(
+    transport: String,
+    label: String,
+    scanning: Boolean?,
+    off: Boolean,
+    peers: List<PeerDiagnostic>,
+    nowMs: Long,
+    offLabel: String = "off",
+) {
+    val (word, color) = when {
+        off -> offLabel to MaterialTheme.colorScheme.onSurfaceVariant
+        scanning == null -> "unknown" to MaterialTheme.colorScheme.onSurfaceVariant
+        scanning -> "scanning" to StatusConnected
+        else -> "idle" to StatusThin
+    }
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                TransportIcon(transport, size = 22)
+                Text(label, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                StatusDot(color, size = 7)
+                Text(word, style = MaterialTheme.typography.labelMedium, color = color)
+            }
+        }
+        if (peers.isEmpty()) {
+            Text(
+                "no peers on this lane",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 44.dp, top = 4.dp),
+            )
+        } else {
+            peers.forEach { p ->
+                PeerLine(
+                    name = p.name.ifEmpty { p.npub.ifEmpty { p.nodeAddrHex.ifEmpty { p.bleAddr } } },
+                    transport = "",
+                    dot = StatusConnected,
+                    status = null,
+                    peer = p,
+                    nowMs = nowMs,
+                    indent = 44,
+                )
+            }
+        }
+    }
+}
+
+// ----- one peer, two lines -----
+
+/**
+ * A peer as this panel states it: who, then the three link numbers.
+ *
+ * `peer` being null (a Circle member reachable over relay with no direct row)
+ * collapses to the identity line alone — the numbers are link facts and there
+ * is no link to state them about.
+ */
+@Composable
+private fun PeerLine(
+    name: String,
+    transport: String,
+    dot: Color,
+    status: String?,
+    peer: PeerDiagnostic?,
+    nowMs: Long,
+    indent: Int = 14,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(start = indent.dp, end = 14.dp, top = 6.dp, bottom = 6.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.weight(1f, fill = false),
+            ) {
+                StatusDot(dot, size = 8)
+                if (transport.isNotEmpty()) TransportIcon(transport, size = 18)
+                Text(shortLabel(name), style = MaterialTheme.typography.bodyMedium)
+            }
+            if (status != null) {
+                Text(
+                    status,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        if (peer != null) {
+            Text(
+                "ping ${ping(peer.srttMs)} · up ${age(peer.authenticatedAtMs, nowMs)} · seen ${seen(peer.lastSeenMs, nowMs)}",
+                style = MaterialTheme.typography.labelMedium.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 16.dp, top = 2.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun Divider() {
+    HorizontalDivider(
+        color = MaterialTheme.colorScheme.outline,
+        modifier = Modifier.padding(horizontal = 14.dp),
+    )
+}
+
+@Composable
+private fun Hint(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 4.dp, top = 2.dp),
+    )
+}
+
+/** MMP's smoothed RTT. Never "0ms" for a link that was simply never timed. */
+private fun ping(srttMs: Double?): String =
+    srttMs?.let { if (it < 10) "%.1fms".format(it) else "%.0fms".format(it) } ?: "—"
+
+/** How long the FMP session has held. `0` means there is none — an em-dash. */
+private fun age(sinceMs: Long, nowMs: Long): String =
+    if (sinceMs <= 0L) "—" else duration((nowMs - sinceMs).coerceAtLeast(0L) / 1000)
+
+/**
+ * Last heard. Anything under ten seconds is "now": the exact second only
+ * matters once a link has gone quiet long enough to worry about, and a counter
+ * flickering 1s/2s/3s reads as a problem when it is the healthy case.
+ */
+private fun seen(lastSeenMs: Long, nowMs: Long): String {
+    if (lastSeenMs <= 0L) return "—"
+    val secs = (nowMs - lastSeenMs).coerceAtLeast(0L) / 1000
+    return if (secs < 10) "now" else duration(secs)
+}
+
+private fun duration(secs: Long): String = when {
+    secs < 60 -> "${secs}s"
+    secs < 3600 -> "${secs / 60}m"
+    else -> "${secs / 3600}h"
+}
+
+/** Trim an npub/hex fallback to something that fits one line. */
+private fun shortLabel(s: String): String =
+    if (s.length > 18) "${s.take(10)}…${s.takeLast(4)}" else s

--- a/android/app/src/main/java/app/myco/ui/MeshStatusSheet.kt
+++ b/android/app/src/main/java/app/myco/ui/MeshStatusSheet.kt
@@ -1,5 +1,6 @@
 package app.myco.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,6 +24,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import app.myco.ap.ApRadio
 import app.myco.aware.AwareRadio
 import app.myco.core.AppState
+import app.myco.core.CircleContact
 import app.myco.core.PeerDiagnostic
 import app.myco.ui.theme.StatusAlone
 import app.myco.ui.theme.StatusConnected
@@ -101,33 +104,101 @@ fun MeshStatusSheet(state: AppState, meshEnabled: Boolean, onDismiss: () -> Unit
 
 // ----- Circle -----
 
-/** Who you're paired with, and whether the mesh can reach them right now. */
+/**
+ * Who you're paired with, online first.
+ *
+ * Ordering is reachable-then-name, never last-heard: a Circle of five phones in
+ * one room re-ranks on every poll if the order carries any live measurement,
+ * and a list that reshuffles under your thumb is unreadable. Two buckets and an
+ * alphabetical sort inside each is stable for as long as reachability is.
+ *
+ * Nothing spells out "reachable" or "offline" — the dot's colour is the whole
+ * status, and repeating it in words on every row was noise. Offline members
+ * collapse behind one line, because the answer they give ("still paired, not
+ * here") is the same for all of them and does not need five rows.
+ */
 @Composable
 private fun CircleSection(state: AppState, nowMs: Long) {
-    val reachable = state.circle.count { it.npub in state.reachableNpubs }
-    GroupLabel("CIRCLE — $reachable/${state.circle.size} REACHABLE")
+    val (online, offline) = state.circle
+        .sortedBy { it.name.ifEmpty { it.npub }.lowercase() }
+        .partition { it.npub in state.reachableNpubs }
+    GroupLabel("CIRCLE — ${online.size}/${state.circle.size} REACHABLE")
     if (state.circle.isEmpty()) {
         Hint("Nobody paired yet. Pair a device from the Circle tab.")
         return
     }
+    // Survives the 1Hz tick — this is a list you open and then read.
+    var showOffline by rememberSaveable { mutableStateOf(false) }
     SectionCard {
-        state.circle.forEachIndexed { i, member ->
+        online.forEachIndexed { i, member ->
             if (i > 0) Divider()
-            // Reachability is the Circle's own fact (a live mesh relay at any
-            // hop count); the peer row, when there is one, is what supplies the
-            // link numbers. A member reachable over several hops has no direct
-            // peer row at all, and that is not a fault.
-            val peer = state.peers.firstOrNull { it.npub == member.npub && it.npub.isNotEmpty() }
-            PeerLine(
-                name = member.name.ifEmpty { "a device" },
-                transport = peer?.transport.orEmpty(),
-                dot = if (member.npub in state.reachableNpubs) StatusReachable else StatusAlone,
-                status = if (member.npub in state.reachableNpubs) "reachable" else "offline",
-                peer = peer,
-                nowMs = nowMs,
+            CircleLine(state, member, StatusReachable, nowMs)
+        }
+        if (offline.isEmpty()) {
+            if (online.isEmpty()) EmptyRow("nobody reachable right now")
+            return@SectionCard
+        }
+        if (online.isNotEmpty()) Divider()
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { showOffline = !showOffline }
+                .padding(start = 14.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                StatusDot(StatusAlone, size = 8)
+                Text(
+                    "${offline.size} offline",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                if (showOffline) "\u2303" else "\u2304",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
             )
         }
+        if (showOffline) {
+            offline.forEach { member ->
+                Divider()
+                CircleLine(state, member, StatusAlone, nowMs)
+            }
+        }
     }
+}
+
+/**
+ * One Circle member. Reachability is the Circle's own fact (a live mesh relay
+ * at any hop count); the peer row, when there is one, supplies the link
+ * numbers. A member reachable over several hops has no direct peer row at all,
+ * and that is not a fault — the row simply carries no numbers.
+ */
+@Composable
+private fun CircleLine(state: AppState, member: CircleContact, dot: Color, nowMs: Long) {
+    val peer = state.peers.firstOrNull { it.npub == member.npub && it.npub.isNotEmpty() }
+    PeerLine(
+        name = member.name.ifEmpty { "a device" },
+        transport = peer?.transport.orEmpty(),
+        dot = dot,
+        peer = peer,
+        nowMs = nowMs,
+    )
+}
+
+@Composable
+private fun EmptyRow(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 14.dp, top = 8.dp, bottom = 8.dp),
+    )
 }
 
 // ----- Mesh -----
@@ -162,20 +233,24 @@ private fun MeshSection(
             peers = connected.filter { it.transport == "ble" },
             nowMs = nowMs,
         )
-        Divider()
-        LaneBlock(
-            transport = "aware",
-            label = "Wi-Fi Aware",
-            scanning = when {
-                !meshEnabled || !state.wifiAwareEnabled -> false
-                state.wifiAwareScanningKnown -> state.wifiAwareScanning
-                else -> null
-            },
-            off = !meshEnabled || !state.wifiAwareEnabled || !awareSupported,
-            offLabel = if (!awareSupported) "unsupported" else "off",
-            peers = connected.filter { it.transport == "aware" },
-            nowMs = nowMs,
-        )
+        // A radio this phone does not have is not a lane you can act on, so it
+        // gets no row at all — an "unsupported" line is a permanent dead entry
+        // on every device that lacks Aware, which is most of them.
+        if (awareSupported) {
+            Divider()
+            LaneBlock(
+                transport = "aware",
+                label = "Wi-Fi Aware",
+                scanning = when {
+                    !meshEnabled || !state.wifiAwareEnabled -> false
+                    state.wifiAwareScanningKnown -> state.wifiAwareScanning
+                    else -> null
+                },
+                off = !meshEnabled || !state.wifiAwareEnabled,
+                peers = connected.filter { it.transport == "aware" },
+                nowMs = nowMs,
+            )
+        }
         Divider()
         LaneBlock(
             transport = "udp",
@@ -231,7 +306,7 @@ private fun LaneBlock(
         }
         if (peers.isEmpty()) {
             Text(
-                "no peers on this lane",
+                "no peers",
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(start = 44.dp, top = 4.dp),
@@ -242,7 +317,6 @@ private fun LaneBlock(
                     name = p.name.ifEmpty { p.npub.ifEmpty { p.nodeAddrHex.ifEmpty { p.bleAddr } } },
                     transport = "",
                     dot = StatusConnected,
-                    status = null,
                     peer = p,
                     nowMs = nowMs,
                     indent = 44,
@@ -257,6 +331,9 @@ private fun LaneBlock(
 /**
  * A peer as this panel states it: who, then the three link numbers.
  *
+ * The dot is the status — there is no status word. Green/teal/red across a
+ * short list reads faster than the same three labels repeated down it.
+ *
  * `peer` being null (a Circle member reachable over relay with no direct row)
  * collapses to the identity line alone — the numbers are link facts and there
  * is no link to state them about.
@@ -266,33 +343,18 @@ private fun PeerLine(
     name: String,
     transport: String,
     dot: Color,
-    status: String?,
     peer: PeerDiagnostic?,
     nowMs: Long,
     indent: Int = 14,
 ) {
     Column(modifier = Modifier.fillMaxWidth().padding(start = indent.dp, end = 14.dp, top = 6.dp, bottom = 6.dp)) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.weight(1f, fill = false),
-            ) {
-                StatusDot(dot, size = 8)
-                if (transport.isNotEmpty()) TransportIcon(transport, size = 18)
-                Text(shortLabel(name), style = MaterialTheme.typography.bodyMedium)
-            }
-            if (status != null) {
-                Text(
-                    status,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            StatusDot(dot, size = 8)
+            if (transport.isNotEmpty()) TransportIcon(transport, size = 18)
+            Text(shortLabel(name), style = MaterialTheme.typography.bodyMedium)
         }
         if (peer != null) {
             Text(

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -27,6 +28,7 @@ import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material.icons.filled.TravelExplore
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -354,6 +356,12 @@ val LocalMeshControl = androidx.compose.runtime.compositionLocalOf { MeshControl
 /**
  * The status pill shown top-right on every screen. Three segments:
  * mesh on/off toggle · Circle reachable/total · live peer count.
+ *
+ * Tapping anywhere but the switch opens [MeshStatusSheet] — the pill is a
+ * summary, and the summary is only useful if the thing it summarises is one
+ * tap away. With the mesh off the whole pill goes red rather than merely
+ * showing an unchecked switch: "off" is a state worth noticing from across the
+ * room, and a grey slider is not.
  */
 @Composable
 fun PeersPill(state: AppState) {
@@ -364,52 +372,86 @@ fun PeersPill(state: AppState) {
     // counting only direct peers showed 0 while sync was working fine.
     val reachable = state.reachableNpubs.size
     val circle = state.circle.size
+    var sheetOpen by remember { mutableStateOf(false) }
+
+    if (sheetOpen) {
+        MeshStatusSheet(state, meshEnabled = mesh.enabled, onDismiss = { sheetOpen = false })
+    }
+
     Surface(
         shape = CircleShape,
-        color = MaterialTheme.colorScheme.primaryContainer,
-        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        color = if (mesh.enabled) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.errorContainer
+        },
+        contentColor = if (mesh.enabled) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.onErrorContainer
+        },
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(start = 6.dp, end = 4.dp),
         ) {
             // 1 — mesh master switch: the same slider as the Settings rows,
-            // scaled down to pill height (the Box bounds its layout footprint;
-            // the scale is a draw transform).
+            // scaled down to pill height. The Box is the touch target, not the
+            // drawn slider (the scale is a draw transform only), so it is sized
+            // to Material's 48dp minimum — the old 36×20 box was the whole
+            // reason this was fiddly to hit.
             Box(
-                modifier = Modifier.size(width = 36.dp, height = 20.dp),
+                modifier = Modifier.size(width = 52.dp, height = 48.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 androidx.compose.material3.Switch(
                     checked = mesh.enabled,
                     onCheckedChange = { mesh.toggle(it) },
-                    modifier = Modifier.scale(0.6f),
+                    modifier = Modifier.scale(0.75f),
+                    colors = androidx.compose.material3.SwitchDefaults.colors(
+                        // Off is a fault state here, not a neutral one.
+                        uncheckedTrackColor = MaterialTheme.colorScheme.error,
+                        uncheckedBorderColor = MaterialTheme.colorScheme.error,
+                        uncheckedThumbColor = MaterialTheme.colorScheme.onError,
+                    ),
                 )
             }
-            PillDivider()
-            // 2 — Circle: reachable now / total paired.
-            Icon(
-                Icons.Filled.People,
-                contentDescription = "Circle reachable / total",
-                modifier = Modifier.size(16.dp),
-            )
-            Text(
-                "$reachable/$circle",
-                fontWeight = FontWeight.SemiBold,
-                style = MaterialTheme.typography.labelLarge,
-            )
-            PillDivider()
-            // 3 — live mesh peers, coloured by how much mesh you actually have:
-            // none is a fault (and pulses, since it is the one state you want
-            // noticed from across the room), one works but has no redundancy,
-            // two or more is healthy.
-            PeerCountDot(connected)
-            Text(
-                "$connected",
-                fontWeight = FontWeight.SemiBold,
-                style = MaterialTheme.typography.labelLarge,
-            )
+            // 2/3 — the counts, and the whole of them is the panel affordance.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(7.dp),
+                modifier = Modifier
+                    .clickable(
+                        onClick = { sheetOpen = true },
+                        onClickLabel = "Show mesh and circle status",
+                    )
+                    .padding(start = 2.dp, end = 10.dp, top = 10.dp, bottom = 10.dp),
+            ) {
+                PillDivider()
+                // Circle: reachable now / total paired.
+                Icon(
+                    Icons.Filled.People,
+                    contentDescription = "Circle reachable / total",
+                    modifier = Modifier.size(18.dp),
+                )
+                Text(
+                    "$reachable/$circle",
+                    fontWeight = FontWeight.SemiBold,
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                PillDivider()
+                // Live mesh peers, coloured by how much mesh you actually have:
+                // none is a fault (and pulses, since it is the one state you
+                // want noticed from across the room), one works but has no
+                // redundancy, two or more is healthy.
+                PeerCountDot(connected)
+                Text(
+                    "$connected",
+                    fontWeight = FontWeight.SemiBold,
+                    style = MaterialTheme.typography.titleSmall,
+                )
+            }
         }
     }
 }
@@ -418,9 +460,8 @@ fun PeersPill(state: AppState) {
 private fun PillDivider() {
     Box(
         Modifier
-            .padding(start = 2.dp)
-            .size(width = 1.dp, height = 14.dp)
-            .background(MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.25f)),
+            .size(width = 1.dp, height = 16.dp)
+            .background(LocalContentColor.current.copy(alpha = 0.25f)),
     )
 }
 

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -8,6 +8,8 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,6 +48,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -397,17 +400,33 @@ fun PeersPill(state: AppState) {
             modifier = Modifier.padding(start = 6.dp, end = 4.dp),
         ) {
             // 1 — mesh master switch: the same slider as the Settings rows,
-            // scaled down to pill height. The Box is the touch target, not the
-            // drawn slider (the scale is a draw transform only), so it is sized
-            // to Material's 48dp minimum — the old 36×20 box was the whole
-            // reason this was fiddly to hit.
+            // scaled down to pill height.
+            //
+            // The whole left block toggles, not the slider. Sizing the Box was
+            // not enough on its own: the Switch keeps its own hit rect and
+            // swallows everything inside it, so taps landing in the Box but
+            // beside the slider did nothing — which is what made this fiddly.
+            // Handing the click to the Box and passing the Switch a null
+            // onCheckedChange makes the slider a pure indicator and the entire
+            // 72×48 block the target. `scale` is a draw transform only, so the
+            // slider stays small while the target does not.
             Box(
-                modifier = Modifier.size(width = 52.dp, height = 48.dp),
+                modifier = Modifier
+                    .size(width = 72.dp, height = 48.dp)
+                    .toggleable(
+                        value = mesh.enabled,
+                        onValueChange = { mesh.toggle(it) },
+                        role = Role.Switch,
+                        // No ripple: a bounded indication on a block wider than
+                        // the thing it draws reads as a misaligned button.
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                    ),
                 contentAlignment = Alignment.Center,
             ) {
                 androidx.compose.material3.Switch(
                     checked = mesh.enabled,
-                    onCheckedChange = { mesh.toggle(it) },
+                    onCheckedChange = null,
                     modifier = Modifier.scale(0.75f),
                     colors = androidx.compose.material3.SwitchDefaults.colors(
                         // Off is a fault state here, not a neutral one.

--- a/android/app/src/main/java/app/myco/ui/NameSuggestions.kt
+++ b/android/app/src/main/java/app/myco/ui/NameSuggestions.kt
@@ -1,0 +1,48 @@
+package app.myco.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import app.myco.share.DeviceName
+
+/**
+ * The one-tap name choices: this phone's own name, and the pseudonymous
+ * generated one.
+ *
+ * Both are chips rather than a "reset" button, because neither is a fallback —
+ * they are two genuinely different answers to "what should people see". A phone
+ * name is recognisable across a table and usually carries a real name; the
+ * generated one is speakable and gives nothing away. Making the second option
+ * cost a tap instead of typing is the whole point of this row.
+ *
+ * The chip matching the current value shows as selected, so the row also
+ * answers "which one am I on".
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun NameSuggestions(ownNpub: String, current: String, onPick: (String) -> Unit) {
+    val context = LocalContext.current
+    val suggestions = DeviceName.suggestions(context, ownNpub)
+    if (suggestions.isEmpty()) return
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        suggestions.forEach { suggestion ->
+            FilterChip(
+                selected = suggestion.equals(current.trim(), ignoreCase = true),
+                onClick = { onPick(suggestion) },
+                label = { Text(suggestion, style = MaterialTheme.typography.labelLarge) },
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/app/myco/ui/PeerLabel.kt
+++ b/android/app/src/main/java/app/myco/ui/PeerLabel.kt
@@ -13,16 +13,21 @@ import app.myco.share.DeviceName
  * Those are checked in that order — most recently confirmed first — and the
  * npub-derived name is the floor, not the default.
  *
- * The floor still matters. A peer we are merely connected to and have never
- * exchanged pair traffic with has told us nothing but an npub: the BLE advert
- * is 27 of its 31 bytes already, and fips's own `display_name` is a local
- * alias, not something the far side sends. For those the generated name is all
- * there is, and it is at least the same two words on both screens.
+ * Below those sits the name a peer broadcasts for itself in its BLE scan
+ * response. It is deliberately last-but-one: it is an unauthenticated plaintext
+ * broadcast that anyone in range can forge, so it may fill a gap but must never
+ * displace a name that arrived signed. It is also BLE-only — a peer found over
+ * Wi-Fi Aware or the LAN carries none.
+ *
+ * The npub-derived name remains the floor, for a peer that has told us nothing
+ * at all. It is at least the same two words on both screens.
  */
 fun peerLabel(state: AppState, npub: String): String {
     if (npub.isEmpty()) return DeviceName.generated(npub)
     val told = state.circle.firstOrNull { it.npub == npub }?.name
         ?: state.pendingPairRequests.firstOrNull { it.npub == npub }?.name
         ?: state.outboundPairs.firstOrNull { it.npub == npub }?.name
-    return told?.trim()?.ifBlank { null } ?: DeviceName.generated(npub)
+    told?.trim()?.ifBlank { null }?.let { return it }
+    val advertised = state.peers.firstOrNull { it.npub == npub }?.advertisedName
+    return advertised?.trim()?.ifBlank { null } ?: DeviceName.generated(npub)
 }

--- a/android/app/src/main/java/app/myco/ui/PeerLabel.kt
+++ b/android/app/src/main/java/app/myco/ui/PeerLabel.kt
@@ -1,0 +1,28 @@
+package app.myco.ui
+
+import app.myco.core.AppState
+import app.myco.share.DeviceName
+
+/**
+ * What to call a peer on screen — the name *they* chose, whenever we have
+ * actually been told it.
+ *
+ * A device's chosen name reaches us only inside pair traffic: the Circle entry
+ * written when pairing completed, the pending request they sent us, or the
+ * invite we sent them (which echoes the name they were showing at the time).
+ * Those are checked in that order — most recently confirmed first — and the
+ * npub-derived name is the floor, not the default.
+ *
+ * The floor still matters. A peer we are merely connected to and have never
+ * exchanged pair traffic with has told us nothing but an npub: the BLE advert
+ * is 27 of its 31 bytes already, and fips's own `display_name` is a local
+ * alias, not something the far side sends. For those the generated name is all
+ * there is, and it is at least the same two words on both screens.
+ */
+fun peerLabel(state: AppState, npub: String): String {
+    if (npub.isEmpty()) return DeviceName.generated(npub)
+    val told = state.circle.firstOrNull { it.npub == npub }?.name
+        ?: state.pendingPairRequests.firstOrNull { it.npub == npub }?.name
+        ?: state.outboundPairs.firstOrNull { it.npub == npub }?.name
+    return told?.trim()?.ifBlank { null } ?: DeviceName.generated(npub)
+}

--- a/android/app/src/main/java/app/myco/ui/TransportIcons.kt
+++ b/android/app/src/main/java/app/myco/ui/TransportIcons.kt
@@ -1,0 +1,52 @@
+package app.myco.ui
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import app.myco.R
+import app.myco.ui.theme.TransportBluetooth
+import app.myco.ui.theme.TransportNetwork
+
+/**
+ * The transport a peer is reachable over, as an icon.
+ *
+ * Three lanes, three glyphs: the Bluetooth rune, the Wi-Fi Aware arcs, and a
+ * globe for anything routed (LAN, the `!FIPS` AP, mDNS). An unknown or absent
+ * transport draws nothing rather than guessing — a peer with no resolved link
+ * is a real state and a wrong icon would assert a link that does not exist.
+ *
+ * Bluetooth keeps its brand blue and the routed lane the app's emerald;
+ * Aware follows `onSurface`, so it reads as the plain radio in either theme.
+ *
+ * Shared between the Dev tab's peer list and the status panel behind the peers
+ * pill, so "which of these is on Bluetooth" is the same glyph in both places.
+ */
+@Composable
+fun TransportIcon(transport: String, modifier: Modifier = Modifier, size: Int = 26) {
+    val (res, tint, label) = when (transport) {
+        "ble" -> Triple(R.drawable.ic_transport_bluetooth, TransportBluetooth, "Bluetooth")
+        "aware" -> Triple(
+            R.drawable.ic_transport_wifi_aware,
+            MaterialTheme.colorScheme.onSurface,
+            "Wi-Fi Aware",
+        )
+        "" -> Triple(0, MaterialTheme.colorScheme.onSurfaceVariant, "")
+        // udp, tcp and anything else routed: it reached us over IP.
+        else -> Triple(R.drawable.ic_transport_network, TransportNetwork, "Network")
+    }
+    if (res == 0) {
+        Spacer(modifier.size(size.dp))
+        return
+    }
+    Icon(
+        painter = painterResource(res),
+        contentDescription = label,
+        tint = tint,
+        modifier = modifier.size(size.dp),
+    )
+}

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -74,6 +74,7 @@ import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
 import app.myco.share.NsiteShare
 import app.myco.ui.NameSuggestions
+import app.myco.ui.applyDeviceName
 import app.myco.ui.PeersPill
 import app.myco.ui.peerLabel
 import app.myco.ui.theme.StatusConnected
@@ -318,9 +319,7 @@ fun CircleScreen(
             ownNpub = state.ownNpub,
             onDismiss = { editing = false },
             onSave = {
-                DeviceName.set(context, it)
-                client.dispatch(NativeActions.setDeviceName(it))
-                name = it
+                name = applyDeviceName(context, client, state.ownNpub, it)
                 // Refresh the NFC payload so we present the new name immediately.
                 if (state.ownNpub.isNotEmpty()) PairPresent.begin(context, state.ownNpub, it)
                 editing = false

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -75,6 +75,7 @@ import app.myco.share.DeviceName
 import app.myco.share.NsiteShare
 import app.myco.ui.NameSuggestions
 import app.myco.ui.PeersPill
+import app.myco.ui.peerLabel
 import app.myco.ui.theme.StatusConnected
 import app.myco.ui.theme.avatarColorFor
 
@@ -132,7 +133,7 @@ fun CircleScreen(
     // strength/discovery order, so bubbles don't reshuffle as RSSI fluctuates.
     val nearby = state.blePeers.filter {
         it.connected && it.npub.isNotEmpty() && it.npub != state.ownNpub && it.npub !in circleNpubs
-    }.sortedWith(compareBy({ DeviceName.generated(it.npub).lowercase() }, { it.npub }))
+    }.sortedWith(compareBy({ peerLabel(state, it.npub).lowercase() }, { it.npub }))
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
@@ -182,7 +183,7 @@ fun CircleScreen(
                         nearby.forEach { peer ->
                             val isSent = peer.npub in invited
                             PersonBubble(
-                                label = DeviceName.generated(peer.npub),
+                                label = peerLabel(state, peer.npub),
                                 npub = peer.npub,
                                 ring = Ring.DASHED,
                                 badge = if (isSent) Badge.SENT else Badge.PLUS,
@@ -250,7 +251,7 @@ fun CircleScreen(
                     ) {
                         state.outboundPairs.forEach { inv ->
                             PersonBubble(
-                                label = inv.name.ifEmpty { DeviceName.generated(inv.npub) },
+                                label = peerLabel(state, inv.npub),
                                 npub = inv.npub,
                                 ring = Ring.DASHED,
                                 badge = Badge.SENT,

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -73,6 +73,7 @@ import app.myco.nfc.NfcStatus
 import app.myco.nfc.PairPresent
 import app.myco.share.DeviceName
 import app.myco.share.NsiteShare
+import app.myco.ui.NameSuggestions
 import app.myco.ui.PeersPill
 import app.myco.ui.theme.StatusConnected
 import app.myco.ui.theme.avatarColorFor
@@ -313,6 +314,7 @@ fun CircleScreen(
     if (editing) {
         RenameDialog(
             initial = name,
+            ownNpub = state.ownNpub,
             onDismiss = { editing = false },
             onSave = {
                 DeviceName.set(context, it)
@@ -566,7 +568,12 @@ private fun PersonBubble(
 }
 
 @Composable
-private fun RenameDialog(initial: String, onDismiss: () -> Unit, onSave: (String) -> Unit) {
+private fun RenameDialog(
+    initial: String,
+    ownNpub: String,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit,
+) {
     var value by remember { mutableStateOf(initial) }
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -575,7 +582,17 @@ private fun RenameDialog(initial: String, onDismiss: () -> Unit, onSave: (String
             Column {
                 Text("How you appear to people you pair with. Pick something you can say out loud.", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyMedium)
                 Spacer(Modifier.height(12.dp))
-                OutlinedTextField(value = value, onValueChange = { value = it }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(
+                    value = value,
+                    onValueChange = { value = it.take(DeviceName.MAX_LENGTH) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(10.dp))
+                // Tapping a chip fills the field rather than saving outright —
+                // in a dialog, Save is the commit and short-circuiting it would
+                // leave Cancel meaning nothing.
+                NameSuggestions(ownNpub, value) { value = it }
             }
         },
         confirmButton = { TextButton(onClick = { if (value.isNotBlank()) onSave(value.trim()) }) { Text("Save") } },

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -31,7 +30,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -51,14 +49,12 @@ import app.myco.ui.KeyVal
 import app.myco.ui.ScreenHeader
 import app.myco.ui.SectionCard
 import app.myco.ui.StatusDot
+import app.myco.ui.TransportIcon
 import app.myco.ui.locationServicesEnabled
-import app.myco.R
 import app.myco.ui.theme.StatusAlone
 import app.myco.ui.theme.StatusConnected
 import app.myco.ui.theme.StatusReachable
 import app.myco.ui.theme.StatusThin
-import app.myco.ui.theme.TransportBluetooth
-import app.myco.ui.theme.TransportNetwork
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.Dispatchers
@@ -556,42 +552,6 @@ private fun PeerDiagnosticRow(peer: PeerDiagnostic, expanded: Boolean, onToggle:
             PeerForensics(peer)
         }
     }
-}
-
-/**
- * The transport a peer is reachable over, as an icon.
- *
- * Three lanes, three glyphs: the Bluetooth rune, the Wi-Fi Aware arcs, and a
- * globe for anything routed (LAN, the `!FIPS` AP, mDNS). An unknown or absent
- * transport draws nothing rather than guessing — a peer with no resolved link
- * is a real state and a wrong icon would assert a link that does not exist.
- *
- * Bluetooth keeps its brand blue and the routed lane the app's emerald;
- * Aware follows `onSurface`, so it reads as the plain radio in either theme.
- */
-@Composable
-private fun TransportIcon(transport: String, modifier: Modifier = Modifier) {
-    val (res, tint, label) = when (transport) {
-        "ble" -> Triple(R.drawable.ic_transport_bluetooth, TransportBluetooth, "Bluetooth")
-        "aware" -> Triple(
-            R.drawable.ic_transport_wifi_aware,
-            MaterialTheme.colorScheme.onSurface,
-            "Wi-Fi Aware",
-        )
-        "" -> Triple(0, MaterialTheme.colorScheme.onSurfaceVariant, "")
-        // udp, tcp and anything else routed: it reached us over IP.
-        else -> Triple(R.drawable.ic_transport_network, TransportNetwork, "Network")
-    }
-    if (res == 0) {
-        Spacer(modifier.size(26.dp))
-        return
-    }
-    Icon(
-        painter = painterResource(res),
-        contentDescription = label,
-        tint = tint,
-        modifier = modifier.size(26.dp),
-    )
 }
 
 /**

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -573,6 +573,11 @@ private fun PeerForensics(peer: PeerDiagnostic) {
         modifier = Modifier.padding(start = 30.dp, end = 16.dp, bottom = 8.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
+        // The name the peer broadcasts for itself, as received — never the
+        // resolved label. This row is what separates "they advertised this" from
+        // "we generated it from their npub", which the peer list alone cannot
+        // show when the two happen to agree.
+        ForensicLine("advert name", peer.advertisedName.ifEmpty { "—" })
         ForensicLine("role", peer.role.ifEmpty { "—" })
         ForensicLine("discovery", if (peer.discoveryMs > 0) "${peer.discoveryMs}ms" else "—")
         ForensicLine("send drops", peer.sendDrops.toString())

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -49,6 +49,7 @@ import app.myco.ui.KeyVal
 import app.myco.ui.ScreenHeader
 import app.myco.ui.SectionCard
 import app.myco.ui.StatusDot
+import app.myco.ui.peerLabel
 import app.myco.ui.TransportIcon
 import app.myco.ui.locationServicesEnabled
 import app.myco.ui.theme.StatusAlone
@@ -350,7 +351,7 @@ private fun SpeedtestCard(state: AppState, client: AppCoreClient) {
             EmptyLine("no connected peer to test")
         } else {
             peers.forEach { peer ->
-                val name = DeviceName.generated(peer.npub)
+                val name = peerLabel(state, peer.npub)
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -373,11 +374,11 @@ private fun SpeedtestCard(state: AppState, client: AppCoreClient) {
         }
 
         val resultLine = when {
-            st.running -> "Testing ${DeviceName.generated(st.peerNpub)}…"
+            st.running -> "Testing ${peerLabel(state, st.peerNpub)}…"
             st.generation == 0L -> null
             st.error.isNotEmpty() -> "✗ ${st.error}"
             else -> "↑ %s   ↓ %s   (%s, %s)".format(
-                rate(st.upMbps), rate(st.downMbps), DeviceName.generated(st.peerNpub), size(st.bytes),
+                rate(st.upMbps), rate(st.downMbps), peerLabel(state, st.peerNpub), size(st.bytes),
             )
         }
         if (resultLine != null) {

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -60,6 +60,7 @@ import app.myco.core.AppState
 import app.myco.core.NativeActions
 import app.myco.share.DeviceName
 import app.myco.ui.GroupLabel
+import app.myco.ui.NameSuggestions
 import app.myco.ui.RadioAction
 import app.myco.ui.RadioWarning
 import app.myco.ui.ScreenHeader
@@ -322,20 +323,20 @@ private fun IdentitySettings(state: AppState, client: AppCoreClient, onBack: () 
                 )
                 OutlinedTextField(
                     value = name,
-                    onValueChange = { name = it.take(40) },
+                    onValueChange = { name = it.take(DeviceName.MAX_LENGTH) },
                     label = { Text("Name") },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
+                // Both defaults, one tap each — picking one saves immediately,
+                // since there is nothing left to confirm about a name you chose
+                // off a list rather than typed.
+                NameSuggestions(state.ownNpub, name) { picked ->
+                    name = picked
+                    DeviceName.set(context, picked)
+                    client.dispatch(NativeActions.setDeviceName(picked))
+                }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    TextButton(
-                        onClick = {
-                            // Empty resets to the npub-derived default.
-                            DeviceName.set(context, "")
-                            name = DeviceName.generated(state.ownNpub)
-                            client.dispatch(NativeActions.setDeviceName(name))
-                        },
-                    ) { Text("Reset") }
                     Spacer(Modifier.weight(1f))
                     TextButton(
                         enabled = name.isNotBlank() && name.trim() != saved,

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -61,6 +61,7 @@ import app.myco.core.NativeActions
 import app.myco.share.DeviceName
 import app.myco.ui.GroupLabel
 import app.myco.ui.NameSuggestions
+import app.myco.ui.applyDeviceName
 import app.myco.ui.RadioAction
 import app.myco.ui.RadioWarning
 import app.myco.ui.ScreenHeader
@@ -332,18 +333,14 @@ private fun IdentitySettings(state: AppState, client: AppCoreClient, onBack: () 
                 // since there is nothing left to confirm about a name you chose
                 // off a list rather than typed.
                 NameSuggestions(state.ownNpub, name) { picked ->
-                    name = picked
-                    DeviceName.set(context, picked)
-                    client.dispatch(NativeActions.setDeviceName(picked))
+                    name = applyDeviceName(context, client, state.ownNpub, picked)
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Spacer(Modifier.weight(1f))
                     TextButton(
                         enabled = name.isNotBlank() && name.trim() != saved,
                         onClick = {
-                            val trimmed = name.trim()
-                            DeviceName.set(context, trimmed)
-                            client.dispatch(NativeActions.setDeviceName(trimmed))
+                            applyDeviceName(context, client, state.ownNpub, name.trim())
                             onBack()
                         },
                     ) { Text("Save") }

--- a/android/app/src/test/java/app/myco/share/DeviceNameTest.kt
+++ b/android/app/src/test/java/app/myco/share/DeviceNameTest.kt
@@ -1,0 +1,58 @@
+package app.myco.share
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The generated name is what people read off each other's screens, so it has to
+ * be stable for a given npub and spread thinly enough that two phones in a room
+ * don't land on the same one.
+ */
+class DeviceNameTest {
+
+    private fun npub(i: Int) = "npub1" + "%059x".format(i)
+
+    @Test
+    fun `the same npub always generates the same name`() {
+        val one = DeviceName.generated(npub(7))
+        assertEquals(one, DeviceName.generated(npub(7)))
+        assertNotEquals(one, DeviceName.generated(npub(8)))
+    }
+
+    @Test
+    fun `an empty npub is never given a fabricated name`() {
+        assertEquals("new device", DeviceName.generated(""))
+    }
+
+    @Test
+    fun `it is always two speakable lowercase words`() {
+        repeat(200) { i ->
+            val name = DeviceName.generated(npub(i))
+            val words = name.split(" ")
+            assertEquals("'$name' should be two words", 2, words.size)
+            assertTrue("'$name' should be lowercase a-z", name.all { it in 'a'..'z' || it == ' ' })
+        }
+    }
+
+    /**
+     * The bound that matters. Drawing 1000 names from a 2048-wide space fills
+     * about 2048·(1−e^−1000/2048) ≈ 790 buckets, so anything near that means
+     * the generator really is using the whole space. The old 12 × 12 = 144
+     * space could not have cleared 144 no matter how good its hash was, and a
+     * correlated hash fails this while the word lists stay the same size.
+     */
+    @Test
+    fun `a thousand npubs spread across most of the name space`() {
+        val distinct = (0 until 1000).map { DeviceName.generated(npub(it)) }.toSet()
+        assertTrue("only ${distinct.size} distinct names from 1000 npubs", distinct.size > 700)
+    }
+
+    /** Twenty devices — a big Circle — should almost never collide. */
+    @Test
+    fun `a circle sized run is collision free`() {
+        val names = (0 until 20).map { DeviceName.generated(npub(it)) }
+        assertEquals(names.toString(), names.size, names.toSet().size)
+    }
+}

--- a/myco-core/src/advert_names.rs
+++ b/myco-core/src/advert_names.rs
@@ -1,0 +1,124 @@
+//! BLE address → self-advertised display name.
+//!
+//! The name a device chose for itself is otherwise invisible until you have
+//! exchanged pair traffic with it: the fips handshake does not carry one, and
+//! `PeerView.display_name` is an abbreviated npub. This module holds the one
+//! place it *is* observable before pairing — the string a peer puts in its BLE
+//! scan response — keyed by the BLE address the scan reported it on.
+//!
+//! Myco-owned on purpose. The name is a Myco-layer nicety with no bearing on
+//! routing, so it stays out of the fips bridge's `deliver_scan` path and rides
+//! its own JNI push instead, exactly as [`crate::lane_observation`] does for
+//! lane origin. Plain lock-based state with no JNI or Android dependency, so it
+//! is unit-testable on the host.
+//!
+//! **This name is unauthenticated.** It arrives in a plaintext broadcast that
+//! anyone in radio range can forge, so it is only ever a fallback *below* every
+//! name learned from signed pair traffic — never an override. Callers must
+//! preserve that ordering.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+/// Longest advertised name accepted. A BLE scan response is 31 bytes and the
+/// service-data header eats four of them, so nothing longer can arrive intact;
+/// truncating here as well means a hostile or buggy advertiser cannot push an
+/// oversized string into the map either.
+pub(crate) const MAX_ADVERT_NAME_BYTES: usize = 27;
+
+/// Cap on distinct addresses remembered. BLE MACs rotate under privacy, so a
+/// long session in a busy room would otherwise accumulate one entry per
+/// rotation forever. Well above any plausible room; a bound, not a policy.
+const MAX_ENTRIES: usize = 512;
+
+static ADVERT_NAMES: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+
+fn advert_names() -> &'static Mutex<HashMap<String, String>> {
+    ADVERT_NAMES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record the name `ble_addr` is advertising for itself.
+///
+/// A blank name clears the entry rather than storing an empty string — a peer
+/// that stopped advertising a name has no name, which is not the same as
+/// having one that is empty.
+pub(crate) fn set_name(ble_addr: &str, name: &str) {
+    let trimmed = truncate_bytes(name.trim(), MAX_ADVERT_NAME_BYTES);
+    let mut map = advert_names().lock().unwrap();
+    if trimmed.is_empty() {
+        map.remove(ble_addr);
+        return;
+    }
+    // Only refuse *new* addresses at the cap, so an already-tracked device can
+    // still update its name in a saturated map.
+    if map.len() >= MAX_ENTRIES && !map.contains_key(ble_addr) {
+        return;
+    }
+    map.insert(ble_addr.to_string(), trimmed);
+}
+
+/// A snapshot of every advertised name, for `merge_peers()`'s
+/// `advert_names` parameter. Cloned rather than held locked across the merge.
+pub(crate) fn snapshot() -> HashMap<String, String> {
+    advert_names().lock().unwrap().clone()
+}
+
+/// Truncate to at most `max` bytes on a UTF-8 character boundary.
+fn truncate_bytes(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Each test uses its own address — the map is a process-global shared
+    // across every test in this binary.
+
+    #[test]
+    fn a_pushed_name_reaches_the_snapshot() {
+        set_name("ble0/AA:00:00:00:00:01", "DC-1");
+        assert_eq!(
+            snapshot().get("ble0/AA:00:00:00:00:01").map(String::as_str),
+            Some("DC-1")
+        );
+    }
+
+    #[test]
+    fn a_blank_name_clears_rather_than_storing_an_empty_string() {
+        set_name("ble0/AA:00:00:00:00:02", "gone");
+        set_name("ble0/AA:00:00:00:00:02", "   ");
+        assert_eq!(snapshot().get("ble0/AA:00:00:00:00:02"), None);
+    }
+
+    /// A multi-byte name cut at the cap must stay valid UTF-8 — the truncation
+    /// point is a character boundary, not a byte offset.
+    #[test]
+    fn an_oversized_name_is_cut_on_a_character_boundary() {
+        let long = "é".repeat(40); // 80 bytes
+        set_name("ble0/AA:00:00:00:00:03", &long);
+        let stored = snapshot()
+            .get("ble0/AA:00:00:00:00:03")
+            .cloned()
+            .expect("stored");
+        assert!(stored.len() <= MAX_ADVERT_NAME_BYTES);
+        assert!(stored.chars().all(|c| c == 'é'), "{stored}");
+    }
+
+    #[test]
+    fn a_later_push_replaces_the_earlier_name() {
+        set_name("ble0/AA:00:00:00:00:04", "old");
+        set_name("ble0/AA:00:00:00:00:04", "new");
+        assert_eq!(
+            snapshot().get("ble0/AA:00:00:00:00:04").map(String::as_str),
+            Some("new")
+        );
+    }
+}

--- a/myco-core/src/advert_names.rs
+++ b/myco-core/src/advert_names.rs
@@ -1,10 +1,18 @@
-//! BLE address → self-advertised display name.
+//! Node-address prefix → self-advertised display name.
 //!
 //! The name a device chose for itself is otherwise invisible until you have
 //! exchanged pair traffic with it: the fips handshake does not carry one, and
 //! `PeerView.display_name` is an abbreviated npub. This module holds the one
 //! place it *is* observable before pairing — the string a peer puts in its BLE
-//! scan response — keyed by the BLE address the scan reported it on.
+//! scan response — keyed by the leading bytes of the peer's own `node_addr`,
+//! which it advertises alongside the name.
+//!
+//! Keyed on the node address rather than the BLE MAC it arrived on, because
+//! those are not the same question. A device is routinely *discovered* by BLE
+//! advert and then *carried* over the LAN lane, and its peer row is keyed by
+//! node address; a MAC-keyed name could only ever be attached to peers
+//! currently on BLE, which is the minority case. The advertiser therefore says
+//! who it is, and no address mapping is needed at all.
 //!
 //! Myco-owned on purpose. The name is a Myco-layer nicety with no bearing on
 //! routing, so it stays out of the fips bridge's `deliver_scan` path and rides
@@ -20,15 +28,15 @@
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
-/// Longest advertised name accepted. A BLE scan response is 31 bytes and the
-/// service-data header eats four of them, so nothing longer can arrive intact;
-/// truncating here as well means a hostile or buggy advertiser cannot push an
-/// oversized string into the map either.
-pub(crate) const MAX_ADVERT_NAME_BYTES: usize = 27;
+/// Longest advertised name accepted. A BLE scan response is 31 bytes, the
+/// service-data header eats four and the node-address prefix six, so nothing
+/// longer can arrive intact; truncating here as well means a hostile or buggy
+/// advertiser cannot push an oversized string into the map either.
+pub(crate) const MAX_ADVERT_NAME_BYTES: usize = 21;
 
-/// Cap on distinct addresses remembered. BLE MACs rotate under privacy, so a
-/// long session in a busy room would otherwise accumulate one entry per
-/// rotation forever. Well above any plausible room; a bound, not a policy.
+/// Cap on distinct devices remembered. A node address is stable, so this grows
+/// far slower than a MAC-keyed map would — but it is still unbounded input from
+/// the air. Well above any plausible room; a bound, not a policy.
 const MAX_ENTRIES: usize = 512;
 
 static ADVERT_NAMES: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
@@ -37,24 +45,25 @@ fn advert_names() -> &'static Mutex<HashMap<String, String>> {
     ADVERT_NAMES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Record the name `ble_addr` is advertising for itself.
+/// Record the name the device whose `node_addr` starts with `node_prefix` (hex)
+/// is advertising for itself.
 ///
 /// A blank name clears the entry rather than storing an empty string — a peer
 /// that stopped advertising a name has no name, which is not the same as
 /// having one that is empty.
-pub(crate) fn set_name(ble_addr: &str, name: &str) {
+pub(crate) fn set_name(node_prefix: &str, name: &str) {
     let trimmed = truncate_bytes(name.trim(), MAX_ADVERT_NAME_BYTES);
     let mut map = advert_names().lock().unwrap();
     if trimmed.is_empty() {
-        map.remove(ble_addr);
+        map.remove(node_prefix);
         return;
     }
     // Only refuse *new* addresses at the cap, so an already-tracked device can
     // still update its name in a saturated map.
-    if map.len() >= MAX_ENTRIES && !map.contains_key(ble_addr) {
+    if map.len() >= MAX_ENTRIES && !map.contains_key(node_prefix) {
         return;
     }
-    map.insert(ble_addr.to_string(), trimmed);
+    map.insert(node_prefix.to_ascii_lowercase(), trimmed);
 }
 
 /// A snapshot of every advertised name, for `merge_peers()`'s
@@ -79,23 +88,34 @@ fn truncate_bytes(s: &str, max: usize) -> String {
 mod tests {
     use super::*;
 
-    // Each test uses its own address — the map is a process-global shared
-    // across every test in this binary.
+    // Each test uses its own key — the map is a process-global shared across
+    // every test in this binary.
+
+    /// Keys are compared against lowercase hex from the peer row, so an
+    /// uppercase push must still be findable.
+    #[test]
+    fn keys_are_normalised_to_lowercase_hex() {
+        set_name("AABB00000005", "Shouty");
+        assert_eq!(
+            snapshot().get("aabb00000005").map(String::as_str),
+            Some("Shouty")
+        );
+    }
 
     #[test]
     fn a_pushed_name_reaches_the_snapshot() {
-        set_name("ble0/AA:00:00:00:00:01", "DC-1");
+        set_name("aabb00000001", "DC-1");
         assert_eq!(
-            snapshot().get("ble0/AA:00:00:00:00:01").map(String::as_str),
+            snapshot().get("aabb00000001").map(String::as_str),
             Some("DC-1")
         );
     }
 
     #[test]
     fn a_blank_name_clears_rather_than_storing_an_empty_string() {
-        set_name("ble0/AA:00:00:00:00:02", "gone");
-        set_name("ble0/AA:00:00:00:00:02", "   ");
-        assert_eq!(snapshot().get("ble0/AA:00:00:00:00:02"), None);
+        set_name("aabb00000002", "gone");
+        set_name("aabb00000002", "   ");
+        assert_eq!(snapshot().get("aabb00000002"), None);
     }
 
     /// A multi-byte name cut at the cap must stay valid UTF-8 — the truncation
@@ -103,21 +123,18 @@ mod tests {
     #[test]
     fn an_oversized_name_is_cut_on_a_character_boundary() {
         let long = "é".repeat(40); // 80 bytes
-        set_name("ble0/AA:00:00:00:00:03", &long);
-        let stored = snapshot()
-            .get("ble0/AA:00:00:00:00:03")
-            .cloned()
-            .expect("stored");
+        set_name("aabb00000003", &long);
+        let stored = snapshot().get("aabb00000003").cloned().expect("stored");
         assert!(stored.len() <= MAX_ADVERT_NAME_BYTES);
         assert!(stored.chars().all(|c| c == 'é'), "{stored}");
     }
 
     #[test]
     fn a_later_push_replaces_the_earlier_name() {
-        set_name("ble0/AA:00:00:00:00:04", "old");
-        set_name("ble0/AA:00:00:00:00:04", "new");
+        set_name("aabb00000004", "old");
+        set_name("aabb00000004", "new");
         assert_eq!(
-            snapshot().get("ble0/AA:00:00:00:00:04").map(String::as_str),
+            snapshot().get("aabb00000004").map(String::as_str),
             Some("new")
         );
     }

--- a/myco-core/src/ble_bridge_jni.rs
+++ b/myco-core/src/ble_bridge_jni.rs
@@ -360,6 +360,34 @@ pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverScan(
     }
 }
 
+/// Kotlin read a self-advertised display name out of a peer's BLE scan
+/// response.
+///
+/// Separate from [`Java_app_myco_core_NativeCore_bleDeliverScan`] on purpose:
+/// the name has no bearing on routing, so it never enters the fips bridge and
+/// lands in Myco's own [`crate::advert_names`] record instead. Needs no bridge
+/// handle for the same reason — the map is process-global, like the lane
+/// record.
+///
+/// The value is an unauthenticated broadcast anyone in range can forge. It is
+/// stored as such; the display layer is what keeps it below every name learned
+/// from signed pair traffic.
+#[no_mangle]
+pub extern "system" fn Java_app_myco_core_NativeCore_bleDeliverAdvertName(
+    mut env: JNIEnv,
+    _class: JClass,
+    addr: JString,
+    name: JString,
+) {
+    let Ok(addr) = env.get_string(&addr) else {
+        return;
+    };
+    let Ok(name) = env.get_string(&name) else {
+        return;
+    };
+    crate::advert_names::set_name(&String::from(addr), &String::from(name));
+}
+
 /// Android's `ScanResult.rssi` in dBm, as an optional signal strength.
 ///
 /// `127` is the platform's "RSSI unknown" sentinel and is not a real reading,

--- a/myco-core/src/control_client.rs
+++ b/myco-core/src/control_client.rs
@@ -43,7 +43,7 @@ const IO_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// Named after the `fips::control::read_handle::PeerView` it replaces so the
 /// merge in [`crate::peer_diagnostics`] keeps its shape, but Myco-owned now.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct PeerView {
     /// The peer's `node_addr`, hex-encoded (`node_addr` on the wire — the value
     /// is hex, the key is not).
@@ -64,6 +64,11 @@ pub struct PeerView {
     pub authenticated_at_ms: u64,
     /// Transport type carrying the peer's link (`"ble"`, `"udp"`, …).
     pub transport: String,
+    /// Smoothed round-trip time over this peer's link, milliseconds, as MMP
+    /// measured it. `None` when MMP has taken no measurement yet — fips omits
+    /// the key entirely in that case, and an unmeasured link must render as
+    /// "no ping", never as a confident `0`.
+    pub srtt_ms: Option<f64>,
     /// fips's render-ready name. **This is an abbreviated npub**
     /// (`"npub1qrjr...msuc"`), not a profile name — observed on device.
     pub display_name: String,
@@ -226,6 +231,10 @@ fn peer_from_json(peer: &Value) -> PeerView {
             .and_then(Value::as_u64)
             .unwrap_or(0),
         transport: s("transport_type"),
+        srtt_ms: peer
+            .get("mmp")
+            .and_then(|mmp| mmp.get("srtt_ms"))
+            .and_then(Value::as_f64),
         display_name: s("display_name"),
     }
 }
@@ -265,6 +274,11 @@ mod tests {
             "npub": "npub1qrjrvpelneupkjnk5nmkxxjfyxkyp5yg5l38t3e8fxs75lzwtgqqfqmsuc",
             "transport_addr": "[::ffff:192.168.8.238]:2121",
             "transport_type": "udp",
+            "mmp": {
+                "mode": "reliable",
+                "srtt_ms": 42.5,
+                "loss_rate": 0.0,
+            },
         });
         let view = peer_from_json(&row);
         assert_eq!(view.node_addr_hex, "ad9d5cb1a248d4ff21e9f30c10b3ea40");
@@ -277,6 +291,24 @@ mod tests {
         assert_eq!(view.authenticated_at_ms, 1786483829884);
         assert_eq!(view.transport, "udp");
         assert_eq!(view.display_name, "npub1qrjr...msuc");
+        assert_eq!(view.srtt_ms, Some(42.5));
+    }
+
+    /// fips omits `srtt_ms` from the inline MMP block until MMP has taken a
+    /// measurement, and omits the whole block on a peer with no MMP session.
+    /// Both must read as "no measurement" — a link that has never been timed
+    /// must never render as a 0ms ping.
+    #[test]
+    fn an_unmeasured_link_carries_no_ping() {
+        let no_srtt = serde_json::json!({
+            "npub": "npub1x",
+            "connectivity": "connected",
+            "mmp": { "mode": "reliable", "loss_rate": 0.0 },
+        });
+        assert_eq!(peer_from_json(&no_srtt).srtt_ms, None);
+
+        let no_mmp = serde_json::json!({ "npub": "npub1x", "connectivity": "connected" });
+        assert_eq!(peer_from_json(&no_mmp).srtt_ms, None);
     }
 
     #[test]

--- a/myco-core/src/control_client.rs
+++ b/myco-core/src/control_client.rs
@@ -64,6 +64,16 @@ pub struct PeerView {
     pub authenticated_at_ms: u64,
     /// Transport type carrying the peer's link (`"ble"`, `"udp"`, …).
     pub transport: String,
+    /// The transport-level address the link currently runs over, exactly as
+    /// fips formats it: `adapter/AA:BB:CC:DD:EE:FF` for BLE, `[addr]:port` for
+    /// the IP transports. Empty when the peer has no resolved address.
+    ///
+    /// For BLE this is the one thing that ties an authenticated peer to the
+    /// address its scan adverts arrive on. Without it a peer that connected
+    /// *inbound* has no recorded address at all — the connect-attempt log only
+    /// covers dials we made — so its adverts, and the RSSI and self-advertised
+    /// name they carry, could never be attributed to it.
+    pub transport_addr: String,
     /// Smoothed round-trip time over this peer's link, milliseconds, as MMP
     /// measured it. `None` when MMP has taken no measurement yet — fips omits
     /// the key entirely in that case, and an unmeasured link must render as
@@ -231,6 +241,7 @@ fn peer_from_json(peer: &Value) -> PeerView {
             .and_then(Value::as_u64)
             .unwrap_or(0),
         transport: s("transport_type"),
+        transport_addr: s("transport_addr"),
         srtt_ms: peer
             .get("mmp")
             .and_then(|mmp| mmp.get("srtt_ms"))
@@ -290,6 +301,7 @@ mod tests {
         assert_eq!(view.last_seen_ms, 1786484197793);
         assert_eq!(view.authenticated_at_ms, 1786483829884);
         assert_eq!(view.transport, "udp");
+        assert_eq!(view.transport_addr, "[::ffff:192.168.8.238]:2121");
         assert_eq!(view.display_name, "npub1qrjr...msuc");
         assert_eq!(view.srtt_ms, Some(42.5));
     }

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -34,6 +34,7 @@ mod ip_source;
 // lane_by_npub override. Plain, non-JNI logic so it is unit-testable on the
 // host; the Android JNI bridge is its only real caller.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod advert_names;
 mod lane_observation;
 mod peer_diagnostics;
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]

--- a/myco-core/src/peer_diagnostics.rs
+++ b/myco-core/src/peer_diagnostics.rs
@@ -85,11 +85,12 @@ fn short(s: &str) -> String {
 /// link-local vs. routable) — that would be exactly the sort of
 /// inference-presented-as-observation this phase prohibits.
 ///
-/// `advert_names` is BLE-address-keyed self-advertised display names, read out
-/// of peers' scan responses. It is joined on after adverts have been attributed
-/// to rows, so a row only carries one if a scan actually saw that address. The
-/// value is unauthenticated (see [`crate::advert_names`]) and is therefore only
-/// ever surfaced as a fallback below the Circle/pairing names.
+/// `advert_names` is self-advertised display names read out of peers' scan
+/// responses, keyed by the node-address prefix each advertiser puts beside its
+/// name. Joining on the node address rather than the BLE address is what lets a
+/// peer discovered over BLE but *carried* over the LAN lane still show the name
+/// it chose. The value is unauthenticated (see [`crate::advert_names`]) and is
+/// therefore only ever surfaced as a fallback below the Circle/pairing names.
 ///
 /// `ble_attempts` is the per-peer BLE connect-attempt log, keyed by BLE
 /// address. It supplies three things: the role/discovery/outcome history joined
@@ -329,17 +330,25 @@ pub fn merge_peers(
         };
     }
 
-    // Step 5b: join self-advertised names on by BLE address. Runs after step 2
-    // has attributed adverts to rows, so `ble_addr` is populated wherever a
-    // scan actually saw the device. Nothing is written for a row we never saw
-    // an advert for — the absence of a broadcast name is a fact, and inventing
-    // one from the npub here would rob the display layer of the distinction.
-    for row in rows.iter_mut() {
-        if row.ble_addr.is_empty() {
-            continue;
-        }
-        if let Some(name) = advert_names.get(&row.ble_addr) {
-            row.advertised_name = name.clone();
+    // Step 5b: join self-advertised names on by node-address prefix. Works for
+    // any row that has a resolved node address, whatever transport now carries
+    // it — a device heard over BLE and then connected over the LAN lane is the
+    // common case, and an address-keyed join missed exactly those. Nothing is
+    // written for a row we never heard a name from: the absence of a broadcast
+    // name is a fact, and filling it from the npub here would rob the display
+    // layer of the distinction.
+    if !advert_names.is_empty() {
+        for row in rows.iter_mut() {
+            if row.node_addr_hex.is_empty() {
+                continue;
+            }
+            let node = row.node_addr_hex.to_ascii_lowercase();
+            if let Some((_, name)) = advert_names
+                .iter()
+                .find(|(prefix, _)| !prefix.is_empty() && node.starts_with(prefix.as_str()))
+            {
+                row.advertised_name = name.clone();
+            }
         }
     }
 
@@ -461,9 +470,8 @@ mod tests {
 
     /// An inbound BLE peer — one we never dialled, so the attempt log knows
     /// nothing about it — must still be attributed its own adverts. Its link
-    /// address is what supplies that, and without it the RSSI and the
-    /// self-advertised name both go missing on exactly the peers most likely to
-    /// have connected that way.
+    /// address is what supplies that, and without it the RSSI goes missing on
+    /// exactly the peers most likely to have connected that way.
     #[test]
     fn an_inbound_ble_peer_is_keyed_by_its_link_address() {
         let mut view = pv("a1", "npub-inbound", true, 1_000, "ble");
@@ -479,10 +487,6 @@ mod tests {
             psm: 196,
             rssi: -61,
         }];
-        let names = HashMap::from([(
-            "ble0/77:B5:98:5E:D1:E6".to_string(),
-            "orchid eero".to_string(),
-        )]);
         let out = merge_peers(
             &[view, ip],
             &peers,
@@ -492,7 +496,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
-            &names,
+            &HashMap::new(),
             // Deliberately empty: this is the no-dial-history case.
             &[],
             0,
@@ -501,59 +505,52 @@ mod tests {
         let inbound = out.iter().find(|r| r.npub == "npub-inbound").expect("row");
         assert_eq!(inbound.ble_addr, "ble0/77:B5:98:5E:D1:E6");
         assert_eq!(inbound.rssi, Some(-61));
-        assert_eq!(inbound.advertised_name, "orchid eero");
         // A socket address is not a scan address and must key into nothing.
         let over_ip = out.iter().find(|r| r.npub == "npub-over-ip").expect("row");
         assert_eq!(over_ip.ble_addr, "");
-        assert_eq!(over_ip.advertised_name, "");
     }
 
-    /// A self-advertised name is joined on by BLE address, and only for a row
-    /// an advert was actually attributed to. A peer seen over another lane
-    /// entirely carries none — the display layer has to be able to tell "chose
-    /// no name" from "we never heard one".
+    /// Advertised names join on the node-address prefix the advertiser puts
+    /// beside the name, **not** on the BLE address it arrived over. That is the
+    /// whole point: a device heard over BLE is routinely carried over the LAN
+    /// lane, and a MAC-keyed join missed exactly those peers.
     #[test]
-    fn an_advertised_name_lands_on_the_row_its_advert_was_attributed_to() {
+    fn an_advertised_name_joins_by_node_address_whatever_carries_the_peer() {
         let views = vec![
-            pv("a1", "npub-ble-seen", true, 1_000, "ble"),
-            pv("a2", "npub-udp-only", true, 1_000, "udp"),
+            // Heard over BLE, carried over udp — the case that was broken.
+            pv("a1b2c3d4e5f6aabb", "npub-lan-carried", true, 1_000, "udp"),
+            pv("ff00ff00ff00ff00", "npub-no-broadcast", true, 1_000, "ble"),
         ];
         let peers = vec![
-            bp("a1", "npub-ble-seen", true),
-            bp("a2", "npub-udp-only", true),
+            bp("a1b2c3d4e5f6aabb", "npub-lan-carried", true),
+            bp("ff00ff00ff00ff00", "npub-no-broadcast", true),
         ];
-        // The advert's address is learned onto the first row by the attempt log.
-        let attempts = vec![BlePeerAttempts {
-            ble_addr: "ble0/AA:01".to_string(),
-            node_addr_hex: "a1".to_string(),
-            send_failures: 0,
-            attempts: Vec::new(),
-        }];
-        let adverts = vec![BleAdvert {
-            addr: "ble0/AA:01".to_string(),
-            psm: 133,
-            rssi: -55,
-        }];
-        let names = HashMap::from([("ble0/AA:01".to_string(), "DC-1".to_string())]);
+        let names = HashMap::from([("a1b2c3d4e5f6".to_string(), "DC-1".to_string())]);
         let out = merge_peers(
             &views,
             &peers,
-            &adverts,
+            &[],
             &[],
             &[],
             &[],
             &[],
             &HashMap::new(),
             &names,
-            &attempts,
+            &[],
             0,
         );
-        let seen = out.iter().find(|r| r.npub == "npub-ble-seen").expect("row");
-        assert_eq!(seen.advertised_name, "DC-1");
-        let other = out.iter().find(|r| r.npub == "npub-udp-only").expect("row");
+        let carried = out
+            .iter()
+            .find(|r| r.npub == "npub-lan-carried")
+            .expect("row");
+        assert_eq!(carried.advertised_name, "DC-1");
+        let silent = out
+            .iter()
+            .find(|r| r.npub == "npub-no-broadcast")
+            .expect("row");
         assert_eq!(
-            other.advertised_name, "",
-            "a row with no attributed advert must not borrow another's name"
+            silent.advertised_name, "",
+            "a peer that broadcast no name must not borrow another's"
         );
     }
 

--- a/myco-core/src/peer_diagnostics.rs
+++ b/myco-core/src/peer_diagnostics.rs
@@ -85,6 +85,12 @@ fn short(s: &str) -> String {
 /// link-local vs. routable) — that would be exactly the sort of
 /// inference-presented-as-observation this phase prohibits.
 ///
+/// `advert_names` is BLE-address-keyed self-advertised display names, read out
+/// of peers' scan responses. It is joined on after adverts have been attributed
+/// to rows, so a row only carries one if a scan actually saw that address. The
+/// value is unauthenticated (see [`crate::advert_names`]) and is therefore only
+/// ever surfaced as a fallback below the Circle/pairing names.
+///
 /// `ble_attempts` is the per-peer BLE connect-attempt log, keyed by BLE
 /// address. It supplies three things: the role/discovery/outcome history joined
 /// onto each row, the per-peer link send-failure count, and the learned
@@ -104,6 +110,7 @@ pub fn merge_peers(
     outbound_pairs: &[OutboundPairView],
     reachable_npubs: &[String],
     lane_by_npub: &HashMap<String, String>,
+    advert_names: &HashMap<String, String>,
     ble_attempts: &[BlePeerAttempts],
     _now_ms: u64,
 ) -> Vec<PeerDiagnosticView> {
@@ -137,11 +144,20 @@ pub fn merge_peers(
         // `None` both when there is no PeerView and when MMP has not measured
         // the link yet — the row cannot tell those apart and must not pretend.
         let srtt_ms = pv.and_then(|p| p.srtt_ms);
+        // A BLE peer's link address is its scan address, so recording it here
+        // is what lets steps 2 and 5b attribute that device's adverts — its
+        // RSSI and the name it broadcasts — to this row. Only for BLE: on the
+        // IP transports the same field is a socket address, which would key
+        // into nothing and match nothing.
+        let ble_addr = match pv {
+            Some(p) if p.transport == "ble" => p.transport_addr.clone(),
+            _ => String::new(),
+        };
         rows.push(PeerDiagnosticView {
             key,
             npub: bp.npub.clone(),
             node_addr_hex: bp.node_addr_hex.clone(),
-            ble_addr: String::new(),
+            ble_addr,
             name,
             // Only "connected" is decided here (the one state a row can
             // already know for certain); every other state is assigned in
@@ -155,6 +171,7 @@ pub fn merge_peers(
             also_reachable_via: Vec::new(),
             last_seen_ms,
             authenticated_at_ms,
+            advertised_name: String::new(),
             srtt_ms,
             rssi: bp.rssi,
             psm: bp.psm,
@@ -208,6 +225,7 @@ pub fn merge_peers(
                 also_reachable_via: Vec::new(),
                 last_seen_ms: 0,
                 authenticated_at_ms: 0,
+                advertised_name: String::new(),
                 srtt_ms: None,
                 rssi: Some(adv.rssi),
                 psm: adv.psm,
@@ -252,6 +270,7 @@ pub fn merge_peers(
             also_reachable_via: Vec::new(),
             last_seen_ms: 0,
             authenticated_at_ms: 0,
+            advertised_name: String::new(),
             srtt_ms: None,
             rssi: None,
             psm: 0,
@@ -308,6 +327,20 @@ pub fn merge_peers(
         } else {
             "unreachable".to_string()
         };
+    }
+
+    // Step 5b: join self-advertised names on by BLE address. Runs after step 2
+    // has attributed adverts to rows, so `ble_addr` is populated wherever a
+    // scan actually saw the device. Nothing is written for a row we never saw
+    // an advert for — the absence of a broadcast name is a fact, and inventing
+    // one from the npub here would rob the display layer of the distinction.
+    for row in rows.iter_mut() {
+        if row.ble_addr.is_empty() {
+            continue;
+        }
+        if let Some(name) = advert_names.get(&row.ble_addr) {
+            row.advertised_name = name.clone();
+        }
     }
 
     // Step 6: join the recorded attempt history onto each row. Rows are matched
@@ -386,6 +419,7 @@ mod tests {
             last_seen_ms,
             authenticated_at_ms: 0,
             transport: transport.to_string(),
+            transport_addr: String::new(),
             srtt_ms: None,
             display_name: String::new(),
         }
@@ -425,6 +459,104 @@ mod tests {
         }
     }
 
+    /// An inbound BLE peer — one we never dialled, so the attempt log knows
+    /// nothing about it — must still be attributed its own adverts. Its link
+    /// address is what supplies that, and without it the RSSI and the
+    /// self-advertised name both go missing on exactly the peers most likely to
+    /// have connected that way.
+    #[test]
+    fn an_inbound_ble_peer_is_keyed_by_its_link_address() {
+        let mut view = pv("a1", "npub-inbound", true, 1_000, "ble");
+        view.transport_addr = "ble0/77:B5:98:5E:D1:E6".to_string();
+        let mut ip = pv("a2", "npub-over-ip", true, 1_000, "udp");
+        ip.transport_addr = "[::ffff:192.168.8.238]:2121".to_string();
+        let peers = vec![
+            bp("a1", "npub-inbound", true),
+            bp("a2", "npub-over-ip", true),
+        ];
+        let adverts = vec![BleAdvert {
+            addr: "ble0/77:B5:98:5E:D1:E6".to_string(),
+            psm: 196,
+            rssi: -61,
+        }];
+        let names = HashMap::from([(
+            "ble0/77:B5:98:5E:D1:E6".to_string(),
+            "orchid eero".to_string(),
+        )]);
+        let out = merge_peers(
+            &[view, ip],
+            &peers,
+            &adverts,
+            &[],
+            &[],
+            &[],
+            &[],
+            &HashMap::new(),
+            &names,
+            // Deliberately empty: this is the no-dial-history case.
+            &[],
+            0,
+        );
+        assert_eq!(out.len(), 2, "the advert must not become a second row");
+        let inbound = out.iter().find(|r| r.npub == "npub-inbound").expect("row");
+        assert_eq!(inbound.ble_addr, "ble0/77:B5:98:5E:D1:E6");
+        assert_eq!(inbound.rssi, Some(-61));
+        assert_eq!(inbound.advertised_name, "orchid eero");
+        // A socket address is not a scan address and must key into nothing.
+        let over_ip = out.iter().find(|r| r.npub == "npub-over-ip").expect("row");
+        assert_eq!(over_ip.ble_addr, "");
+        assert_eq!(over_ip.advertised_name, "");
+    }
+
+    /// A self-advertised name is joined on by BLE address, and only for a row
+    /// an advert was actually attributed to. A peer seen over another lane
+    /// entirely carries none — the display layer has to be able to tell "chose
+    /// no name" from "we never heard one".
+    #[test]
+    fn an_advertised_name_lands_on_the_row_its_advert_was_attributed_to() {
+        let views = vec![
+            pv("a1", "npub-ble-seen", true, 1_000, "ble"),
+            pv("a2", "npub-udp-only", true, 1_000, "udp"),
+        ];
+        let peers = vec![
+            bp("a1", "npub-ble-seen", true),
+            bp("a2", "npub-udp-only", true),
+        ];
+        // The advert's address is learned onto the first row by the attempt log.
+        let attempts = vec![BlePeerAttempts {
+            ble_addr: "ble0/AA:01".to_string(),
+            node_addr_hex: "a1".to_string(),
+            send_failures: 0,
+            attempts: Vec::new(),
+        }];
+        let adverts = vec![BleAdvert {
+            addr: "ble0/AA:01".to_string(),
+            psm: 133,
+            rssi: -55,
+        }];
+        let names = HashMap::from([("ble0/AA:01".to_string(), "DC-1".to_string())]);
+        let out = merge_peers(
+            &views,
+            &peers,
+            &adverts,
+            &[],
+            &[],
+            &[],
+            &[],
+            &HashMap::new(),
+            &names,
+            &attempts,
+            0,
+        );
+        let seen = out.iter().find(|r| r.npub == "npub-ble-seen").expect("row");
+        assert_eq!(seen.advertised_name, "DC-1");
+        let other = out.iter().find(|r| r.npub == "npub-udp-only").expect("row");
+        assert_eq!(
+            other.advertised_name, "",
+            "a row with no attributed advert must not borrow another's name"
+        );
+    }
+
     /// The ping the status panel shows is the peer's MMP SRTT, carried through
     /// untouched. A row with no `PeerView` behind it (a Circle member who is
     /// merely paired-offline) carries `None` rather than inheriting anyone's.
@@ -442,6 +574,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,
@@ -463,6 +596,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,
@@ -490,6 +624,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            &HashMap::new(),
             &[],
             0,
         );
@@ -512,6 +647,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,
@@ -554,6 +690,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            &HashMap::new(),
             &[],
             0,
         );
@@ -565,6 +702,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,
@@ -590,6 +728,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            &HashMap::new(),
             &[],
             0,
         );
@@ -613,6 +752,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,
@@ -647,6 +787,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            &HashMap::new(),
             &[],
             0,
         );
@@ -671,6 +812,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            &HashMap::new(),
             &[],
             0,
         );
@@ -692,6 +834,7 @@ mod tests {
             &[],
             &reachable,
             &HashMap::new(),
+            &HashMap::new(),
             &[],
             0,
         );
@@ -710,6 +853,7 @@ mod tests {
             &pending_pairs,
             &[],
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,
@@ -730,6 +874,7 @@ mod tests {
             &pending_pairs,
             &outbound_pairs,
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,
@@ -753,6 +898,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,
@@ -778,6 +924,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            &HashMap::new(),
             &[],
             0,
         );
@@ -787,7 +934,19 @@ mod tests {
 
     #[test]
     fn empty_inputs_produce_empty_vec_not_panic() {
-        let out = merge_peers(&[], &[], &[], &[], &[], &[], &[], &HashMap::new(), &[], 0);
+        let out = merge_peers(
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+            0,
+        );
         assert!(out.is_empty());
     }
 
@@ -820,6 +979,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            &HashMap::new(),
             &[],
             0,
         );
@@ -850,6 +1010,7 @@ mod tests {
             &[],
             &[],
             &lane_by_npub,
+            &HashMap::new(),
             &[],
             0,
         );
@@ -872,6 +1033,7 @@ mod tests {
             &[],
             &[],
             &lane_by_npub,
+            &HashMap::new(),
             &[],
             0,
         );
@@ -911,6 +1073,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            &HashMap::new(),
             &recorded,
             0,
         );
@@ -947,6 +1110,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,
@@ -995,6 +1159,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            &HashMap::new(),
             &recorded,
             0,
         );
@@ -1027,6 +1192,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &HashMap::new(),
             &HashMap::new(),
             &[],
             0,

--- a/myco-core/src/peer_diagnostics.rs
+++ b/myco-core/src/peer_diagnostics.rs
@@ -134,6 +134,9 @@ pub fn merge_peers(
             .unwrap_or_default();
         let last_seen_ms = pv.map(|p| p.last_seen_ms).unwrap_or(0);
         let authenticated_at_ms = pv.map(|p| p.authenticated_at_ms).unwrap_or(0);
+        // `None` both when there is no PeerView and when MMP has not measured
+        // the link yet — the row cannot tell those apart and must not pretend.
+        let srtt_ms = pv.and_then(|p| p.srtt_ms);
         rows.push(PeerDiagnosticView {
             key,
             npub: bp.npub.clone(),
@@ -152,6 +155,7 @@ pub fn merge_peers(
             also_reachable_via: Vec::new(),
             last_seen_ms,
             authenticated_at_ms,
+            srtt_ms,
             rssi: bp.rssi,
             psm: bp.psm,
             pair_state: String::new(),
@@ -204,6 +208,7 @@ pub fn merge_peers(
                 also_reachable_via: Vec::new(),
                 last_seen_ms: 0,
                 authenticated_at_ms: 0,
+                srtt_ms: None,
                 rssi: Some(adv.rssi),
                 psm: adv.psm,
                 pair_state: String::new(),
@@ -247,6 +252,7 @@ pub fn merge_peers(
             also_reachable_via: Vec::new(),
             last_seen_ms: 0,
             authenticated_at_ms: 0,
+            srtt_ms: None,
             rssi: None,
             psm: 0,
             pair_state: String::new(),
@@ -380,6 +386,7 @@ mod tests {
             last_seen_ms,
             authenticated_at_ms: 0,
             transport: transport.to_string(),
+            srtt_ms: None,
             display_name: String::new(),
         }
     }
@@ -416,6 +423,31 @@ mod tests {
             name: name.to_string(),
             since: 0,
         }
+    }
+
+    /// The ping the status panel shows is the peer's MMP SRTT, carried through
+    /// untouched. A row with no `PeerView` behind it (a Circle member who is
+    /// merely paired-offline) carries `None` rather than inheriting anyone's.
+    #[test]
+    fn srtt_rides_the_peer_view_onto_the_row() {
+        let mut view = pv("a1", "npub1connected", true, 1_000, "udp");
+        view.srtt_ms = Some(37.5);
+        let peers = vec![bp("a1", "npub1connected", true)];
+        let members = vec![circle("npub2offline", "Offline Friend")];
+        let out = merge_peers(
+            &[view],
+            &peers,
+            &[],
+            &members,
+            &[],
+            &[],
+            &[],
+            &HashMap::new(),
+            &[],
+            0,
+        );
+        assert_eq!(out[0].srtt_ms, Some(37.5));
+        assert_eq!(out[1].srtt_ms, None);
     }
 
     #[test]

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -1193,6 +1193,7 @@ impl AppRuntime {
             &outbound_pairs,
             &reachable_npubs,
             &lane_by_npub,
+            &crate::advert_names::snapshot(),
             &ble_attempts,
             now_ms(),
         );

--- a/myco-core/src/state.rs
+++ b/myco-core/src/state.rs
@@ -102,6 +102,14 @@ pub struct PeerDiagnosticView {
     /// itself survives, so a long age means the link has held, not that a
     /// handshake is stale.
     pub authenticated_at_ms: u64,
+    /// The display name this peer broadcasts for itself in its BLE scan
+    /// response; empty when it has advertised none or was not found over BLE.
+    ///
+    /// **Unauthenticated** — a plaintext broadcast anyone in range can forge.
+    /// It exists so a device you have never paired with can still show the name
+    /// its owner chose, and it must always rank *below* any name learned from
+    /// signed pair traffic, never above.
+    pub advertised_name: String,
     /// Smoothed round-trip time over this peer's link, milliseconds, as MMP
     /// measured it. `None` when there is no measurement — an unmeasured link
     /// renders as an em-dash, never as a confident `0ms`.

--- a/myco-core/src/state.rs
+++ b/myco-core/src/state.rs
@@ -102,6 +102,10 @@ pub struct PeerDiagnosticView {
     /// itself survives, so a long age means the link has held, not that a
     /// handshake is stale.
     pub authenticated_at_ms: u64,
+    /// Smoothed round-trip time over this peer's link, milliseconds, as MMP
+    /// measured it. `None` when there is no measurement — an unmeasured link
+    /// renders as an em-dash, never as a confident `0ms`.
+    pub srtt_ms: Option<f64>,
     /// Signal strength from the most recent scan advert attributed to this
     /// row, dBm; `None` when no advert has been attributed.
     pub rssi: Option<i32>,


### PR DESCRIPTION
Turns the top-right pill from three numbers into something you can ask questions of, and makes a device's name its own rather than one derived from its public key.

## The status panel

Tapping the pill's counts opens a sheet answering the two questions people actually have: **can I reach my Circle**, and **what are the radios doing**.

Circle members sort reachable-first, alphabetically inside each group. Deliberately not by last-heard — five phones in one room re-rank on every poll if the order carries any live measurement, and a list that reshuffles under your thumb cannot be read. Offline members fold behind one line, since the answer they give is the same for all of them. No "reachable"/"offline" labels; the dot's colour was already saying it.

Each lane says whether it is scanning and lists the peers it carries, with **ping · session age · last seen**. Anything heard inside ten seconds reads "now" — a counter flickering 1s/2s/3s reads as a fault when it is the healthy case. Scan state is tri-state: a lane the app cannot observe says `unknown`, never `idle`, and a radio the phone does not have gets no row at all.

The ping was already on the wire. FIPS reports a smoothed RTT per link in `show_peers`' inline `mmp` block and Myco discarded it at the control-socket boundary. It is `Option` the whole way — FIPS omits the key until MMP has measured, and an unmeasured link has to read as no ping rather than a confident `0ms`.

## Device names

**The default is now the phone's own name.** `Settings.Global.DEVICE_NAME`, falling back to the Bluetooth adapter name and the legacy secure setting. Far easier to pick out across a table than "green sammy" — but it usually carries a real name, and it travels in every pair request. So it is *shown before it is used*: a first-run dialog asks once, with the phone name prefilled and the pseudonymous generated name one tap beside it.

**The generator was the source of the duplicates.** 12 × 12 = 144 combinations puts a collision at even money by fourteen devices. Now 32 × 64 = 2048, and the key moved from `String.hashCode()` to SHA-256 with disjoint digest bytes per list — the old code drew colour and name from correlated bits of one 32-bit value, so the real space was narrower than the word lists implied.

**The chosen name now rides the BLE advert**, so Nearby shows it before pairing. The primary advert is untouched — it is already 27 of its 31 legacy bytes and the PSM must stay there, since a scan response needs an active-scan round-trip that drops asymmetrically. That is exactly why the name goes in the scan response instead: a dropped scan response is fatal for a PSM and merely cosmetic for a name.

The name carries a 6-byte `node_addr` prefix ahead of it, so it says *whose* it is. Keying on the BLE MAC (the first attempt) only attaches a name to a peer currently carried over BLE — but a device is routinely discovered by advert and then connected over the LAN lane, and its row is keyed by node address. Received names land in a Myco-owned map with their own JNI entry rather than riding the FIPS bridge's `deliver_scan`; the name has no bearing on routing and FIPS stays clean.

**The advertised name is unauthenticated** — a plaintext broadcast anyone in range can forge. `peerLabel()` therefore ranks it strictly below every name learned from signed pair traffic and above the key-derived floor. That ordering is load-bearing, not cosmetic.

## First-run gating

`onCreate` started every lane before `setContent`, so a cold install brought up the LAN browse and then stacked the Bluetooth prompt, the Wi-Fi Aware prompt and the system's "Myco wants to set up a VPN connection" dialog over the splash animation — four system dialogs before the app had said what it is. They now all wait for the intro. Returning launches are byte-for-byte what they were; a replayed intro re-enters the same path as a no-op.

## Two bugs this surfaced

- **A rename never reached the radio.** It wrote the preference and told the core, but the advertised name only caught up on the next `onResume`. `applyDeviceName()` is now the single way to change a name and moves all three publish points together.
- **Inbound BLE peers were never attributed their own adverts.** Attribution ran through the connect-attempt log, which records only dials *we* made, so a peer that connected to us had no address on file — losing its RSSI, and later its advertised name. FIPS was already reporting the answer: `show_peers`' `transport_addr` is the live link address, formatted for BLE as the same `adapter/AA:BB:..` key the adverts arrive under.

## Verified

- `cargo test -p myco-core` — 92 pass, including new coverage for SRTT parsing, advert-name joins by node address, and the inbound-BLE attribution case.
- `DeviceNameTest`: determinism, shape, a 20-device Circle with no collision, and 1000 npubs filling >700 of 2048 buckets — a correlated hash fails that even with the bigger word lists.
- On two devices, from a clean install: eleven seconds between `Displayed` and the first system dialog (the intro waiting for its tap), the name dialog, then the prompts. Advertised names confirmed in both directions on the wire and rendering in Nearby.

## Not covered

Advertised names are BLE-only — a peer found over Wi-Fi Aware or the LAN carries none. Nearby bubble labels truncate two-word names (`jade ma…`), which the wider generator made routine. And the permission dialogs still stack on each other after the intro rather than being sequenced.
