### PR TITLE
Swappable relay and blob store, and Wi-Fi Aware links that hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Someone can no longer add themselves to your Circle uninvited. A pairing
+  acceptance is only acted on if it answers an invitation you actually sent, and
+  if it was addressed to your device — a signed acceptance meant for somebody
+  else could otherwise be captured and replayed at you. Being in a Circle grants
+  access to your relay and files, so this was worth closing properly.
 - Wi-Fi Aware links stop dying about once a minute. A data path would come up,
   carry traffic, and be torn down by the phone's firmware on a startlingly
   regular 64-second cycle. Radio coexistence was the obvious suspect and turned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Myco can store its data on a relay you run instead of on the phone. Settings →
+  Storage → Advanced takes a relay URL — Citrine on the same device, or a relay
+  on your own network — and everything Myco keeps in its event store lives there
+  instead. A Blossom server for the app files themselves can be set the same way.
+  Both are off by default and neither is needed to use Myco; the built-in stores
+  remain the normal case. Confirmed working against Citrine.
+- Settings warns when a store you configured cannot be reached, with a red dot on
+  the Settings tab and on Storage. Without it the symptom is apps that will not
+  load and nothing to explain why — the same class of invisible failure the radio
+  warnings already cover. Changing either store offers to restart, since the
+  setting is read when Myco starts.
+- Storage says when the built-in store is no longer the one being used, rather
+  than showing a usage bar for data nothing reads. Delete now says plainly that
+  it clears this device only: a store you run is not Myco's to empty, and
+  claiming otherwise about a destructive action is worse than saying nothing.
+
 - The status pill opens. Tapping the counts brings up a panel with the two
   questions people actually have — can I reach my Circle, and what are the
   radios doing. Circle members are listed reachable-first (alphabetically
@@ -63,6 +79,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Devices must be on the same version to exchange messages.** Mesh state — how
+  far a message travels, which query it belongs to — used to be written into the
+  messages themselves, which meant any relay carrying Myco traffic had to
+  understand Myco. It now travels alongside them, so the events and queries Myco
+  stores are ordinary Nostr and an ordinary relay can hold them. The cost is a
+  clean break: a phone on an older build and a phone on this one will not pass
+  events to each other.
+- Pairing has its own door. It used to arrive on the same port that serves your
+  apps and messages, which meant that port had to stay open to strangers and
+  every pairing request was written into your event store as a side effect.
+  Pairing now has a service of its own — the only thing an unpaired device can
+  reach — and the content ports are closed to anyone you have not paired with,
+  refused before a connection is established rather than after.
+- A peer you have paired with can no longer upload files to your device by
+  default. Nothing in normal use needs it: sharing an app works by the other side
+  fetching it from you. The developer speedtest is the only thing that did, and
+  it now says the peer declined rather than failing obscurely.
 - Nothing starts and nothing is asked for until the intro has played. A cold
   install used to bring up the LAN browse and then stack the Bluetooth prompt,
   the Wi-Fi Aware prompt and the system's "Myco wants to set up a VPN
@@ -92,6 +125,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Wi-Fi Aware links stop dying about once a minute. A data path would come up,
+  carry traffic, and be torn down by the phone's firmware on a startlingly
+  regular 64-second cycle. Radio coexistence was the obvious suspect and turned
+  out to be wrong — backing the Bluetooth scan off changed nothing at all. The
+  cause was Myco itself, re-establishing the same peer alternately over Bluetooth
+  and Aware; it now leaves a peer alone on Aware instead of also dialling it over
+  Bluetooth. Teardowns go from one a minute to one in seven, with both radios
+  scanning harder than before. Some churn remains in the first few minutes after
+  launch, when Bluetooth legitimately connects first.
+- Opening a chat or an app list no longer waits on a slow peer before showing
+  anything. A request from an app was answered only once every peer had replied
+  or timed out, so a single unreachable phone made the app look hung. What is on
+  this device now appears immediately, and anything a peer adds arrives as it
+  comes.
+- An old message is no longer re-broadcast to everyone each time someone new
+  comes into range. Whether a message counted as new was decided by whether the
+  store still held it, so a message that had expired and was fetched again looked
+  new and started a fresh wave.
+- Removing someone from your Circle now closes the connection they already have,
+  instead of only refusing the next one. They could otherwise keep receiving
+  everything they were already subscribed to.
 - Renaming your device changes what goes out over the air. The rename wrote the
   preference and told the mesh node but never told the radio, so the old name
   kept being broadcast until the app was next brought to the foreground — which

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,6 +2153,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-tungstenite 0.24.0",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,6 +2136,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "fips",
  "futures-util",
  "hex",
@@ -2149,6 +2150,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple-dns",
+ "socket2",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tracing",
@@ -2161,15 +2163,11 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
- "futures-util",
  "hex",
  "nostr",
  "nsite-deck",
  "serde_json",
- "socket2",
  "tokio",
- "tokio-tungstenite 0.24.0",
  "tracing",
 ]
 

--- a/android/app/src/main/java/app/myco/aware/AwareRadio.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareRadio.kt
@@ -26,6 +26,7 @@ import android.os.SystemClock
 import android.util.Log
 import app.myco.core.NativeCore
 import app.myco.core.UdpSocketPin
+import app.myco.ble.BleRadio
 import java.net.Inet6Address
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -223,6 +224,7 @@ class AwareRadio(
         for ((_, st) in retries) st.pending?.let { handler.removeCallbacks(it) }
         retries.clear()
         liveNdps.clear()
+        publishCoexState()
         ndpTargets.clear()
         peerIdentities.clear()
         _links.value = emptyList()
@@ -413,6 +415,7 @@ class AwareRadio(
                 val addr = formatPeerAddr(info.peerIpv6Addr, remote.port) ?: return
                 Log.i(TAG, "Aware NDP up to ${short(peerNpub)} at $addr")
                 liveNdps.add(peerNpub)
+                publishCoexState()
                 // The link is good: hand the peer a fresh retry budget.
                 if (retries.containsKey(peerNpub)) handler.post { clearRetry(peerNpub) }
                 // Pin BEFORE announcing the peer: the core dials as soon as it
@@ -634,8 +637,15 @@ class AwareRadio(
     }
 
     /** Unregister and forget a peer's NDP request, freeing its data-path slot. */
+    /** Tell the BLE radio whether any data path is live, so the PIN_TO_AWARE
+     *  experiment can stop the core from moving a peer off Aware onto BLE. */
+    private fun publishCoexState() {
+        BleRadio.awareNdpActive = liveNdps.isNotEmpty()
+    }
+
     private fun releaseNdp(peerNpub: String) {
         liveNdps.remove(peerNpub)
+        publishCoexState()
         ndpCallbacks.remove(peerNpub)?.let {
             runCatching { connectivity.unregisterNetworkCallback(it) }
         }

--- a/android/app/src/main/java/app/myco/aware/AwareRadio.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareRadio.kt
@@ -637,10 +637,53 @@ class AwareRadio(
     }
 
     /** Unregister and forget a peer's NDP request, freeing its data-path slot. */
-    /** Tell the BLE radio whether any data path is live, so the PIN_TO_AWARE
-     *  experiment can stop the core from moving a peer off Aware onto BLE. */
+    /** Publish the node_addr prefixes of peers Aware is carrying, so the BLE
+     *  radio can refuse to dial them. The core otherwise re-establishes one
+     *  peer alternately over both transports, and that churn tears the NAN
+     *  data path down every ~60s.
+     *
+     *  node_addr is the only identity both radios can compute: BLE reads a
+     *  prefix of it from the peer's scan response, and it is
+     *  `SHA-256(x-only pubkey)[..16]`, which is derivable from the npub here.
+     *  An npub that fails to decode is simply left out — the peer then keeps
+     *  its BLE lane, which is the pre-existing behaviour. */
     private fun publishCoexState() {
-        BleRadio.awareNdpActive = liveNdps.isNotEmpty()
+        BleRadio.awareNodePrefixes = liveNdps.mapNotNull { nodeAddrPrefix(it) }.toSet()
+    }
+
+    /** `SHA-256(pubkey)` truncated to the same prefix width BLE advertises,
+     *  hex-encoded. Mirrors `NodeAddr::from_pubkey` in fips. */
+    private fun nodeAddrPrefix(npub: String): String? {
+        val pubkey = decodeNpub(npub) ?: return null
+        val hash = java.security.MessageDigest.getInstance("SHA-256").digest(pubkey)
+        return hash.take(BleRadio.NODE_PREFIX_BYTES).joinToString("") { "%02x".format(it) }
+    }
+
+    /** bech32 npub -> 32-byte x-only pubkey. Checksum is not verified: these
+     *  npubs come from our own core, not from the wire. */
+    private fun decodeNpub(npub: String): ByteArray? {
+        val sep = npub.lastIndexOf('1')
+        if (sep < 0) return null
+        val data = ArrayList<Int>(npub.length - sep)
+        for (c in npub.substring(sep + 1)) {
+            val v = BECH32_CHARSET.indexOf(c)
+            if (v < 0) return null
+            data.add(v)
+        }
+        if (data.size < 7) return null
+        val payload = data.subList(0, data.size - 6) // strip checksum
+        var acc = 0
+        var bits = 0
+        val out = ArrayList<Byte>(32)
+        for (v in payload) {
+            acc = (acc shl 5) or v
+            bits += 5
+            while (bits >= 8) {
+                bits -= 8
+                out.add(((acc shr bits) and 0xff).toByte())
+            }
+        }
+        return if (out.size == 32) out.toByteArray() else null
     }
 
     private fun releaseNdp(peerNpub: String) {
@@ -745,6 +788,8 @@ class AwareRadio(
 
         /** Shape of a valid npub: bech32, `npub1` + 58 chars of the bech32
          *  alphabet (no `1`, `b`, `i`, `o`). Anything else is not dialled. */
+        private const val BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
         private val NPUB_RE = Regex("^npub1[023456789acdefghjklmnpqrstuvwxyz]{58}$")
 
         /** Where a peer that advertises no port listens: builds from before the

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -156,6 +156,17 @@ class BleRadio(context: Context) {
     @Volatile
     private var backgroundMode = false
 
+    // True while at least one Wi-Fi Aware data path is live, published by
+    // AwareRadio. Read only by the PIN_TO_AWARE experiment in [connect].
+    @Volatile
+    private var awareNdpLive = false
+
+    /** Adopt the current Aware state; a rebuilt radio would otherwise start
+     *  stale, since the companion setter only fires on a change. */
+    private fun onAwareNdpActiveChanged(active: Boolean) {
+        awareNdpLive = active
+    }
+
     /** Flip fore/background discovery intensity; restarts the scan if one is live. */
     fun setBackgroundMode(bg: Boolean) {
         if (backgroundMode == bg) return
@@ -168,6 +179,12 @@ class BleRadio(context: Context) {
     }
 
     init {
+        // Adopt the current Aware state. A rebuilt radio (mesh toggle, adapter
+        // off/on) starts with the field default, and the companion setter only
+        // fires on a *change* — so without this a new instance would dial a
+        // peer that Aware is already carrying.
+        awareNdpLive = awareActiveField
+
         // There is only ever one radio per process (BleService guards it), and
         // the app needs a handle on it to push the display name in without
         // threading a reference through the service's start intents.
@@ -258,6 +275,18 @@ class BleRadio(context: Context) {
         // that is silently dropped costs the probe loop its full 10s timeout
         // waiting for an attempt that was never made.
         if (stopped) {
+            failDial(connectId, addr)
+            return
+        }
+        // EXPERIMENT (PIN_TO_AWARE): refuse outbound dials while a Wi-Fi Aware
+        // data path is live, so the core can never move a peer from Aware onto
+        // BLE. Tests whether the ~60s NAN data-path teardowns are caused by the
+        // core re-establishing the same peer across transports rather than by
+        // radio coexistence. Inbound connections, advertising and scanning are
+        // untouched — only our own dialling is suppressed. Blunt on purpose: it
+        // also blocks dials to BLE-only peers, so it is not shippable as-is.
+        if (PIN_TO_AWARE && awareNdpLive) {
+            Log.i(TAG, "PIN_TO_AWARE: refusing BLE dial to $addr (aware data path live)")
             failDial(connectId, addr)
             return
         }
@@ -942,6 +971,9 @@ class BleRadio(context: Context) {
          *  first result is never accused. */
         private const val SILENT_WINDOWS_BEFORE_ALARM = 2
 
+        /** Experiment switch — see [BleRadio.connect]. Must be false to ship. */
+        private const val PIN_TO_AWARE = true
+
         /** Background scan: batched delivery window (controller-offloaded). */
         private const val BACKGROUND_BATCH_MS = 5000L
 
@@ -990,6 +1022,21 @@ class BleRadio(context: Context) {
                 if (next == nameField) return
                 nameField = next
                 instance?.reAdvertiseForName()
+            }
+
+        @Volatile
+        private var awareActiveField = false
+
+        /** Whether any Wi-Fi Aware data path is currently up, published by
+         *  [app.myco.aware.AwareRadio]. The two radios live in separate
+         *  services; the dial gate in [connect] needs to know when a data path
+         *  is carrying the peer. */
+        var awareNdpActive: Boolean
+            get() = awareActiveField
+            set(value) {
+                if (value == awareActiveField) return
+                awareActiveField = value
+                instance?.onAwareNdpActiveChanged(value)
             }
 
         @Volatile

--- a/android/app/src/main/java/app/myco/ble/BleRadio.kt
+++ b/android/app/src/main/java/app/myco/ble/BleRadio.kt
@@ -20,6 +20,7 @@ import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.os.ParcelUuid
+import android.os.SystemClock
 import android.util.Log
 import app.myco.core.NativeCore
 import java.io.IOException
@@ -156,15 +157,54 @@ class BleRadio(context: Context) {
     @Volatile
     private var backgroundMode = false
 
-    // True while at least one Wi-Fi Aware data path is live, published by
-    // AwareRadio. Read only by the PIN_TO_AWARE experiment in [connect].
+    // node_addr prefixes (hex, [NODE_PREFIX_BYTES] bytes) of peers currently
+    // carried by a Wi-Fi Aware data path, published by AwareRadio. A peer on
+    // Aware must not also be dialled over BLE: the core re-establishing one
+    // peer across two transports is what drives the ~60s NAN data-path
+    // teardowns. Keyed by node_addr because that is the only identity both
+    // radios can compute — BLE learns it from the scan response, Aware derives
+    // it from the peer's npub.
     @Volatile
-    private var awareNdpLive = false
+    private var awarePrefixes: Set<String> = emptySet()
 
-    /** Adopt the current Aware state; a rebuilt radio would otherwise start
+    /** node_addr prefix last advertised by each BLE MAC, so a dial (which only
+     *  carries an address) can be attributed to a peer. Populated from scan
+     *  responses; a peer whose response never arrives is simply not matched
+     *  and is dialled as before.
+     *
+     *  Keyed by MAC, so a peer that rotates its RPA re-learns the mapping from
+     *  the next scan response on the new address — the prefix itself is stable
+     *  because it derives from the peer's identity key, not its address. The
+     *  dead entry the rotation leaves behind is what [pruneNodePrefixes]
+     *  clears; without it this map grows for the life of the process, one
+     *  entry per rotation per peer. */
+    private val nodePrefixByMac = ConcurrentHashMap<String, PrefixSighting>()
+
+    private class PrefixSighting(val prefix: String, @Volatile var lastSeenMs: Long)
+
+    /** Sightings of an address whose peer we could not identify, while Aware
+     *  had peers to protect. Bounded by [SIGHTINGS_BEFORE_UNIDENTIFIED_PUSH] so
+     *  a peer that never sends a scan response is still reported. */
+    private val unidentifiedSightings = ConcurrentHashMap<String, Int>()
+
+    /** The node_addr prefix carried by this scan record, if it brought one. */
+    private fun nodePrefixOf(result: ScanResult): String? =
+        result.scanRecord?.getServiceData(NAME_SD_PARCEL_UUID)
+            ?.takeIf { it.size > NODE_PREFIX_BYTES }
+            ?.take(NODE_PREFIX_BYTES)
+            ?.joinToString("") { "%02x".format(it) }
+
+    /** Drop mappings for addresses not seen for [PREFIX_TTL_MS]. Rotation makes
+     *  the old address unreachable, so a stale entry can only mislead. */
+    private fun pruneNodePrefixes(now: Long) {
+        if (nodePrefixByMac.size < PREFIX_PRUNE_AT) return
+        nodePrefixByMac.entries.removeIf { now - it.value.lastSeenMs > PREFIX_TTL_MS }
+    }
+
+    /** Adopt the current Aware set; a rebuilt radio would otherwise start
      *  stale, since the companion setter only fires on a change. */
-    private fun onAwareNdpActiveChanged(active: Boolean) {
-        awareNdpLive = active
+    private fun onAwarePrefixesChanged(prefixes: Set<String>) {
+        awarePrefixes = prefixes
     }
 
     /** Flip fore/background discovery intensity; restarts the scan if one is live. */
@@ -183,7 +223,7 @@ class BleRadio(context: Context) {
         // off/on) starts with the field default, and the companion setter only
         // fires on a *change* — so without this a new instance would dial a
         // peer that Aware is already carrying.
-        awareNdpLive = awareActiveField
+        awarePrefixes = awarePrefixField
 
         // There is only ever one radio per process (BleService guards it), and
         // the app needs a handle on it to push the display name in without
@@ -278,15 +318,15 @@ class BleRadio(context: Context) {
             failDial(connectId, addr)
             return
         }
-        // EXPERIMENT (PIN_TO_AWARE): refuse outbound dials while a Wi-Fi Aware
-        // data path is live, so the core can never move a peer from Aware onto
-        // BLE. Tests whether the ~60s NAN data-path teardowns are caused by the
-        // core re-establishing the same peer across transports rather than by
-        // radio coexistence. Inbound connections, advertising and scanning are
-        // untouched — only our own dialling is suppressed. Blunt on purpose: it
-        // also blocks dials to BLE-only peers, so it is not shippable as-is.
-        if (PIN_TO_AWARE && awareNdpLive) {
-            Log.i(TAG, "PIN_TO_AWARE: refusing BLE dial to $addr (aware data path live)")
+        // A peer already carried by Wi-Fi Aware is not dialled over BLE. The
+        // core otherwise re-establishes the same peer alternately on both
+        // transports, and that churn is what tears the NAN data path down
+        // every ~60s. Only this peer's dials are suppressed: BLE-only peers
+        // dial normally, and inbound connections, advertising and scanning are
+        // untouched on every peer.
+        val prefix = nodePrefixByMac[addr]?.prefix
+        if (prefix != null && prefix in awarePrefixes) {
+            Log.i(TAG, "aware carries $prefix… — refusing BLE dial to $addr")
             failDial(connectId, addr)
             return
         }
@@ -590,6 +630,31 @@ class BleRadio(context: Context) {
         if (psm > 0) {
             scanWithPsm.incrementAndGet()
             scanPsmAddrs.add(addr)
+            // Identify the peer before handing the core a BLE address for it.
+            // Refusing the dial afterwards is too late on a freshly rotated
+            // RPA: the core dials the moment it learns the address, and the
+            // scan response carrying the node_addr may not have arrived yet —
+            // one such dial is enough to restart the transport churn that
+            // tears the Aware data path down.
+            //
+            // Unidentified peers are held back only while Aware actually has
+            // something to protect, and only for a few sightings: a peer with
+            // no display name set never sends a scan response at all (see the
+            // advertiser), and must still be reachable over BLE.
+            val seenPrefix = nodePrefixOf(result) ?: nodePrefixByMac[addr]?.prefix
+            val holdBack =
+                when {
+                    seenPrefix != null -> seenPrefix in awarePrefixes
+                    awarePrefixes.isEmpty() -> false
+                    else ->
+                        unidentifiedSightings.merge(addr, 1, Int::plus)!! <=
+                            SIGHTINGS_BEFORE_UNIDENTIFIED_PUSH
+                }
+            if (holdBack) {
+                if (seenPrefix != null) unidentifiedSightings.remove(addr)
+                return
+            }
+            unidentifiedSightings.remove(addr)
             NativeCore.bleDeliverScan(bridgeHandle, addr, psm, result.rssi)
             // The peer's chosen name, when its scan response reached us. Pushed
             // separately from the PSM: it is a Myco-layer label with no bearing
@@ -604,6 +669,16 @@ class BleRadio(context: Context) {
                     val advertised = String(
                         blob, NODE_PREFIX_BYTES, blob.size - NODE_PREFIX_BYTES, Charsets.UTF_8,
                     )
+                    val now = SystemClock.elapsedRealtime()
+                    nodePrefixByMac.compute(addr) { _, prev ->
+                        if (prev != null && prev.prefix == nodePrefix) {
+                            prev.lastSeenMs = now
+                            prev
+                        } else {
+                            PrefixSighting(nodePrefix, now)
+                        }
+                    }
+                    pruneNodePrefixes(now)
                     NativeCore.bleDeliverAdvertName(nodePrefix, advertised)
                     // Logged on change only. The push itself fires several
                     // times a second per peer, but a name that just appeared or
@@ -971,9 +1046,6 @@ class BleRadio(context: Context) {
          *  first result is never accused. */
         private const val SILENT_WINDOWS_BEFORE_ALARM = 2
 
-        /** Experiment switch — see [BleRadio.connect]. Must be false to ship. */
-        private const val PIN_TO_AWARE = true
-
         /** Background scan: batched delivery window (controller-offloaded). */
         private const val BACKGROUND_BATCH_MS = 5000L
 
@@ -1025,18 +1097,18 @@ class BleRadio(context: Context) {
             }
 
         @Volatile
-        private var awareActiveField = false
+        private var awarePrefixField: Set<String> = emptySet()
 
-        /** Whether any Wi-Fi Aware data path is currently up, published by
-         *  [app.myco.aware.AwareRadio]. The two radios live in separate
-         *  services; the dial gate in [connect] needs to know when a data path
-         *  is carrying the peer. */
-        var awareNdpActive: Boolean
-            get() = awareActiveField
+        /** node_addr prefixes of peers currently carried by a Wi-Fi Aware data
+         *  path, published by [app.myco.aware.AwareRadio]. The two radios live
+         *  in separate services, so this is how the dial gate in [connect]
+         *  learns which peers Aware already has. */
+        var awareNodePrefixes: Set<String>
+            get() = awarePrefixField
             set(value) {
-                if (value == awareActiveField) return
-                awareActiveField = value
-                instance?.onAwareNdpActiveChanged(value)
+                if (value == awarePrefixField) return
+                awarePrefixField = value
+                instance?.onAwarePrefixesChanged(value)
             }
 
         @Volatile
@@ -1081,6 +1153,19 @@ class BleRadio(context: Context) {
          *  of node address: ample against accidental collision in a room, and
          *  cheap enough to leave the name most of the payload. */
         const val NODE_PREFIX_BYTES = 6
+
+        /** How long a MAC -> node_addr mapping stays usable after the last
+         *  sighting. Comfortably longer than the RPA rotation period so an
+         *  in-use peer is never forgotten, short enough that rotated-away
+         *  addresses do not accumulate. */
+        private const val PREFIX_TTL_MS = 30 * 60 * 1000L
+        private const val PREFIX_PRUNE_AT = 128
+
+        /** How many sightings an unidentified address is held back for before
+         *  it is reported anyway. At observed advert rates this is a second or
+         *  two — long enough for a scan response, short enough that a peer
+         *  which never sends one is not stranded. */
+        private const val SIGHTINGS_BEFORE_UNIDENTIFIED_PUSH = 4
 
         /** Longest name that fits the 31-byte scan response beside its 4-byte
          *  service-data header and the node-address prefix. Cut on a UTF-8

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -50,6 +50,10 @@ data class CacheStatus(
     val relayEvents: Long,
     val blobCount: Long,
     val usedBytes: Long,
+    /** A custom relay is configured, so the built-in event store is not serving. */
+    val externalRelay: Boolean = false,
+    /** A custom Blossom is configured, so the built-in blob store is not serving. */
+    val externalBlobs: Boolean = false,
 )
 
 /** A Circle contact: a paired peer we pull nsites from over the mesh. */
@@ -280,6 +284,8 @@ data class AppState(
                 relayEvents = cacheJson.optLong("relayEvents"),
                 blobCount = cacheJson.optLong("blobCount"),
                 usedBytes = cacheJson.optLong("usedBytes"),
+                externalRelay = cacheJson.optBoolean("externalRelay"),
+                externalBlobs = cacheJson.optBoolean("externalBlobs"),
             )
             val circleJson = o.optJSONArray("circle")
             val circle = buildList {

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -212,6 +212,10 @@ data class AppState(
     val relayBackend: RelayBackendHealth = RelayBackendHealth(),
     /** The custom relay URL as last saved; may differ from the one in use until restart. */
     val pendingRelayUrl: String = "",
+    /** The configured custom Blossom and whether it can be reached. */
+    val blobBackend: RelayBackendHealth = RelayBackendHealth(),
+    /** The custom Blossom URL as last saved. */
+    val pendingBlossomUrl: String = "",
     val updateCheck: UpdateCheck = UpdateCheck(),
     val speedtest: SpeedtestStatus = SpeedtestStatus(),
     /** Merged per-identity peer diagnostics rows (DIAG-01/03/04/06). Built once
@@ -463,6 +467,13 @@ data class AppState(
                     )
                 },
                 pendingRelayUrl = o.optString("pendingRelayUrl"),
+                blobBackend = o.optJSONObject("blobBackend").let { bb ->
+                    RelayBackendHealth(
+                        url = bb?.optString("url").orEmpty(),
+                        error = bb?.optString("error").orEmpty(),
+                    )
+                },
+                pendingBlossomUrl = o.optString("pendingBlossomUrl"),
                 speedtest = o.optJSONObject("speedtest")?.let { s ->
                     SpeedtestStatus(
                         running = s.optBoolean("running"),
@@ -664,15 +675,22 @@ object NativeActions {
     /** Discover nsites on connected Circle peers' relays ("nsites around me"). */
     fun searchNsites(): JSONObject = JSONObject().put("type", "search_nsites")
 
-    /** Toggle mesh-only: when enabled, don't use the public IP relay/Blossom fallback. */
     /**
      * Point the event store at [url], or back at the built-in store with an
      * empty string. Applied on the next launch — the backend is chosen when the
      * content layer is built.
      */
     fun setCustomRelay(url: String): JSONObject =
-        JSONObject().put("type", "SetCustomRelay").put("url", url)
+        JSONObject().put("type", "set_custom_relay").put("url", url)
 
+    /**
+     * Point the blob store at [url], or back at the built-in one with an empty
+     * string. Applied on the next launch, like [setCustomRelay].
+     */
+    fun setCustomBlossom(url: String): JSONObject =
+        JSONObject().put("type", "set_custom_blossom").put("url", url)
+
+    /** Toggle mesh-only: when enabled, don't use the public IP relay/Blossom fallback. */
     fun setOfflineOnly(enabled: Boolean): JSONObject =
         JSONObject().put("type", "set_offline_only").put("enabled", enabled)
 

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -56,6 +56,14 @@ data class CacheStatus(
     val externalBlobs: Boolean = false,
 )
 
+/** The configured custom relay, and why it is unreachable if it is. */
+data class RelayBackendHealth(
+    /** Empty when the built-in store is in use. */
+    val url: String = "",
+    /** Empty when reachable, or when there is no custom relay. */
+    val error: String = "",
+)
+
 /** A Circle contact: a paired peer we pull nsites from over the mesh. */
 data class CircleContact(
     val npub: String,
@@ -200,6 +208,10 @@ data class AppState(
     /** Invites we sent that are still waiting to be accepted. */
     val outboundPairs: List<OutboundPair> = emptyList(),
     val offlineOnly: Boolean,
+    /** The configured custom relay and whether it can be reached. */
+    val relayBackend: RelayBackendHealth = RelayBackendHealth(),
+    /** The custom relay URL as last saved; may differ from the one in use until restart. */
+    val pendingRelayUrl: String = "",
     val updateCheck: UpdateCheck = UpdateCheck(),
     val speedtest: SpeedtestStatus = SpeedtestStatus(),
     /** Merged per-identity peer diagnostics rows (DIAG-01/03/04/06). Built once
@@ -444,6 +456,13 @@ data class AppState(
                 pendingPairRequests = pendingPairRequests,
                 outboundPairs = outboundPairs,
                 offlineOnly = o.optBoolean("offlineOnly"),
+                relayBackend = o.optJSONObject("relayBackend").let { rb ->
+                    RelayBackendHealth(
+                        url = rb?.optString("url").orEmpty(),
+                        error = rb?.optString("error").orEmpty(),
+                    )
+                },
+                pendingRelayUrl = o.optString("pendingRelayUrl"),
                 speedtest = o.optJSONObject("speedtest")?.let { s ->
                     SpeedtestStatus(
                         running = s.optBoolean("running"),
@@ -646,6 +665,14 @@ object NativeActions {
     fun searchNsites(): JSONObject = JSONObject().put("type", "search_nsites")
 
     /** Toggle mesh-only: when enabled, don't use the public IP relay/Blossom fallback. */
+    /**
+     * Point the event store at [url], or back at the built-in store with an
+     * empty string. Applied on the next launch — the backend is chosen when the
+     * content layer is built.
+     */
+    fun setCustomRelay(url: String): JSONObject =
+        JSONObject().put("type", "SetCustomRelay").put("url", url)
+
     fun setOfflineOnly(enabled: Boolean): JSONObject =
         JSONObject().put("type", "set_offline_only").put("enabled", enabled)
 

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -62,6 +62,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import app.myco.ble.BleHealth
+import app.myco.ui.screens.backendErrors
 import androidx.compose.ui.platform.LocalContext
 import app.myco.ui.radioWarnings
 import app.myco.core.AppCoreClient
@@ -225,7 +226,10 @@ fun MycoApp(
                                 }
                             },
                             icon = {
-                                val badged = (tab.route == "settings" && (bleExhausted || radioAlert)) ||
+                                val badged = (
+                                    tab.route == "settings" &&
+                                        (bleExhausted || radioAlert || backendErrors(state).isNotEmpty())
+                                    ) ||
                                     (tab.route == "circle" && state.pendingPairRequests.isNotEmpty())
                                 if (badged) {
                                     BadgedBox(badge = { Badge() }) {

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -358,8 +358,8 @@ private fun IdentitySettings(state: AppState, client: AppCoreClient, onBack: () 
 private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -> Unit) {
     var confirmCache by remember { mutableStateOf(false) }
     var confirmAll by remember { mutableStateOf(false) }
-    // The rows below are laid out but not wired: the store cannot be swapped yet.
-    // Better to say so on tap than to look functional and do nothing.
+    var editRelay by remember { mutableStateOf(false) }
+    // Blossom has no backend to point at yet, so that row still says so.
     var notYet by remember { mutableStateOf<String?>(null) }
 
     val used = state.cache.usedBytes
@@ -417,16 +417,22 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
 
         Spacer(Modifier.height(8.dp))
         GroupLabel("ADVANCED")
+        // A backend that has gone away otherwise looks like an app with no
+        // content: every site missing, no explanation. Warn the way the radio
+        // warnings do, since the cause is equally invisible from the app.
+        if (state.relayBackend.error.isNotEmpty()) {
+            BackendUnreachableCard(state.relayBackend.error)
+            Spacer(Modifier.height(8.dp))
+        }
         SectionCard {
             SettingRow(
                 icon = null,
                 title = "Custom relay",
-                subtitle = if (state.cache.externalRelay) {
-                    "Events are stored on a relay you chose"
-                } else {
-                    "Use another Nostr relay instead of the built-in one"
+                subtitle = when {
+                    state.pendingRelayUrl.isNotEmpty() -> state.pendingRelayUrl
+                    else -> "Use another Nostr relay instead of the built-in one"
                 },
-                onClick = { notYet = "relay" },
+                onClick = { editRelay = true },
             )
             RowDivider()
             SettingRow(
@@ -462,6 +468,16 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
         }
     }
 
+    if (editRelay) {
+        CustomRelayDialog(
+            current = state.pendingRelayUrl,
+            onSave = { url ->
+                client.dispatch(NativeActions.setCustomRelay(url))
+                editRelay = false
+            },
+            onDismiss = { editRelay = false },
+        )
+    }
     notYet?.let { what ->
         AlertDialog(
             onDismissRequest = { notYet = null },
@@ -719,6 +735,89 @@ private fun RadioWarningCard(warning: RadioWarning, onClick: () -> Unit) {
 /** Warning shown when the OS denied our BLE advertiser (TOO_MANY_ADVERTISERS):
  *  other apps hold every advertising slot, so peers can't discover this device.
  *  The radio keeps retrying on a backoff; this tells the user how to free a slot. */
+@Composable
+private fun BackendUnreachableCard(detail: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                MaterialTheme.colorScheme.errorContainer,
+                RoundedCornerShape(14.dp),
+            )
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.Filled.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.size(10.dp))
+            Text(
+                "Can't reach your relay",
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+        Text(
+            "$detail\n\nYour apps and messages are stored there, so they won't load " +
+                "until it's reachable again. Check that it's running and on the same " +
+                "network, or clear the setting below to go back to the built-in store.",
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+/**
+ * Enter (or clear) the custom relay URL.
+ *
+ * Carries the trust warning at the point of the decision rather than in a help
+ * page: reads are not re-verified, so whoever runs the relay decides what this
+ * device believes.
+ */
+@Composable
+private fun CustomRelayDialog(
+    current: String,
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var url by remember { mutableStateOf(current) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = { TextButton(onClick = { onSave(url.trim()) }) { Text("Save") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text("Custom relay") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = { url = it },
+                    singleLine = true,
+                    label = { Text("Relay URL") },
+                    placeholder = { Text("ws://192.168.1.10:4869") },
+                )
+                Text(
+                    "Your apps and messages will be stored on this relay instead of on " +
+                        "this device. Myco trusts it to check signatures, so whoever runs " +
+                        "it decides what this device believes — only use one you control.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    "Leave it empty to go back to the built-in store. Either way it takes " +
+                        "effect the next time Myco starts.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+    )
+}
+
 @Composable
 private fun BleExhaustedCard() {
     Column(

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
@@ -72,6 +73,21 @@ import app.myco.ui.radioWarnings
 
 /** The Settings surfaces: the root list and its three drill-in sub-pages. */
 private enum class SettingsPage { Root, Identity, Storage, Developer }
+
+/**
+ * Stores the user pointed us at that cannot be reached, as (title, detail).
+ *
+ * One definition so the tab badge, the row dot, and the cards cannot drift
+ * apart — they are three views of the same fact.
+ */
+fun backendErrors(state: AppState): List<Pair<String, String>> = buildList {
+    if (state.relayBackend.error.isNotEmpty()) {
+        add("Can't reach your relay" to state.relayBackend.error)
+    }
+    if (state.blobBackend.error.isNotEmpty()) {
+        add("Can't reach your blob store" to state.blobBackend.error)
+    }
+}
 
 /** Cap used for the storage gauge (matches the LRU target in the core). */
 private const val STORAGE_CAP_BYTES = 2_000_000_000.0
@@ -158,6 +174,7 @@ private fun RootSettings(
     val used = state.cache.usedBytes.toDouble()
     val pct = (used / STORAGE_CAP_BYTES * 100).coerceIn(0.0, 100.0)
     val free = (STORAGE_CAP_BYTES - used).coerceAtLeast(0.0).toLong()
+    val backendErrors = backendErrors(state)
 
     SettingsColumn {
         ScreenHeader("Settings", state)
@@ -176,6 +193,7 @@ private fun RootSettings(
                 icon = Icons.Filled.Storage,
                 title = "Storage",
                 subtitle = "${"%.0f".format(pct)}% used · ${humanBytes(free)} free",
+                alert = backendErrors.isNotEmpty(),
                 onClick = onOpenStorage,
             )
         }
@@ -221,6 +239,15 @@ private fun RootSettings(
                 title = "Internet",
                 subtitle = "Mesh over the internet",
             )
+        }
+
+        // A store the user pointed us at that has gone away. Surfaced here as
+        // well as inside Storage, because the symptom — apps that will not load
+        // — gives no hint that a setting is the cause, and the user has no
+        // reason to open Storage looking for it.
+        backendErrors.forEach { (title, detail) ->
+            Spacer(Modifier.height(8.dp))
+            BackendUnreachableCard(title, detail)
         }
 
         // Radio/VPN misconfigurations that silently break peering — recomputed
@@ -370,6 +397,7 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
     val used = state.cache.usedBytes
     val fraction = (used.toDouble() / STORAGE_CAP_BYTES).coerceIn(0.0, 1.0).toFloat()
     val free = (STORAGE_CAP_BYTES - used).coerceAtLeast(0.0).toLong()
+    val backendErrors = backendErrors(state)
 
     SettingsColumn {
         SubHeader("Storage", onBack)
@@ -425,12 +453,8 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
         // A backend that has gone away otherwise looks like an app with no
         // content: every site missing, no explanation. Warn the way the radio
         // warnings do, since the cause is equally invisible from the app.
-        if (state.relayBackend.error.isNotEmpty()) {
-            BackendUnreachableCard("Can't reach your relay", state.relayBackend.error)
-            Spacer(Modifier.height(8.dp))
-        }
-        if (state.blobBackend.error.isNotEmpty()) {
-            BackendUnreachableCard("Can't reach your blob store", state.blobBackend.error)
+        backendErrors(state).forEach { (title, detail) ->
+            BackendUnreachableCard(title, detail)
             Spacer(Modifier.height(8.dp))
         }
         SectionCard {
@@ -954,6 +978,8 @@ private fun SettingRow(
     title: String,
     subtitle: String,
     titleColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
+    /** Show a red dot: something inside this page needs attention. */
+    alert: Boolean = false,
     onClick: () -> Unit,
 ) {
     Row(
@@ -967,6 +993,14 @@ private fun SettingRow(
         Column(modifier = Modifier.weight(1f)) {
             Text(title, color = titleColor, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.titleMedium)
             Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
+        }
+        if (alert) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(MaterialTheme.colorScheme.error, CircleShape),
+            )
+            Spacer(Modifier.size(10.dp))
         }
         Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
     }

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -359,8 +359,7 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
     var confirmCache by remember { mutableStateOf(false) }
     var confirmAll by remember { mutableStateOf(false) }
     var editRelay by remember { mutableStateOf(false) }
-    // Blossom has no backend to point at yet, so that row still says so.
-    var notYet by remember { mutableStateOf<String?>(null) }
+    var editBlossom by remember { mutableStateOf(false) }
 
     val used = state.cache.usedBytes
     val fraction = (used.toDouble() / STORAGE_CAP_BYTES).coerceIn(0.0, 1.0).toFloat()
@@ -421,7 +420,11 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
         // content: every site missing, no explanation. Warn the way the radio
         // warnings do, since the cause is equally invisible from the app.
         if (state.relayBackend.error.isNotEmpty()) {
-            BackendUnreachableCard(state.relayBackend.error)
+            BackendUnreachableCard("Can't reach your relay", state.relayBackend.error)
+            Spacer(Modifier.height(8.dp))
+        }
+        if (state.blobBackend.error.isNotEmpty()) {
+            BackendUnreachableCard("Can't reach your blob store", state.blobBackend.error)
             Spacer(Modifier.height(8.dp))
         }
         SectionCard {
@@ -438,12 +441,11 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
             SettingRow(
                 icon = null,
                 title = "Custom Blossom",
-                subtitle = if (state.cache.externalBlobs) {
-                    "Blobs are stored on a server you chose"
-                } else {
-                    "Use another Blossom server instead of the built-in one"
+                subtitle = when {
+                    state.pendingBlossomUrl.isNotEmpty() -> state.pendingBlossomUrl
+                    else -> "Use another Blossom server instead of the built-in one"
                 },
-                onClick = { notYet = "Blossom" },
+                onClick = { editBlossom = true },
             )
         }
 
@@ -478,17 +480,14 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
             onDismiss = { editRelay = false },
         )
     }
-    notYet?.let { what ->
-        AlertDialog(
-            onDismissRequest = { notYet = null },
-            confirmButton = { TextButton(onClick = { notYet = null }) { Text("OK") } },
-            title = { Text("Not available yet") },
-            text = {
-                Text(
-                    "Pointing Myco at your own $what is still being built. " +
-                        "Everything is stored on this device for now.",
-                )
+    if (editBlossom) {
+        CustomBlossomDialog(
+            current = state.pendingBlossomUrl,
+            onSave = { url ->
+                client.dispatch(NativeActions.setCustomBlossom(url))
+                editBlossom = false
             },
+            onDismiss = { editBlossom = false },
         )
     }
     if (confirmCache) {
@@ -736,7 +735,7 @@ private fun RadioWarningCard(warning: RadioWarning, onClick: () -> Unit) {
  *  other apps hold every advertising slot, so peers can't discover this device.
  *  The radio keeps retrying on a backoff; this tells the user how to free a slot. */
 @Composable
-private fun BackendUnreachableCard(detail: String) {
+private fun BackendUnreachableCard(title: String, detail: String) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -756,16 +755,16 @@ private fun BackendUnreachableCard(detail: String) {
             )
             Spacer(Modifier.size(10.dp))
             Text(
-                "Can't reach your relay",
+                title,
                 color = MaterialTheme.colorScheme.onErrorContainer,
                 fontWeight = FontWeight.SemiBold,
                 style = MaterialTheme.typography.titleMedium,
             )
         }
         Text(
-            "$detail\n\nYour apps and messages are stored there, so they won't load " +
-                "until it's reachable again. Check that it's running and on the same " +
-                "network, or clear the setting below to go back to the built-in store.",
+            "$detail\n\nYour apps are stored there, so they won't load until it's " +
+                "reachable again. Check that it's running and on the same network, " +
+                "or clear the setting below to go back to the built-in store.",
             color = MaterialTheme.colorScheme.onErrorContainer,
             style = MaterialTheme.typography.bodySmall,
         )
@@ -804,6 +803,53 @@ private fun CustomRelayDialog(
                     "Your apps and messages will be stored on this relay instead of on " +
                         "this device. Myco trusts it to check signatures, so whoever runs " +
                         "it decides what this device believes — only use one you control.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    "Leave it empty to go back to the built-in store. Either way it takes " +
+                        "effect the next time Myco starts.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+    )
+}
+
+/**
+ * Enter (or clear) the custom Blossom URL.
+ *
+ * Carries a blunter warning than the relay's. Blobs are the bulk of an nsite, so
+ * moving them off the device means a peer pulling an app from you needs your
+ * connection to the server — which is the opposite of what the mesh is for.
+ */
+@Composable
+private fun CustomBlossomDialog(
+    current: String,
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var url by remember { mutableStateOf(current) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = { TextButton(onClick = { onSave(url.trim()) }) { Text("Save") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text("Custom Blossom") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = { url = it },
+                    singleLine = true,
+                    label = { Text("Blossom URL") },
+                    placeholder = { Text("http://192.168.1.10:24242") },
+                )
+                Text(
+                    "App files will be stored on this server instead of on this device. " +
+                        "If it's not on your own network, sharing an app with someone " +
+                        "nearby will need your internet connection — Myco won't work " +
+                        "offline the way it does now.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import kotlin.system.exitProcess
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -360,6 +361,11 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
     var confirmAll by remember { mutableStateOf(false) }
     var editRelay by remember { mutableStateOf(false) }
     var editBlossom by remember { mutableStateOf(false) }
+    // Both settings are read when the core starts, so a save only takes hold on
+    // the next launch. Offer the restart rather than leaving the user to guess
+    // why nothing changed.
+    var restartPrompt by remember { mutableStateOf(false) }
+    val context = LocalContext.current
 
     val used = state.cache.usedBytes
     val fraction = (used.toDouble() / STORAGE_CAP_BYTES).coerceIn(0.0, 1.0).toFloat()
@@ -476,6 +482,7 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
             onSave = { url ->
                 client.dispatch(NativeActions.setCustomRelay(url))
                 editRelay = false
+                restartPrompt = true
             },
             onDismiss = { editRelay = false },
         )
@@ -486,8 +493,27 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
             onSave = { url ->
                 client.dispatch(NativeActions.setCustomBlossom(url))
                 editBlossom = false
+                restartPrompt = true
             },
             onDismiss = { editBlossom = false },
+        )
+    }
+    if (restartPrompt) {
+        AlertDialog(
+            onDismissRequest = { restartPrompt = false },
+            confirmButton = {
+                TextButton(onClick = { restartApp(context) }) { Text("Restart now") }
+            },
+            dismissButton = {
+                TextButton(onClick = { restartPrompt = false }) { Text("Later") }
+            },
+            title = { Text("Saved") },
+            text = {
+                Text(
+                    "Myco needs to restart to use the new setting. Until then it keeps " +
+                        "using the current store.",
+                )
+            },
         )
     }
     if (confirmCache) {
@@ -734,6 +760,26 @@ private fun RadioWarningCard(warning: RadioWarning, onClick: () -> Unit) {
 /** Warning shown when the OS denied our BLE advertiser (TOO_MANY_ADVERTISERS):
  *  other apps hold every advertising slot, so peers can't discover this device.
  *  The radio keeps retrying on a backoff; this tells the user how to free a slot. */
+/**
+ * Relaunch the app, process and all.
+ *
+ * Restarting the activity is not enough: the settings are read once when the
+ * native core is constructed, so the process itself has to go. `makeRestartActivityTask`
+ * queues a fresh launch first, so exiting hands control straight back to a new
+ * process rather than dropping the user to the launcher.
+ */
+private fun restartApp(context: android.content.Context) {
+    val launch = context.packageManager.getLaunchIntentForPackage(context.packageName)
+    val component = launch?.component
+    if (component == null) {
+        // Nothing sane left to do but stop; the next manual launch picks up the
+        // setting anyway.
+        exitProcess(0)
+    }
+    context.startActivity(android.content.Intent.makeRestartActivityTask(component))
+    exitProcess(0)
+}
+
 @Composable
 private fun BackendUnreachableCard(title: String, detail: String) {
     Column(

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -393,6 +393,9 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
     // why nothing changed.
     var restartPrompt by remember { mutableStateOf(false) }
     val context = LocalContext.current
+    // Deleting only ever clears the built-in stores. Saying otherwise would be a
+    // lie about a destructive action, which is the one place it matters most.
+    val external = state.cache.externalRelay || state.cache.externalBlobs
 
     val used = state.cache.usedBytes
     val fraction = (used.toDouble() / STORAGE_CAP_BYTES).coerceIn(0.0, 1.0).toFloat()
@@ -485,7 +488,11 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
             SettingRow(
                 icon = null,
                 title = "Delete cache",
-                subtitle = "Free up space — keeps your pinned apps, clears everything else",
+                subtitle = if (external) {
+                    "Frees space on this device — your custom store is untouched"
+                } else {
+                    "Free up space — keeps your pinned apps, clears everything else"
+                },
                 titleColor = MaterialTheme.colorScheme.error,
                 onClick = { confirmCache = true },
             )
@@ -493,7 +500,11 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
             SettingRow(
                 icon = null,
                 title = "Delete all data, including apps",
-                subtitle = "Wipe entirely (keeps identity & Circle)",
+                subtitle = if (external) {
+                    "Wipes this device only (keeps identity & Circle)"
+                } else {
+                    "Wipe entirely (keeps identity & Circle)"
+                },
                 titleColor = MaterialTheme.colorScheme.error,
                 onClick = { confirmAll = true },
             )
@@ -543,8 +554,14 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
     if (confirmCache) {
         ConfirmDialog(
             title = "Delete cache?",
-            body = "Clears all downloaded relay events and blobs except your pinned apps, " +
-                "which keep working offline.",
+            body = if (external) {
+                "Clears what's stored on this device, except your pinned apps. " +
+                    "Anything on your custom relay or Blossom stays where it is — " +
+                    "it isn't ours to delete."
+            } else {
+                "Clears all downloaded relay events and blobs except your pinned apps, " +
+                    "which keep working offline."
+            },
             confirmLabel = "Delete cache",
             onConfirm = { client.dispatch(NativeActions.wipeCache()); confirmCache = false },
             onDismiss = { confirmCache = false },
@@ -553,8 +570,14 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
     if (confirmAll) {
         ConfirmDialog(
             title = "Delete all data?",
-            body = "Removes every downloaded nsite, including pinned apps (relay events + blobs). " +
-                "Your identity and Circle stay.",
+            body = if (external) {
+                "Removes every downloaded nsite stored on this device, including pinned " +
+                    "apps. Anything on your custom relay or Blossom stays where it is — " +
+                    "it isn't ours to delete. Your identity and Circle stay."
+            } else {
+                "Removes every downloaded nsite, including pinned apps (relay events + blobs). " +
+                    "Your identity and Circle stay."
+            },
             confirmLabel = "Delete all",
             onConfirm = { client.dispatch(NativeActions.wipeStores()); confirmAll = false },
             onDismiss = { confirmAll = false },

--- a/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/SettingsScreen.kt
@@ -358,6 +358,9 @@ private fun IdentitySettings(state: AppState, client: AppCoreClient, onBack: () 
 private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -> Unit) {
     var confirmCache by remember { mutableStateOf(false) }
     var confirmAll by remember { mutableStateOf(false) }
+    // The rows below are laid out but not wired: the store cannot be swapped yet.
+    // Better to say so on tap than to look functional and do nothing.
+    var notYet by remember { mutableStateOf<String?>(null) }
 
     val used = state.cache.usedBytes
     val fraction = (used.toDouble() / STORAGE_CAP_BYTES).coerceIn(0.0, 1.0).toFloat()
@@ -388,7 +391,54 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodySmall,
                 )
+                // These figures are always the built-in store's. With a custom
+                // relay or Blossom configured they still describe what is taking
+                // up room here, but no longer what is serving — say so, rather
+                // than letting the bar read as the whole picture.
+                val notInUse = when {
+                    state.cache.externalRelay && state.cache.externalBlobs ->
+                        "Not in use — a custom relay and Blossom are configured below."
+                    state.cache.externalRelay ->
+                        "Events not in use — a custom relay is configured below."
+                    state.cache.externalBlobs ->
+                        "Blobs not in use — a custom Blossom is configured below."
+                    else -> null
+                }
+                if (notInUse != null) {
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        notInUse,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
             }
+        }
+
+        Spacer(Modifier.height(8.dp))
+        GroupLabel("ADVANCED")
+        SectionCard {
+            SettingRow(
+                icon = null,
+                title = "Custom relay",
+                subtitle = if (state.cache.externalRelay) {
+                    "Events are stored on a relay you chose"
+                } else {
+                    "Use another Nostr relay instead of the built-in one"
+                },
+                onClick = { notYet = "relay" },
+            )
+            RowDivider()
+            SettingRow(
+                icon = null,
+                title = "Custom Blossom",
+                subtitle = if (state.cache.externalBlobs) {
+                    "Blobs are stored on a server you chose"
+                } else {
+                    "Use another Blossom server instead of the built-in one"
+                },
+                onClick = { notYet = "Blossom" },
+            )
         }
 
         Spacer(Modifier.height(8.dp))
@@ -412,6 +462,19 @@ private fun StorageSettings(state: AppState, client: AppCoreClient, onBack: () -
         }
     }
 
+    notYet?.let { what ->
+        AlertDialog(
+            onDismissRequest = { notYet = null },
+            confirmButton = { TextButton(onClick = { notYet = null }) { Text("OK") } },
+            title = { Text("Not available yet") },
+            text = {
+                Text(
+                    "Pointing Myco at your own $what is still being built. " +
+                        "Everything is stored on this device for now.",
+                )
+            },
+        )
+    }
     if (confirmCache) {
         ConfirmDialog(
             title = "Delete cache?",

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -180,7 +180,7 @@ no good Android app to forward to:
   is the embedded relay; optionally it can **forward to a local relay app (e.g.
   Citrine)** for devs who already run one. Embedding is the default and earliest
   path,
-- **Blossom** (`http://localhost:24243`) is **always embedded** — a small
+- **Blossom** (`http://localhost:24243`) is **currently always embedded** — a small
   content-addressed HTTP store (`GET /<sha256>`, `PUT /upload`, `HEAD`). There is
   no good Android Blossom app to forward to, so embedding is the only sensible
   path.
@@ -356,7 +356,7 @@ Provenance for each band, matching the legend in
 | `NsiteActivity` (fullscreen WebView per nsite, no chrome) | **net-new (thin)** | own task/instance; standard WebView; nsite-deck "loads localhost" pattern |
 | Local gateway + `*.nsite` resolution | **port (site-deck)** | Go → **Rust** in `nsite-deck`; HTTP-listener placement TBD/open |
 | Embedded Nostr relay (`:4870`) | **port (site-deck) → Rust** | was Khatru/Go; now the **`myco-relay`** crate (impl `RelayBackend`); embedded default, optional Citrine-forward backend |
-| Embedded Blossom (`:24243`) | **port (site-deck) → Rust** | now the **`myco-blossom`** crate (impl `BlobStore`); always embedded; content-addressed blobs, BUD-01 |
+| Embedded Blossom (`:24243`) | **port (site-deck) → Rust** | now the **`myco-blossom`** crate (impl `BlobStore`); the only implementation today, a pluggable blob backend is planned; content-addressed blobs, BUD-01 |
 | Store-and-forward cache (re-serve peers' events/blobs) | **net-new** | the offline-propagation mechanism; Blossom blob store, LRU 2 GB, Library = pinned |
 | nsite sync (fetch + verify + retain over `.fips`) | **net-new** | runs in **`nsite-deck`**; v0 serves direct from relay + Blossom |
 | htdocs serving cache (path-named files under `current/`) | **deferred** | nsite-deck speed optimization; not needed for v0 |

--- a/docs/design/event-gossip.md
+++ b/docs/design/event-gossip.md
@@ -1,7 +1,8 @@
 # Live event gossip: push + pull for app data over the mesh
 
-> Status: DESIGN / proposal for a not-yet-built feature. Voice is "the app
-> will…". Open questions are marked **TBD / open**.
+> Status: BUILT. The push plane, the pull plane, the `MESH` envelope, the
+> proxy-owned seen-set and query ids are all in the tree. Remaining open items
+> are marked **TBD / open**.
 
 [Propagation](./propagation.md) specifies how author-signed **nsite manifests**
 (kinds 15128/35128) + content-addressed blobs spread and survive partitions. This
@@ -12,16 +13,40 @@ relay it can reach is the device's own embedded relay (`ws://localhost:4870`).
 
 The enabling idea is the same one the whole project rests on: **the embedded
 relay is fed by the FIPS mesh, so physical proximity *is* the transport.** A
-plain Nostr client pointed at localhost becomes a nearby-chat client — *if* the
-mesh gossips its events between peers. Today it does not: the general `FanoutSink`
-is a P3 no-op stub and the peer pull is hardcoded to manifest kinds
-([nsite-layer.md §2.1](./nsite-layer.md), [propagation.md](./propagation.md)).
-This is the design for filling that gap.
+plain Nostr client pointed at localhost becomes a nearby-chat client, because the
+mesh gossips its events between peers.
 
-> **Scope.** This is core/native work in `myco-core` + `myco-relay`. The WebView
-> never reaches `.fips` peers; only the native engine does. The nsite is an
-> ordinary Nostr client and is unaware any of this exists — it just sees nearby
-> peers' events appear in its localhost relay.
+> **Scope.** Core/native work in `myco-core`. The WebView never reaches `.fips`
+> peers; only the native engine does. The nsite is an ordinary Nostr client and
+> is unaware any of this exists — it just sees nearby peers' events appear in its
+> localhost relay.
+
+---
+
+## 0. Two boundaries that stay plain NIP-01
+
+Everything below sits between two links that must keep speaking stock NIP-01, and
+one link that is ours to shape.
+
+| Link | Protocol | Why |
+| --- | --- | --- |
+| nsite ↔ `ws://localhost:4870` | Plain NIP-01, no Myco verb or key | The in-app client is an ordinary Nostr client |
+| proxy ↔ backing relay | Plain NIP-01 | Lets any relay sit behind Myco |
+| proxy ↔ proxy over `.fips` | Plain NIP-01 **or** a `MESH` envelope (§2) | Nobody else is listening on it |
+
+The Myco-specific code lives in one place: the **mesh relay proxy**
+([`myco-core/src/mesh_relay.rs`](../../myco-core/src/mesh_relay.rs)), which
+serves both the loopback socket and the mesh socket and holds the store behind
+it. The store ([`myco-relay`](../../myco-relay/src/lib.rs)) has no mesh, ttl, or
+circle concepts in it at all.
+
+A `MESH` frame arriving on the **loopback** socket is refused with a `NOTICE`.
+That is boundary 1 enforced rather than assumed, and it is the only route by
+which an nsite could otherwise have asked for extra hops.
+
+If a future change wants to put something Myco-shaped on the loopback socket or
+on the backend link, that is not a tweak to this design — it is a reversal of it.
+Background: [`reference/thinning-custom-relay.md`](../../reference/thinning-custom-relay.md).
 
 ---
 
@@ -32,22 +57,23 @@ makes the whole thing terminate and stay cheap.
 
 ### Plane A — Push (live fan-out)
 
-When a device **originates** an event, or **receives** one via a push frame with
-budget left, it forwards that event to its connected circle peers. This is a
-**live wave**: it ripples outward a bounded number of hops while the event is
-fresh, then stops. It is **`event-ttl`-bounded** (§2–3) and triggered **only** by
-the push path — origination and relayed EVENTs — never by a write landing in the
-relay store (§4, the load-bearing invariant).
+When a device **originates** an event, or **receives** one in a push frame with
+budget left, it forwards that event to its circle peers. This is a **live wave**:
+it ripples outward a bounded number of hops while the event is fresh, then stops.
+It is bounded by the envelope's `ttl` (§2–3) and triggered **only** by the push
+path — origination and relayed `EVENT`s — never by a write landing in the store
+(§4, the load-bearing invariant).
 
 ### Plane B — Pull (backlog reconcile on contact)
 
-When two relays become adjacent (a peer comes into range), the arriving device
-**pulls recent events** directly from that one neighbour — the last *N* / last
-few minutes for the app's kind(s). This is a direct **1-hop** request between two
-now-adjacent relays, so it carries **no `event-ttl`**. It is store-only: pulled
-events are stored for serving and display, and **do not** re-enter the push wave.
-(A multi-hop pull — a TTL-bounded `REQ` flood, **`req-ttl`** — is the read-side
-counterpart, used for *discovery* rather than chat backlog; §7.)
+When a peer comes into range, the arriving device **pulls recent events** from
+that one neighbour — the last *N* / last few minutes for the app's kind(s). This
+is a direct **1-hop** request between two now-adjacent relays, so it carries **no
+mesh metadata**. It is store-only: pulled events are stored for serving and
+display, and **do not** re-enter the push wave.
+
+A **multi-hop** pull also exists — a hop-bounded `REQ` flood used for *discovery*
+rather than chat backlog (§7). It is driven by the core, not by an nsite.
 
 ### Why both
 
@@ -55,95 +81,135 @@ Push gives fast live delivery to the nearby cluster. Pull is what reaches
 everyone push didn't: a device five hops away never receives the live wave, but
 the moment it moves near *anyone* who stored the event, it pulls it directly.
 Physical movement + neighbour catch-up does the long-range work — the way bitchat
-actually spreads — which is exactly why a **short `event-ttl` is fine** (§3).
+actually spreads — which is exactly why a **short hop budget is fine** (§3).
 
 ---
 
-## 2. `event-ttl`: a transient field on the event
+## 2. The `MESH` envelope: hop state beside the message, not inside it
 
-The push hop count is named **`event-ttl`** (Rust `event_ttl`; the read-side
-counterpart is **`req-ttl`**, §7). It is a property of the **live wave, not the
-event**, but it does **not** need a custom frame to carry it. It rides as a
-**non-signed, non-persisted top-level field** on the event, over the standard
-NIP-01 `["EVENT", …]` message:
+The push hop count is a property of the **live wave, not the event**. So it
+travels *beside* the NIP-01 message, in an envelope that wraps it.
 
-```
-["EVENT", {
-  id, pubkey, created_at, kind, tags, content, sig,
-  "event-ttl": 2     // ← NOT in the signed preimage, NOT a tag; read by mesh relays, stripped on store
-}]
+### 2.1 The frame
+
+```jsonc
+["MESH", {"ttl": 2}, ["EVENT", <event>]]
+["MESH", {"ttl": 1, "qid": "…", "budgetMs": 5000}, ["REQ", <sub_id>, <filter>, …]]
 ```
 
-**Signature and id stay intact.** The signed preimage is
-`[0, pubkey, created_at, kind, tags, content]`. `event-ttl` is neither in it nor
-a tag, so `id` (`sha256` of the preimage) and `sig` are unaffected — any client
-verifies the event and simply ignores `event-ttl`. (Putting the hop count in
-`tags` *would* break the signature; a top-level sibling field does not.)
+The inner element is **exactly** what would go on the wire to any relay: the
+event object and every filter object are canonical NIP-01, byte for byte. The
+proxy reads the metadata, decides, and passes the inner element through
+unchanged. Nothing is re-encoded anywhere in the path, so there is nothing to
+strip and nothing to smuggle.
 
-**The relay reads it on receipt, then stores canonical.** A conforming mesh relay
-grabs `event-ttl` for the forward decision (§3), then persists exactly
-`{id, pubkey, created_at, kind, tags, content, sig}` — **never the `event-ttl`**.
-When it forwards to a peer it re-attaches the decremented value on the outgoing
-`["EVENT", …]`. Handling `event-ttl` this way — read on receipt, strip on store,
-re-attach on forward — is **part of the mesh protocol every relay in the mesh
-must implement** (this doc happens to describe the `myco-relay` implementation,
-but any other implementation has to adhere). Both ends of every hop handle the
-field; it is invisible to everything else.
+The wrapper is **verb-agnostic**. `["MESH", meta, <anything NIP-01>]` carries
+`COUNT`, a future `NEG-OPEN`, or anything else without the proxy learning what
+they are, and it is one grep to find every mesh frame in a log.
 
-**Why a field, not a custom envelope.** The relay↔relay link must keep speaking
-standard NIP-01 — the message stays `["EVENT", {...}]`, the verb every relay
-already implements and every stock Nostr tool can read for debugging. A bespoke
-gossip frame would replace that with a non-NIP-01 websocket message: a strictly
-bigger break, for no gain. An unknown top-level field is ignored by anything that
-doesn't care; only mesh relays implementing this protocol act on it.
+The shape lives in
+[`myco-core/src/mesh_wire.rs`](../../myco-core/src/mesh_wire.rs).
 
-**Storage dropping `event-ttl` is the mechanism, not a loss.** Because the field
-is stripped on store, a **pushed** EVENT arrives carrying `event-ttl`
-(forward-eligible), while a **stored** event re-served via `REQ` (backlog/pull,
-§1 Plane B) comes back with **none** — so it is never re-flooded. The push/pull
-split thus enforces itself: this is exactly the §4 invariant, for free. Storing
-an event is the terminal state of a hop ("this fact now lives here"); a wave's
-remaining hop-count is meaningless at rest.
+### 2.2 What the metadata carries
 
-> **Originating `event-ttl`.** A local nsite need not set anything — the
-> originating relay stamps the default (**3**) when a WebView client publishes
-> without one. A client *may* suggest a per-message reach by including the field,
-> subject to the `max-event-ttl` clamp (§3).
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `ttl` | `u8` (omitted when 0) | Remaining forward hops. `0` means store it, do not pass it on. |
+| `qid` | string, optional | Query id for a pull, stamped by the originating proxy so each node serves a given query once (§7). |
+| `budgetMs` | `u32`, optional | Relative time budget for a pull. **Carried but not yet enforced** — every hop currently uses a hardcoded timeout. |
+
+Future fields (a path vector, an origin hint, a rate class) extend the metadata,
+never the inner message.
+
+### 2.3 A plain NIP-01 frame is still valid on the mesh link
+
+`["EVENT", …]` and `["REQ", …]` with no envelope mean "no mesh metadata": store
+it, do not forward it. That is the right default for poking a peer with `nak`
+over `.fips`, and it means an old or foreign relay on the link degrades to
+single-hop rather than misbehaving.
+
+### 2.4 Why not a field on the event (the design this replaced)
+
+This section used to argue the opposite case: that the hop count should ride as a
+**non-signed top-level `event-ttl` key added to the event object**, with a
+matching `req-ttl` key added to a **filter object** inside a `REQ`.
+
+The argument's technical premise was correct and is not why it was dropped. The
+signed preimage is `[0, pubkey, created_at, kind, tags, content]`, so an extra
+top-level sibling key leaves `id` and `sig` verifying fine. Three other problems
+sank it:
+
+- **Every relay in the mesh had to implement Myco's protocol.** Read on receipt,
+  strip on store, re-attach on forward was a mesh-wide requirement. That is
+  exactly the requirement we wanted to drop, because it is what stopped Citrine,
+  strfry, or nostr-rs-relay sitting behind Myco.
+- **Correctness depended on backend behaviour we do not control.** A relay that
+  round-tripped unknown top-level keys would store and re-serve `event-ttl`,
+  restarting a wave that should have ended.
+- **`req-ttl` travelled through the query language.** A backend that ignores
+  unknown filter keys is harmless; one that reads them as a tag constraint
+  silently returns nothing. Either way, routing state was riding inside a filter.
+
+The envelope keeps the useful half — the hop count is still outside anything
+signed or stored — and concentrates the fork on the one link where it costs
+nothing.
+
+### 2.5 Why a wrapper and not new verbs
+
+An earlier draft used flat `MESH-EVENT` and `MESH-REQ` verbs. With those, the
+proxy has to take apart and rebuild every message type it knows, so each new verb
+means new proxy code and another chance to mangle a filter. The wrapper forwards
+anything NIP-01 without knowing what it is.
+
+Two other shapes were rejected:
+
+- **Trailing metadata on a stock verb**, e.g. `["EVENT", ev, {"ttl":2}]` — the
+  `REQ` version is ambiguous with a filter, and metadata placed before the
+  filters reads to any relay as a match-everything filter.
+- **A per-connection ttl handshake** — stateful, and wrong as soon as one socket
+  carries waves at different depths.
+
+### 2.6 Originating hop budget
+
+A local nsite sets nothing, and **cannot** set anything: it may not send a `MESH`
+frame, so its publishes always originate at the gossiper's default (**3**,
+`DEFAULT_EVENT_TTL` in [`gossip.rs`](../../myco-core/src/gossip.rs)). A single
+message key must never change a message's cost by orders of magnitude, so
+per-message reach is not a client-facing knob.
 
 ---
 
 ## 3. Forward rule
 
-On receiving a publish-form `["EVENT", event]` that carries an `event-ttl` (a
-live push; a `REQ`-response EVENT has none and is pull/backlog, never forwarded):
+On receiving a push frame — an `EVENT` inside a `MESH` envelope, from a mesh peer:
 
-1. **Seen?** If `event.id` is already in my relay store / seen-set → **drop**
-   (store nothing new, forward nothing).
-2. **New?** Store the canonical event (without `event-ttl`), then let
-   `fwd = min(event-ttl, max-event-ttl)`; if `fwd > 0`, send
-   `["EVENT", { …event, "event-ttl": fwd - 1 }]` to **every circle peer except
+1. **Seen?** If `event.id` is already in the proxy's seen-set → store it anyway
+   (storing is idempotent) but **forward nothing**.
+2. **New?** Store it, fan it to this device's live subscriptions, then let
+   `fwd = min(meta.ttl, MAX_EVENT_TTL, peer_clamp)`. If `fwd > 0`, send
+   `["MESH", {"ttl": fwd - 1}, ["EVENT", event]]` to **every circle peer except
    the sender** (split-horizon).
 
-Two knobs, distinct:
+A `REQ` response is not a push frame and never triggers step 2. Neither does a
+plain `["EVENT", …]` with no envelope, which arrives with no budget.
 
-- **Originating `event-ttl`** — how far *my own* events travel; the originator
-  stamps it. Proposed default **3** (experimental).
-- **`max-event-ttl`** — a clamp on forwarding, so a misbehaving peer can't send
-  `event-ttl: 255` and turn this device into a flood amplifier. "The max I will
-  honour." Set to the originate default (**3**) so own-origin waves aren't clamped
-  by neighbours. (This is also the per-nsite permission knob — §7.)
+### The knobs
 
-### Loop safety is the seen-set, not the `event-ttl`
+| Knob | Value | Meaning |
+| --- | --- | --- |
+| Originating ttl | **3** | How far *my own* events travel. The originator stamps it. |
+| `MAX_EVENT_TTL` | **3** | Clamp on forwarding, so a peer sending `ttl: 255` cannot turn this device into an amplifier. Set to the originate default so own-origin waves aren't clamped by neighbours. |
+| `relay_write_multihop` | per peer, default **on** | A per-peer clamp. Off means an inbound event's budget is treated as 0: store it, show it, never pass it on. See [nsite-permissions.md](./nsite-permissions.md). |
+
+### Loop safety is the seen-set, not the hop budget
 
 A Nostr `id` is content-derived and **stable**: re-broadcasting a signed event is
 idempotent — every device, any number of hops away, computes the same id. So each
 device forwards each id **at most once**, and the flood **always terminates**,
-even with `event-ttl` set arbitrarily high. It bounds only **reach and cost**; it
-is not a loop guard. (This is the seen-set + hop-budget pattern already specified for
-manifest fan-out in [nsite-layer.md §2.1](./nsite-layer.md), generalized here to
-app events.)
+even with `ttl` set arbitrarily high. The budget bounds only **reach and cost**;
+it is not a loop guard.
 
-### Worked example — originating `event-ttl` = 3 (= forwards still allowed)
+### Worked example — originating ttl = 3
 
 ```
 A (origin) ─ttl3─▶ B ─ttl2─▶ C ─ttl1─▶ D ─ttl0─▶ E
@@ -158,27 +224,53 @@ Plane B when they next come into range.
 ## 4. The load-bearing invariant
 
 > **A stored event never re-enters the push flood. Push is triggered by a
-> publish-form EVENT carrying `event-ttl > 0` — origination, or a forwarded hop —
+> publish-form EVENT carrying `ttl > 0` — origination, or a forwarded hop —
 > never by a write landing in the relay store.**
 
-This is what the §2 strip-on-store mechanism buys: forwarding keys off the
-`event-ttl` that rode in on the live `["EVENT", …]`, and a stored event has none.
+### What enforces it
 
-The naive propagator ("subscribe to the relay, fan out on every new event")
-breaks here. With it, Plane B bites you: a device that comes into range and pulls
-the last 21 messages would store them — and a store-triggered push would kick off
-a **fresh wave for old messages, with a fresh `event-ttl`, every time someone new
-arrives**. The seen-set stops infinite loops, but you still get pointless
-re-flood churn — worse once a peer has GC'd an id at expiry (§5) and sees it as
-"new" again.
+The proxy keeps its **own seen-set** of event ids and consults it *before* the
+store is touched. Storing happens either way; only a **first sighting** fans out.
+So the trigger for push is the proxy's own novelty judgement about an inbound
+push frame, not anything the store reports.
 
-Keeping `event-ttl` *only* on the live push EVENT, and making store-insertion
-**not** a push trigger, is what cleanly separates the two planes. Note this diverges from
-the manifest propagator's store-triggered fanout described in
-[nsite-layer.md §2.1](./nsite-layer.md): manifests are replaceable and rare, so
-re-emitting on store is cheap and desirable; high-rate ephemeral app events are
-not, so their push must be `event-ttl`-driven. **A gossiped event kind is therefore a
-distinct path from manifest fanout, not the same code.**
+This replaces the earlier mechanism, which leaned on strip-on-store: a pushed
+`EVENT` carried `event-ttl` and a stored one came back without it, so the split
+enforced itself. That worked, but it made a correctness property depend on the
+backend faithfully dropping an unknown key.
+
+### The naive propagator still breaks
+
+"Subscribe to the relay, fan out on every new event" fails here. Plane B bites
+you: a device that comes into range and pulls the last 21 messages would store
+them, and a store-triggered push would kick off a **fresh wave for old messages,
+with a fresh budget, every time someone new arrives**.
+
+### The seen-set also fixes the churn this section used to warn about
+
+The old text noted that the problem gets worse once a peer has GC'd an id at
+expiry (§5) and sees it as "new" again. That was a real hole in the store-based
+version: storage answers "do I hold this?", which is a different question from "have
+I handled this?". An id GC'd at NIP-40 expiry looks new to the store on the next
+pull.
+
+The proxy's seen-set has its own retention, independent of what the store keeps:
+
+| Case | Remembered until |
+| --- | --- |
+| Event with a NIP-40 `expiration` | Its own expiry |
+| Event with no expiry (e.g. a manifest) | 30 minutes |
+| Either, minimum | 60 seconds — so an already-stale arrival still cannot be re-forwarded at every hop |
+
+Bounded at 4096 ids, oldest evicted first. Novelty is a property of this node's
+history, so this node keeps it.
+
+### Manifests are the same plane, a different policy
+
+Manifest kinds (15128/35128) travel this same push plane, but with an
+interest-aware download-then-forward policy and an active-version gate rather
+than the plain forward rule above. See
+[nsite-updates.md §4](./nsite-updates.md).
 
 ---
 
@@ -186,67 +278,120 @@ distinct path from manifest fanout, not the same code.**
 
 The driving consumer, `myco-bitchat`, makes events **expire** (NIP-40
 `["expiration", <ts>]`, +10 min) and shows a new arrival only the last ~21. For
-that to hold, `myco-relay` must **GC events past their `expiration` tag**, so the
-store stays small, the Plane-B backlog stays bounded, and the room is genuinely
-ephemeral. Expiry also bounds the seen-set: ids age out with their events, so
-memory is naturally capped. (An event re-pulled after its own expiry is simply
-gone — there is nothing to re-serve, which is the intended behaviour.)
+that to hold, the store **GCs events past their `expiration` tag**, so the store
+stays small, the Plane-B backlog stays bounded, and the room is genuinely
+ephemeral. An event re-pulled after its own expiry is simply gone — there is
+nothing to re-serve, which is the intended behaviour.
+
+Expiry also bounds the seen-set: an expiring event's id is remembered exactly
+until it expires (§4), so memory is naturally capped. Note that this is now a
+*coincidence of retention policy*, not a dependency — the seen-set caps itself,
+and NIP-40 GC is not something an arbitrary backend guarantees.
 
 ---
 
-## 6. Phasing
+## 6. What shipped
 
-- **P1 — circle fan-out, 1 hop.** Generalize the stubbed `FanoutSink` to gossip
-  published app events — v1 default **all kinds** except the manifest kinds
-  15128/35128, which keep their own store-triggered path (§4) — to direct circle
-  peers on origination/receipt. Ignore `event-ttl` (treat as 1). Turns the client
-  from a local toy into real two-device nearby chat.
-- **P2 — multi-hop flood.** Carry `event-ttl` as a transient event field (§2),
-  add the §3 forward rule (seen-set + split-horizon + clamp), decrement per hop.
-- **P3 — Plane B pull.** Backlog reconcile on peer contact (`{kinds, since}` or
-  piggyback the negentropy reconcile already planned for manifests,
-  [nsite-layer.md §2.4](./nsite-layer.md)), store-only.
+- **Circle fan-out.** Published app events are gossiped to circle peers — v1
+  default **all kinds** except the manifest kinds 15128/35128, which take the
+  interest-aware path (§4).
+- **Multi-hop flood.** The `MESH` envelope (§2), the §3 forward rule (seen-set +
+  split-horizon + clamp), decrementing per hop.
+- **Multi-hop pull.** Hop budget, mandatory query id, and a carried time budget
+  on the `REQ` side (§7), driven by the core rather than by a client.
+- **Per-peer clamps.** `relay_write_multihop` and `relay_read_multihop` turn
+  `MAX_EVENT_TTL` and `MAX_REQ_TTL` into per-peer values.
+
+Still to come: **Plane B backlog reconcile on peer contact** as a first-class
+step (`{kinds, since}`, or piggybacking the negentropy reconcile planned for
+manifests, [nsite-layer.md §2.4](./nsite-layer.md)). Today a reappearing peer is
+caught up by replaying open local subscriptions against it, which covers the
+common case but is not the same as a reconcile.
 
 ---
 
 ## 7. Decisions and open questions
 
-**Decided — gossip eligibility is per-application.** Which kinds an nsite may
-fan out is a **per-application permission**, enforced by mapping the WebSocket
-`Origin` → siteKey → permission record. **v1 default: all kinds**, with the
-default `event-ttl` (3) / `req-ttl` (2) as per-app clamps and lenient rate
-limits — i.e. default-allow, no prompts. The Android-style request/grant flow
-comes later. Full model: [nsite-permissions.md](./nsite-permissions.md).
+### Decided — the pull plane is core-driven
 
-**Decided — rate limits start lenient.** Sane per-`Origin` caps that stop a
-runaway app from saturating a BLE link without throttling normal chat; slow-down
-over hard-fail. Starting numbers in [nsite-permissions.md §4](./nsite-permissions.md).
+A `REQ` from a **loopback** client returns its stored backlog and `EOSE` at
+local-store speed and **never** fans out. That removes the multi-second hang a
+client used to see when one peer was slow.
 
-Still open:
+Multi-hop pull is a **core** operation instead — discovery ("nsites around me")
+and update checks call the peer pool directly and write results into polled
+state. The proxy keeps only the forwarding half, for a `REQ` that arrives from a
+mesh peer with hops left. If an nsite ever needs transitive reach, it gets an
+explicit API rather than a magic filter key.
 
-- **Best-`event-ttl` re-forward.** If the same id arrives first with a low
-  `event-ttl` (not forwarded) then later via a shorter path with a higher one,
-  the seen-set says "already handled" and the device under-propagates slightly.
-  "Remember the best seen and re-forward the improvement" is a refinement; for v1
-  we accept the minor under-reach (Plane B covers it). **TBD / open.**
-- **`req-ttl` — multi-hop pull / discovery.** The read-side counterpart of
-  `event-ttl`: a `REQ` carrying a `req-ttl` floods the *query* outward, each relay
-  answering from its store and forwarding the decremented `REQ` to peers, results
-  merged back — the natural mechanism for **transitive discovery** ("nsites around
-  me," rooms/people nearby, [nsite-layer.md §6](./nsite-layer.md)'s `SearchNsites`
-  "transitive reach"). **Reconciliation is negentropy ([NIP-77](https://github.com/nostr-protocol/nips/blob/master/77.md))**,
-  not blind re-pulls — the same set-reconciliation the manifest sync uses
-  ([nsite-layer.md §2.4](./nsite-layer.md)), so a hop settles "what do you have
-  that I don't" in ~log bandwidth. It is **heavier than the push flood** (responses
-  routed back, a separate query-id seen-set, result merge/dedup — the Gnutella
-  cost), so it is a discovery feature, P3+, not v1 chat backlog. Default `req-ttl`
-  **2** (experimental), below `event-ttl` (3) because flooded reads cost more.
-  **TBD / open.**
+`MAX_REQ_TTL` is **2**, below the push default of 3, because flooded reads cost
+more. A peer's `relay_read_multihop` clamps it to 0 for that peer.
+
+### Decided — a query id is mandatory on a pull
+
+Split-horizon on the immediate sender is not a loop guard on a graph. A circle is
+not a tree, so the same query arrives by several paths and would be re-fanned
+every time. Event-id dedup at merge hides that in the *results* while the cost has
+already been paid: at ttl 2 across a circle of 10, roughly 110 `REQ`s over BLE
+for one query.
+
+The originating proxy stamps a random `qid`, forwarded copies carry the same one,
+and each node **serves a given query once** — it still answers from its own
+store, but does not fan it out again. This is also the amplification bound:
+without it, one peer's `REQ` makes us issue N. Bounded at 512 remembered ids,
+FIFO.
+
+### Decided — carry a relative budget, do not compose deadlines
+
+`budgetMs` is **relative**, never a wall-clock deadline, because mesh clocks are
+not synced. Each hop is meant to spend about 60% of what it received on the hop
+below and keep the rest to receive and relay, so a depth-2 peer is not squeezed
+inside its parent's timeout.
+
+**Not yet enforced.** The field is stamped, decayed per hop, and carried, but
+every hop still applies a hardcoded timeout. Enforcement is a separate change.
+
+### Decided — the recursion stays synchronous for now
+
+No per-query routing table. With `EOSE` unblocked, a slow deep hop costs a
+truncated result set rather than a hung client, which is an acceptable trade at
+`MAX_REQ_TTL = 2`. Full asynchronous response routing — responses flowing back
+tagged by query id, each hop relaying toward the requester — stays deferred until
+multi-hop pull has a user that justifies the routing state and its expiry rules.
+
+### Decided — gossip eligibility is per-application
+
+Which kinds an nsite may fan out is a **per-application permission**, to be
+enforced by mapping the WebSocket `Origin` → siteKey → permission record. **v1
+default: all kinds**, with the protocol hop budgets as per-app clamps and lenient
+rate limits — default-allow, no prompts. The Android-style request/grant flow
+comes later. Full model: [nsite-permissions.md](./nsite-permissions.md), which is
+still a proposal: the per-app record and the `Origin` mapping are not built yet.
+
+### Decided — rate limits start lenient
+
+Sane per-`Origin` caps that stop a runaway app from saturating a BLE link without
+throttling normal chat; slow-down over hard-fail. Starting numbers in
+[nsite-permissions.md §4](./nsite-permissions.md).
+
+### Still open
+
+- **Best-ttl re-forward.** If the same id arrives first with a low `ttl` (not
+  forwarded) then later via a shorter path with a higher one, the seen-set says
+  "already handled" and the device under-propagates slightly. "Remember the best
+  seen and re-forward the improvement" is a refinement; for v1 we accept the
+  minor under-reach (Plane B covers it). **TBD / open.**
+- **Negentropy reconcile.** [NIP-77](https://github.com/nostr-protocol/nips/blob/master/77.md)
+  would settle "what do you have that I don't" in ~log bandwidth, replacing blind
+  re-pulls on the pull plane and in manifest sync
+  ([nsite-layer.md §2.4](./nsite-layer.md)). Not implemented, and an external
+  relay backend may or may not support it — capability detection is a future
+  step. **TBD / open.**
 - **Closest / fastest source selection.** When several reachable peers hold the
   wanted events, prefer the nearer / faster one (and possibly pull different
-  slices from different holders in parallel — the data is content-addressed/
+  slices from different holders in parallel — the data is content-addressed /
   self-authenticating, so any holder will do). Overlaps the multi-source open
-  question in [nsite-layer.md §5.2](./nsite-layer.md). Likely future. **TBD / open.**
+  question in [nsite-layer.md §5.2](./nsite-layer.md). **TBD / open.**
 
 ---
 
@@ -254,9 +399,13 @@ Still open:
 
 - [./propagation.md](./propagation.md) — manifest + blob propagation, the
   store-and-forward layer, source discovery.
-- [./nsite-layer.md](./nsite-layer.md) — embedded relay/Blossom/gateway, the
-  manifest fanout + negentropy this generalizes (§2.1, §2.4).
-- [./nsite-permissions.md](./nsite-permissions.md) — the per-application
-  capability model that gates fan-out (gossip-kinds, TTL clamps, rate).
+- [./nsite-layer.md](./nsite-layer.md) — the relay/blob backends, gateway, and
+  the negentropy reconcile this would use (§2.1, §2.2, §2.4).
+- [./nsite-permissions.md](./nsite-permissions.md) — the per-peer permissions
+  that clamp these planes, and the proposed per-application capability model.
+- [./identity-pairing.md](./identity-pairing.md) — pairing, which no longer
+  travels on this plane at all.
+- [../../reference/thinning-custom-relay.md](../../reference/thinning-custom-relay.md) —
+  why the envelope, the seen-set, and the auth plane are shaped this way.
 - [../../myco-bitchat/README.md](../../myco-bitchat/README.md) — the in-app Nostr
   chat client that consumes this.

--- a/docs/design/event-gossip.md
+++ b/docs/design/event-gossip.md
@@ -116,7 +116,7 @@ The shape lives in
 | --- | --- | --- |
 | `ttl` | `u8` (omitted when 0) | Remaining forward hops. `0` means store it, do not pass it on. |
 | `qid` | string, optional | Query id for a pull, stamped by the originating proxy so each node serves a given query once (§7). |
-| `budgetMs` | `u32`, optional | Relative time budget for a pull. **Carried but not yet enforced** — every hop currently uses a hardcoded timeout. |
+| `budgetMs` | `u32`, optional | Relative time budget for a pull. A forwarded hop waits no longer than the budget that arrived (§7). |
 
 Future fields (a path vector, an origin hint, a rate class) extend the metadata,
 never the inner message.
@@ -344,12 +344,27 @@ FIFO.
 ### Decided — carry a relative budget, do not compose deadlines
 
 `budgetMs` is **relative**, never a wall-clock deadline, because mesh clocks are
-not synced. Each hop is meant to spend about 60% of what it received on the hop
-below and keep the rest to receive and relay, so a depth-2 peer is not squeezed
-inside its parent's timeout.
+not synced. The originator stamps 10 s; each hop passes on about 60% of what it
+received and keeps the rest to receive and relay.
 
-**Not yet enforced.** The field is stamped, decayed per hop, and carried, but
-every hop still applies a hardcoded timeout. Enforcement is a separate change.
+**A forwarded hop waits `min(budget, fallback)`.** Without that the field was
+decorative: every hop applied its own fixed 8 s, so each hop's window started
+fresh *inside* its parent's and a peer two hops out that honestly used most of
+its time answered after the hop above had already given up.
+
+Three properties fall out:
+
+- **Hop windows nest, they do not add up.** Each hop must allow strictly less
+  than the one above it, which is what makes a wave terminate.
+- **A peer cannot extend us.** A large incoming budget is clamped to our own
+  fallback (8 s).
+- **A floor of 1.5 s.** A budget worn down by several hops still leaves time for
+  a BLE connect. A peer that sends no budget at all falls back to the fixed
+  timeout.
+
+The budget only bounds how long a node holds query state. Late results are not an
+error; they stream to whoever is still listening, and a node whose budget has
+expired drops them.
 
 ### Decided — the recursion stays synchronous for now
 
@@ -372,7 +387,7 @@ still a proposal: the per-app record and the `Origin` mapping are not built yet.
 
 Sane per-`Origin` caps that stop a runaway app from saturating a BLE link without
 throttling normal chat; slow-down over hard-fail. Starting numbers in
-[nsite-permissions.md §4](./nsite-permissions.md).
+[nsite-permissions.md §5](./nsite-permissions.md).
 
 ### Still open
 

--- a/docs/design/identity-pairing.md
+++ b/docs/design/identity-pairing.md
@@ -17,7 +17,7 @@ content source and how that reach goes transitive), [security.md](./security.md)
 does not authorize).
 
 > **Where pairing lives now.** Pairing is **not** relay traffic. It has its own
-> service, `POST /pair` on `:4871` (§6.2), and it is the only port an unpaired
+> service, `POST /pair` on `:4873` (§6.2), and it is the only port an unpaired
 > device can reach. The content ports — `:4870` relay, `:24243` Blossom — require
 > circle membership with no exceptions. The handshake events and their signatures
 > are unchanged; only where they land changed.
@@ -206,7 +206,7 @@ When you scan a peer's `myco://pair/<base64>` (or open the deep link), the app:
 1. Decodes and validates the npub, memorable name, and `pairSecret`.
 2. Derives `node_addr` and the `fd00::` ULA from the npub (§1) — no network call.
 3. **Initiates the mandatory handshake** against the inviter's on-device pairing
-   endpoint — `POST http://<npub>.fips:4871/pair` (§6.1): echoes `pairSecret` back
+   endpoint — `POST http://<npub>.fips:4873/pair` (§6.1): echoes `pairSecret` back
    over that Noise-encrypted channel, the inviter matches it and confirms.
 4. On a completed handshake, adds two sources to your source set, addressed
    deterministically:
@@ -263,7 +263,7 @@ mesh), so no public relay is required.
    The `pairSecret` is a **long random string** (≈256 bits), **single-use**, and
    optionally **TTL-bounded**.
 2. **B scans once** and posts to **A's pairing endpoint at
-   `http://<npub_A>.fips:4871/pair`** — an **on-device** service, no third party
+   `http://<npub_A>.fips:4873/pair`** — an **on-device** service, no third party
    (§6.2). That channel is already **Noise-XK encrypted and authenticated to A's
    device key** (§1), so B is talking to the real A in confidence. B simply
    **echoes the `pairSecret` back** over it, along with `{npub_B, name}`. No
@@ -311,7 +311,7 @@ pulled eagerly or on demand are propagation concerns — see
 15128 / 35128) flood with a default budget of 3 hops, while the large blobs stay
 pull-only (fetched only when a site is opened).
 
-### 6.2 Where the handshake lands: the auth service on `:4871`
+### 6.2 Where the handshake lands: the auth service on `:4873`
 
 The handshake events and their signatures are unchanged. What changed is where
 they stop.
@@ -325,7 +325,7 @@ Storing it was incidental — nothing ever read those kinds back.
 **Now.** Pairing terminates at its own small HTTP service:
 
 ```
-POST http://<npub>.fips:4871/pair    body: a signed pair event (9101 / 9102 / 9103)
+POST http://<npub>.fips:4873/pair    body: a signed pair event (9101 / 9102 / 9103)
   → 200 {"status":"paired"}      an accept, processed — they are in our circle
   → 200 {"status":"unpaired"}    a remove, processed
   → 202 {"status":"pending"}     a request, waiting on the user
@@ -342,7 +342,7 @@ signed Nostr event because the **signature is the pairing identity proof**.
 | --- | --- |
 | **No stranger writes into the store** | Pairing events are never stored now. With a swappable relay behind us, an incidental write would have handed a stranger a write path into a store we do not own. |
 | **The content ports have no exceptions** | `:4870` and `:24243` require circle membership, checked **before** the WebSocket upgrade. The relay refuses the pairing kinds from *every* source, paired or not. |
-| **One unauthenticated surface** | `:4871` is the only port an unpaired device can reach, so hardening and rate limiting have a single address. |
+| **One unauthenticated surface** | `:4873` is the only port an unpaired device can reach, so hardening and rate limiting have a single address. |
 | **Bootstrap survives a broken content plane** | Relay port taken, backend down or misconfigured — two phones can still pair, which is the one operation that could repair the situation. |
 | **Honest acknowledgements** | HTTP status separates *delivered, waiting on them* from *never reached them*. The old retry loop re-sent 15 times because a relay `OK true` only meant "received"; a `202` now stops it. |
 
@@ -377,7 +377,7 @@ ban that costs a mesh peer anything to replace.
 
 #### Port
 
-`:4871` is a Myco constant, not negotiated: peers agree by running the same
+`:4873` is a Myco constant, not negotiated: peers agree by running the same
 version. That is fine pre-1.0, where a change here is a version bump rather than
 a compatibility problem.
 
@@ -438,7 +438,7 @@ held to the phone is read but ignored, never opened.
 **Where the secret lives.** §6.1 framed the `pairSecret` as echoed back inside the
 Noise-encrypted channel to `<npub_A>.fips`. The implementation keeps that property:
 the scanner/tapper posts a signed pair **request** (kind 9101) to
-`<npub_A>.fips:4871/pair` — already Noise-XK encrypted and authenticated to A —
+`<npub_A>.fips:4873/pair` — already Noise-XK encrypted and authenticated to A —
 carrying the secret. What differs from the doc is *who matches it*: A enforces
 single-use locally, via a small persisted ledger of the secrets it has issued. Each
 presented code mints a fresh secret; it is consumed on first accept and the

--- a/docs/design/identity-pairing.md
+++ b/docs/design/identity-pairing.md
@@ -313,6 +313,26 @@ pull-only (fetched only when a site is opened).
 
 ### 6.2 Where the handshake lands: the auth service on `:4873`
 
+#### Two checks before anything is acted on
+
+A valid signature proves **who wrote** an event. It says nothing about who the
+event was *for*, and nothing about whether we wanted it. Both gaps are checked
+explicitly:
+
+- **Addressed to us.** Every pair event names its target in a `p` tag. An event
+  addressed to a third device verifies perfectly when replayed at us, so one
+  captured off the wire would otherwise be usable against anyone.
+- **An accept answers an invite.** A `pair-accept` is only honoured while a
+  matching invite from us is outstanding, and an invite is spent once answered.
+  Without this, anyone could sign an accept and add themselves to the Circle
+  unprompted — which grants relay read/write, blob reads, and multihop
+  forwarding by default.
+
+Invites are persisted, so an accept that arrives after a restart is still
+honoured, and expire after a week so an unanswered one does not remain a
+standing authorisation. A refused event is answered `403`.
+
+
 The handshake events and their signatures are unchanged. What changed is where
 they stop.
 

--- a/docs/design/identity-pairing.md
+++ b/docs/design/identity-pairing.md
@@ -200,8 +200,8 @@ When you scan a peer's `myco://pair/<base64>` (or open the deep link), the app:
 1. Decodes and validates the npub, memorable name, and `pairSecret`.
 2. Derives `node_addr` and the `fd00::` ULA from the npub (§1) — no network call.
 3. **Initiates the mandatory handshake** against the inviter's on-device pairing
-   endpoint at `<npub>.fips` (§6.1): echoes `pairSecret` back over that
-   Noise-encrypted channel, the inviter matches it and confirms.
+   endpoint — `POST http://<npub>.fips:4871/pair` (§6.1): echoes `pairSecret` back
+   over that Noise-encrypted channel, the inviter matches it and confirms.
 4. On a completed handshake, adds two sources to your source set, addressed
    deterministically:
    - relay at `<npub>.fips:4870`
@@ -256,14 +256,14 @@ mesh), so no public relay is required.
    `<npub_A>.fips` is derivable from `npub_A` (§1), so the token carries no address.
    The `pairSecret` is a **long random string** (≈256 bits), **single-use**, and
    optionally **TTL-bounded**.
-2. **B scans once** and opens a connection to **A's pairing endpoint at
-   `<npub_A>.fips`** — an **on-device** endpoint (an FSP port or a channel on the
-   embedded relay; no third party). That channel is already **Noise-XK encrypted and
-   authenticated to A's device key** (§1), so B is talking to the real A in
-   confidence. B simply **echoes the `pairSecret` back** over it, along with
-   `{npub_B, name}`. No key-exchange protocol is needed: because the secret is a long
-   random string, echoing it *inside the encrypted channel* reveals nothing to anyone
-   else and cannot be guessed.
+2. **B scans once** and posts to **A's pairing endpoint at
+   `http://<npub_A>.fips:4871/pair`** — an **on-device** service, no third party
+   (§6.2). That channel is already **Noise-XK encrypted and authenticated to A's
+   device key** (§1), so B is talking to the real A in confidence. B simply
+   **echoes the `pairSecret` back** over it, along with `{npub_B, name}`. No
+   key-exchange protocol is needed: because the secret is a long random string,
+   echoing it *inside the encrypted channel* reveals nothing to anyone else and
+   cannot be guessed.
 3. **A matches the secret** against the one it generated (single-use, not yet
    redeemed) and shows a **confirm prompt** — B's npub + memorable name — that A's
    user taps **OK** to accept. A then **acks** (+ A's memorable name), marks the
@@ -304,6 +304,76 @@ pulled eagerly or on demand are propagation concerns — see
 [propagation.md](./propagation.md). Author-signed manifest events (kinds
 15128 / 35128) flood with a default TTL of 5 hops, while the large blobs stay
 pull-only (fetched only when a site is opened).
+
+### 6.2 Where the handshake lands: the auth service on `:4871`
+
+The handshake events and their signatures are unchanged. What changed is where
+they stop.
+
+**Before.** The three pairing kinds were published to the peer's **relay** port
+as ordinary Nostr events. The relay's access gate whitelisted exactly those kinds
+so an unpaired stranger could publish them and only them, and the event was
+verified, written into the event store, and then handed to the pairing handler.
+Storing it was incidental — nothing ever read those kinds back.
+
+**Now.** Pairing terminates at its own small HTTP service:
+
+```
+POST http://<npub>.fips:4871/pair    body: a signed pair event (9101 / 9102 / 9103)
+  → 200 {"status":"paired"}      an accept, processed — they are in our circle
+  → 200 {"status":"unpaired"}    a remove, processed
+  → 202 {"status":"pending"}     a request, waiting on the user
+  → 403 {"status":"declined"}    bad signature, expired, or not a pairing event
+  → 429 / 503                    rate limited or at capacity
+```
+
+One route, not three: the kind is already in the event. The payload stays a
+signed Nostr event because the **signature is the pairing identity proof**.
+
+#### What this buys
+
+| | |
+| --- | --- |
+| **No stranger writes into the store** | Pairing events are never stored now. With a swappable relay behind us, an incidental write would have handed a stranger a write path into a store we do not own. |
+| **The content ports have no exceptions** | `:4870` and `:24243` require circle membership, checked **before** the WebSocket upgrade. The relay refuses the pairing kinds from *every* source, paired or not. |
+| **One unauthenticated surface** | `:4871` is the only port an unpaired device can reach, so hardening and rate limiting have a single address. |
+| **Bootstrap survives a broken content plane** | Relay port taken, backend down or misconfigured — two phones can still pair, which is the one operation that could repair the situation. |
+| **Honest acknowledgements** | HTTP status separates *delivered, waiting on them* from *never reached them*. The old retry loop re-sent 15 times because a relay `OK true` only meant "received"; a `202` now stops it. |
+
+#### No tokens, no sessions
+
+FIPS addresses are identity-derived and Noise-IK authenticated, so the mesh
+address already **is** the authenticated npub. The service's only output is a
+circle membership commit, which is exactly what the content gates read. A session
+credential would be redundant crypto over an already-authenticated channel.
+
+Membership is committed **before** the reply is sent, so a peer that dials the
+relay the instant it sees a `200` is already admitted.
+
+That reasoning stops holding if Myco ever gates a transport whose addresses are
+not identity-bound. Worth noting; not worth building for.
+
+#### Limits
+
+An open port on a BLE-constrained radio needs its own bounds. In the lenient
+spirit of [nsite-permissions.md](./nsite-permissions.md) — slow down rather than
+hard-fail:
+
+| Limit | Value |
+| --- | --- |
+| Per-source token bucket | 1/s sustained, burst 5 |
+| Global in-flight pair requests | 8 |
+| Body size | 8 KiB |
+
+Failed attempts cost the same as successful ones, with no escalating penalty. A
+source that empties its bucket is delayed, not banned — there is no identity to
+ban that costs a mesh peer anything to replace.
+
+#### Port
+
+`:4871` is a Myco constant, not negotiated: peers agree by running the same
+version. That is fine pre-1.0, where a change here is a version bump rather than
+a compatibility problem.
 
 ### Open questions
 

--- a/docs/design/identity-pairing.md
+++ b/docs/design/identity-pairing.md
@@ -16,6 +16,12 @@ content source and how that reach goes transitive), [security.md](./security.md)
 (key storage threat model, self-authenticating data, what a mutual pairing does and
 does not authorize).
 
+> **Where pairing lives now.** Pairing is **not** relay traffic. It has its own
+> service, `POST /pair` on `:4871` (§6.2), and it is the only port an unpaired
+> device can reach. The content ports — `:4870` relay, `:24243` Blossom — require
+> circle membership with no exceptions. The handshake events and their signatures
+> are unchanged; only where they land changed.
+
 ## 1. One device identity = three derived forms
 
 Myco reuses the FIPS unification: a single Nostr keypair is the **device
@@ -302,7 +308,7 @@ Once mutually paired:
 How the poll is carried, how often, scope/TTL, and whether Carl's content is
 pulled eagerly or on demand are propagation concerns — see
 [propagation.md](./propagation.md). Author-signed manifest events (kinds
-15128 / 35128) flood with a default TTL of 5 hops, while the large blobs stay
+15128 / 35128) flood with a default budget of 3 hops, while the large blobs stay
 pull-only (fetched only when a site is opened).
 
 ### 6.2 Where the handshake lands: the auth service on `:4871`
@@ -431,12 +437,12 @@ held to the phone is read but ignored, never opened.
 
 **Where the secret lives.** §6.1 framed the `pairSecret` as echoed back inside the
 Noise-encrypted channel to `<npub_A>.fips`. The implementation keeps that property:
-the scanner/tapper sends a signed pair **request** (kind 9101) to
-`<npub_A>.fips:4870` — already Noise-XK encrypted and authenticated to A — carrying
-the secret. What differs from the doc is *who matches it*: A enforces single-use
-locally, via a small persisted ledger of the secrets it has issued. Each presented
-code mints a fresh secret; it is consumed on first accept and the presented payload
-rotates, so a captured QR/tag can't pair twice.
+the scanner/tapper posts a signed pair **request** (kind 9101) to
+`<npub_A>.fips:4871/pair` — already Noise-XK encrypted and authenticated to A —
+carrying the secret. What differs from the doc is *who matches it*: A enforces
+single-use locally, via a small persisted ledger of the secrets it has issued. Each
+presented code mints a fresh secret; it is consumed on first accept and the
+presented payload rotates, so a captured QR/tag can't pair twice.
 
 **Auto-accept scope.** A request auto-accepts only while A is actively presenting
 (on the Circle tab) and the secret matches a live issued one. A request that
@@ -444,11 +450,16 @@ arrives otherwise — A on another screen, or Myco launched by the tap — surfa
 accept/ignore prompt instead, keeping the §6.1 human-in-the-loop confirmation.
 
 **Unpairing (partially answers the open question above).** Forgetting a peer now
-sends a signed **pair-remove** event (kind 9103) to their relay; on receipt they
-drop the sender from their Circle, so the two sides stay symmetric. It is
-best-effort and fire-once — an offline peer is not retried, so their Circle keeps a
-stale entry until they forget us or we re-pair. A durable (queue + ack) handshake
-is left open.
+posts a signed **pair-remove** event (kind 9103) to their auth service; on receipt
+they drop the sender from their Circle, so the two sides stay symmetric. Delivery
+is retried on the same schedule as a request (about a minute), and a `403` from
+the peer stops the loop rather than burning the whole window. A peer that stays
+offline for the whole window keeps a stale entry until they forget us or we
+re-pair. A durable (queue + ack) handshake is left open.
+
+**Revocation reaches open connections.** Because admission to the content ports is
+checked once, at the WebSocket upgrade, dropping a peer also **closes connections
+they already hold** rather than only blocking the next one.
 
 **NFC exposure.** While presenting, the emulated tag answers *any* NFC reader, not
 just another Myco device, with `{npub, name, pairSecret}`. This is acceptable: the

--- a/docs/design/nsite-layer.md
+++ b/docs/design/nsite-layer.md
@@ -154,13 +154,17 @@ socket is refused with a `NOTICE`.
 
 #### The backend seam
 
-`nsite-deck`'s [`RelayBackend`](../../nsite-deck/src/seams.rs) is the seam. It is
-being re-cut around the verbs every relay already speaks (`publish`, `query` over
-real `nostr::Filter`s, a live `subscribe`), with operations that have no NIP-01
-expression — the selective cache wipe that keeps pinned sites — split into a
-separate admin trait that only the embedded store implements. Where that trait is
-absent, the settings UI should report the operation as unavailable rather than
-silently doing nothing.
+`nsite-deck`'s [`RelayBackend`](../../nsite-deck/src/seams.rs) is the seam, and it
+is cut around the verbs every relay already speaks: `publish`, and `query` over
+real `nostr::Filter`s. Using real filters rather than a hand-rolled subset means
+`since`, `until`, ids, and general tag matching all work, and a remote backend
+needs no translation layer. "Newest event in a replaceable slot" is a helper over
+`query`, not a backend method, because it is an ordinary filter.
+
+Operations with **no NIP-01 expression** — the selective cache wipe that keeps
+pinned sites — live in a separate `AdminBackend` trait that only the embedded
+store implements. Where it is absent, the settings UI should report the operation
+as unavailable rather than silently doing nothing.
 
 **Planned, not built:** a `RemoteBackend` that speaks WebSocket to a configured
 relay URL — [Citrine](https://github.com/greenart7c3/Citrine) on the same device,

--- a/docs/design/nsite-layer.md
+++ b/docs/design/nsite-layer.md
@@ -118,47 +118,83 @@ and the TUN; Rust owns the content layer and the mesh. See
 
 ---
 
-## 2. Proposed Rust implementation
+## 2. The Rust implementation
 
-> Everything in this section is **proposed**, not chosen. Crate names are
-> candidates; the load-bearing requirement is the *behaviour*, not the
+> §2.1 and §2.2 describe what is built. Items marked **planned** or **not built**
+> are still proposals; the load-bearing requirement is the *behaviour*, not the
 > dependency.
 
-### 2.1 Embedded relay
+### 2.1 The relay: a proxy in front of a swappable store
 
-A NIP-01 relay with a local event store, listening on `ws://localhost:4870` — the
-**`myco-relay`** crate, which implements `nsite-deck`'s `RelayBackend` seam.
+Two components, deliberately separated.
+
+**The mesh relay proxy** ([`myco-core/src/mesh_relay.rs`](../../myco-core/src/mesh_relay.rs))
+is the NIP-01 WebSocket front door. It serves the in-app WebView on
+`ws://localhost:4870` and mesh peers on `ws://[fd00::self]:4870`, and it is the
+only Myco-specific code on the content path: origin classification, the gossip
+seen-set, hop-budget stamping and clamping, split-horizon, pull fan-out, live
+subscription mirroring, and the circle access gate all live here.
+
+**The store** ([`myco-relay`](../../myco-relay/src/lib.rs)) is a plain NIP-01
+event store behind it. It holds **no Myco concepts** — no mesh, no ttl, no
+circles — and it has no socket of its own. It is the default backend, not "our
+relay".
+
+#### The two boundaries
+
+| Link | Protocol |
+| --- | --- |
+| nsite ↔ `ws://localhost:4870` | Plain NIP-01. No Myco verb, no Myco key, ever. |
+| proxy ↔ backing store | Plain NIP-01. This is what lets any relay sit there. |
+| proxy ↔ proxy over `.fips` | Plain NIP-01 or a `MESH` envelope ([event-gossip.md §2](./event-gossip.md)) |
+
+Concentrating the Myco-specific behaviour on the one link nobody else listens on
+is what makes the store replaceable. A `MESH` frame arriving on the loopback
+socket is refused with a `NOTICE`.
+
+#### The backend seam
+
+`nsite-deck`'s [`RelayBackend`](../../nsite-deck/src/seams.rs) is the seam. It is
+being re-cut around the verbs every relay already speaks (`publish`, `query` over
+real `nostr::Filter`s, a live `subscribe`), with operations that have no NIP-01
+expression — the selective cache wipe that keeps pinned sites — split into a
+separate admin trait that only the embedded store implements. Where that trait is
+absent, the settings UI should report the operation as unavailable rather than
+silently doing nothing.
+
+**Planned, not built:** a `RemoteBackend` that speaks WebSocket to a configured
+relay URL — [Citrine](https://github.com/greenart7c3/Citrine) on the same device,
+a `strfry` or `nostr-rs-relay` on the LAN — plus the settings field that selects
+it. Today the embedded store is the only implementation. Two things the settings
+screen will have to say when a custom backend is configured:
+
+- **We stop verifying what comes back out.** Signatures are checked once, at
+  ingress; reads from the backend are trusted because NIP-01 already requires a
+  relay to verify what it accepts. Pointing Myco at someone else's relay means
+  trusting that relay, and any other writer it has.
+- **NIP-40 expiry is not guaranteed.** The proxy drops expired events on the way
+  out; unbounded growth inside someone else's relay is their operator's problem.
+
 The Go reference uses [Khatru](https://github.com/fiatjaf/khatru) over a BoltDB
 event store and advertises NIPs 1, 9, 11, 12, 15, 16, 20, 33
-([embedded.go](../../reference/site-deck/internal/relay/embedded.go)). The Rust
-port needs the same minimal surface: accept `EVENT`, answer `REQ` with a stored
-event set, honour `CLOSE`, and serve a NIP-11 document — plus, net-new vs. the Go
-reference, speak **negentropy ([NIP-77](https://github.com/nostr-protocol/nips/blob/master/77.md))**
-(`NEG-OPEN` / `NEG-MSG` / `NEG-CLOSE`) for set reconciliation (§2.4) and advertise
-NIP-77 in its NIP-11.
+([embedded.go](../../reference/site-deck/internal/relay/embedded.go)). Still
+wanted, net-new vs. the Go reference: **negentropy
+([NIP-77](https://github.com/nostr-protocol/nips/blob/master/77.md))**
+(`NEG-OPEN` / `NEG-MSG` / `NEG-CLOSE`) for set reconciliation (§2.4), which for an
+external backend becomes a capability to detect rather than something we can
+assume.
 
-**Embedded from day one — relay *backend* is a pluggable seam.** The relay and
-Blossom are both **bundled and in-process from day one**; they are simple enough
-that there is no "forward to an external relay first, embed later" phase. The
-relay *backend*, however, is a **pluggable seam** (the `RelayBackend` trait): the **default** is the
-embedded store described here; an **optional** backend **forwards to a local
-relay app on the device — e.g. [Citrine](https://github.com/greenart7c3/Citrine)** —
-for developers who already run one. The embedded backend is the default and the
-earliest path; forwarding is a configuration choice on top of it, not a
-prerequisite. (Blossom has no such seam — see §2.2.)
+**Patterns in use:**
 
-**Proposed candidates / patterns:**
-
-- An `nostr-rs-relay`-style store: a SQLite (or redb) backed event store with a
-  filter index over `kind`, `authors`, and `#d`. The query surface the gateway
-  and sync engine actually use is tiny — `{kinds, authors, #d, limit}` — so a
-  hand-rolled store over `rusqlite` is viable and avoids pulling a full relay
-  framework.
-- The [`nostr` / `nostr-sdk`](https://github.com/rust-nostr/nostr) crates for
-  event types, signature verification, NIP-19 (`npub`) encode/decode, and the
-  relay-message wire format.
-- An `axum` (or `tower`) WebSocket handler for the relay socket and the Blossom
-  HTTP routes, sharing one Tokio runtime with the FIPS endpoint.
+- A hand-rolled store over the [`nostr`](https://github.com/rust-nostr/nostr)
+  crate's `Event` type, keyed by event id, with replaceable/addressable slot
+  dedup, NIP-40 expiry GC, and JSON persistence of the non-expiring (manifest)
+  set. Ephemeral chat is memory-only by design. A SQLite- or redb-backed index is
+  the obvious upgrade if the store ever outgrows this.
+- The same `nostr` crate for signature verification, NIP-19 (`npub`)
+  encode/decode, and the relay-message wire format.
+- `axum` handlers for the proxy's WebSocket sockets, the Blossom HTTP routes, and
+  the auth service, all sharing one Tokio runtime with the FIPS endpoint.
 
 **Replaceable-event semantics matter.** Kind `15128` is replaceable (one per
 pubkey); kind `35128` is parameterized-replaceable (one per `(pubkey, d-tag)`).
@@ -166,41 +202,34 @@ The store MUST keep only the newest event per slot, matching the dedup the Go
 sync does by `(kind, d-tag)`
 ([service.go `deduplicateManifests`](../../reference/site-deck/internal/sync/service.go)).
 
-**Propagator fanout (multiplex to connected peers).** The embedded relay is a
-**plain NIP-01 store + socket** — it never fans out. Fanout is done by a separate
-**propagator process inside `nsite-deck`**: it **subscribes** to the relevant
-relays (the local relay plus every connected peer's relay) and, when a new Nostr
-manifest arrives — whether pushed in by a peer or pulled in by the sync engine —
-it **publishes that event to every other connected peer** (an `["EVENT", …]` to
-each `<peer>.fips:4870`), excluding the peer it came from. This is what makes the
-"announce widely" half of propagation push-based and automatic instead of a
-flood the app has to orchestrate (see [./propagation.md §2](./propagation.md)).
-Constraints:
+**Fanout to connected peers.** The store never fans out. Fanout is the proxy's
+gossiper: when an event is accepted for the first time, it is published onward to
+every circle peer except the one it came from, as a `MESH`-wrapped `["EVENT", …]`
+to each `<peer>.fips:4870`. This is what makes the "announce widely" half of
+propagation push-based and automatic instead of a flood the app has to
+orchestrate (see [./propagation.md §2](./propagation.md)). Constraints:
 
 - **Events fan out; blobs do not.** Only Nostr events (in practice the small,
   self-authenticating manifests) are multiplexed. Blossom blobs are *not* events
   and stay **pull-only** — fanning megabytes to N peers would saturate a BLE
   link.
-- **Source-excluded + de-duplicated.** A seen-set keyed by the 16-byte
-  SHA-256 event id (and a hop budget, default TTL 5) prevents echoing an event
-  back to its sender or re-flooding one already forwarded. Same dedup the
-  propagation layer uses ([./propagation.md §5](./propagation.md)).
-- **Re-emitted unmodified.** Forwarded events keep the author's signature intact;
-  the propagator never re-signs. Forwarding an already-signed event is normal
-  publish behaviour, not authoring.
+- **Source-excluded + de-duplicated.** The proxy's own seen-set, keyed by event
+  id, plus a hop budget (default 3) prevents echoing an event back to its sender
+  or re-flooding one already forwarded. The seen-set is the proxy's, **not** the
+  store's, so an id the store GCs at expiry does not look new again
+  ([event-gossip.md §4](./event-gossip.md)).
+- **Re-emitted unmodified.** Forwarded events keep the author's signature intact
+  and are byte-for-byte canonical NIP-01; the hop budget rides beside them in the
+  envelope. Forwarding an already-signed event is normal publish behaviour, not
+  authoring.
 
-This is wanted **early** (roadmap P3 — see [../reference/config.md](../reference/config.md)
-`[propagation] fanout`), so two connected nodes gossip events both ways as soon
-as a FIPS link exists, with the heavier transitive-discovery and scale-dedup
-machinery layered on later (P5). See [diagrams/07-relay-mesh-fanout.svg](diagrams/07-relay-mesh-fanout.svg).
+See [diagrams/07-relay-mesh-fanout.svg](diagrams/07-relay-mesh-fanout.svg).
 
-### 2.2 Embedded Blossom
+### 2.2 Blossom: the same layering, one implementation so far
 
-A content-addressed blob server on `http://localhost:24243` — the **`myco-blossom`**
-crate, implementing the `BlobStore` seam — **always embedded**
-— unlike the relay, Blossom has **no pluggable forward-to-an-app backend**,
-because there is no good Android Blossom app to forward to, so embedding is the
-only sensible path. It implements the
+A content-addressed blob server on `http://localhost:24243` and
+`http://[fd00::self]:24243` — the **`myco-blossom`** crate, implementing
+`nsite-deck`'s `BlobStore` seam. It serves the
 [BUD-01](https://github.com/hzrd149/blossom/blob/master/buds/01.md) surface the
 gateway and sync need:
 
@@ -208,17 +237,41 @@ gateway and sync need:
 - `PUT /upload` → store blob, key by `sha256(body)`.
 - `HEAD /<sha256>` → existence check.
 
-The Go reference stores blobs as files named by their hash under a `blobs/`
-dir, with a BoltDB metadata index, and **disables auth** for the local server
-([embedded.go](../../reference/site-deck/internal/blossom/embedded.go)). The
-Rust port keeps the same shape: blobs on the filesystem keyed by sha256, a small
-metadata index, no auth on localhost.
+**No protocol fork anywhere on the blob plane.** There is no ttl, no gossip, and
+no query semantics on blobs, so nothing needs a `MESH` envelope. Peers speak
+plain BUD-01 to us and we speak plain BUD-01 to the store. This is the one plane
+where both boundaries *and* the peer link are stock protocol.
 
-**Proposed candidates / patterns:** a thin `axum` handler over a
-filesystem blob store; sha256 via `sha2`; reuse the same `rusqlite`/redb handle
-as the relay for the metadata index. Blobs are immutable and self-authenticating
-(the hash *is* the identity), so the store needs no per-blob signature check —
-only a `sha256(bytes) == name` verify on read/write.
+**Access, but no Myco knowledge in the crate.** The mesh-facing port is gated:
+loopback bypasses, and a mesh source must pass an access function supplied by
+`myco-core`, which answers from the circle and the peer's own permissions
+([nsite-permissions.md §2](./nsite-permissions.md)). The gate distinguishes reads
+from uploads, so `myco-blossom` stays a generic store that knows nothing about
+circles.
+
+**One implementation today; a second is planned.** The filesystem store described
+here is currently the only `BlobStore`. A `RemoteBlobStore` that reads through to
+an external Blossom server is planned — the HTTP client already exists in
+[`ip_source.rs`](../../myco-core/src/ip_source.rs) and needs collecting behind the
+seam, plus kind-24242 upload authorization and hash verification on read (the
+embedded store can skip re-hashing because the only way bytes get in is a verified
+write; a shared store cannot). **Not built yet**, and when it lands the settings
+screen has to carry two warnings sharper than the relay's:
+
+- **A remote backend breaks offline-first.** Blobs are the bulk of an nsite, so
+  pointing this at an internet server means a peer pulling an app from us needs
+  *our* internet connection. A Blossom app on the same device, or one on the LAN,
+  is fine.
+- **Every gateway blob read becomes a round trip.** Today it is a file read. An
+  nsite with many assets pays that per request.
+
+The Go reference stores blobs as files named by their hash under a `blobs/` dir,
+with a BoltDB metadata index, and **disables auth** for the local server
+([embedded.go](../../reference/site-deck/internal/blossom/embedded.go)). The Rust
+port keeps the storage shape: blobs on the filesystem keyed by sha256, no auth on
+localhost. Blobs are immutable and self-authenticating (the hash *is* the
+identity), so the store needs no per-blob signature check — only a
+`sha256(bytes) == name` verify on write.
 
 ### 2.3 The gateway
 

--- a/docs/design/nsite-layer.md
+++ b/docs/design/nsite-layer.md
@@ -163,14 +163,24 @@ needs no translation layer. "Newest event in a replaceable slot" is a helper ove
 
 Operations with **no NIP-01 expression** — the selective cache wipe that keeps
 pinned sites — live in a separate `AdminBackend` trait that only the embedded
-store implements. Where it is absent, the settings UI should report the operation
-as unavailable rather than silently doing nothing.
+store implements. Where it is absent the operation is skipped, and the Storage
+screen says so: with a custom store configured, Delete states that it clears this
+device only and leaves the custom store alone. Claiming otherwise would be a lie
+about a destructive action.
 
-**Planned, not built:** a `RemoteBackend` that speaks WebSocket to a configured
-relay URL — [Citrine](https://github.com/greenart7c3/Citrine) on the same device,
-a `strfry` or `nostr-rs-relay` on the LAN — plus the settings field that selects
-it. Today the embedded store is the only implementation. Two things the settings
-screen will have to say when a custom backend is configured:
+**Built.** [`RemoteBackend`](../../myco-core/src/remote_backend.rs) speaks
+WebSocket to a configured relay URL — [Citrine](https://github.com/greenart7c3/Citrine)
+on the same device, a `strfry` or `nostr-rs-relay` on the LAN. It holds one
+connection open and multiplexes publishes and queries over it by subscription id;
+an unreachable relay is an error rather than an empty result, because an empty
+set would render as a missing site.
+
+The URL lives under **Settings → Storage → Advanced**, persisted in
+`settings.json` and read at startup, since the backend is chosen when the content
+layer is constructed. Changing it therefore applies on the next launch, and the
+app offers to restart. Citrine has been confirmed working as the store.
+
+Two things the settings screen says when a custom backend is configured:
 
 - **We stop verifying what comes back out.** Signatures are checked once, at
   ingress; reads from the backend are trusted because NIP-01 already requires a
@@ -253,14 +263,20 @@ loopback bypasses, and a mesh source must pass an access function supplied by
 from uploads, so `myco-blossom` stays a generic store that knows nothing about
 circles.
 
-**One implementation today; a second is planned.** The filesystem store described
-here is currently the only `BlobStore`. A `RemoteBlobStore` that reads through to
-an external Blossom server is planned — the HTTP client already exists in
-[`ip_source.rs`](../../myco-core/src/ip_source.rs) and needs collecting behind the
-seam, plus kind-24242 upload authorization and hash verification on read (the
-embedded store can skip re-hashing because the only way bytes get in is a verified
-write; a shared store cannot). **Not built yet**, and when it lands the settings
-screen has to carry two warnings sharper than the relay's:
+**Two implementations.** The filesystem store described here is the default;
+[`RemoteBlobStore`](../../myco-core/src/remote_blobs.rs) reads through to an
+external Blossom server over BUD-01, with kind-24242 upload authorization signed
+by the device key and **hash verification on every read** (the embedded store can
+skip re-hashing because the only way bytes get in is a verified write; a shared
+store cannot, so bytes that do not match the requested hash are treated as
+absent).
+
+With a custom server configured the mesh Blossom listener on `:24243` is **not
+bound at all**: it exists to serve our own blobs to peers, and there are none —
+peers reach that server by its own URL rather than through us.
+
+Not yet exercised against a third-party Blossom implementation. The settings
+screen carries two warnings sharper than the relay's:
 
 - **A remote backend breaks offline-first.** Blobs are the bulk of an nsite, so
   pointing this at an internet server means a peer pulling an app from us needs

--- a/docs/design/nsite-permissions.md
+++ b/docs/design/nsite-permissions.md
@@ -43,7 +43,7 @@ The blob plane is the same shape: `myco-blossom` is a generic BUD-01 store and
 takes an access function from `myco-core`, so it stays free of circle knowledge.
 
 Pairing itself is enforced nowhere on the content path, because it does not travel
-there any more — it has its own service on `:4871`
+there any more — it has its own service on `:4873`
 ([identity-pairing.md](./identity-pairing.md)).
 
 ---
@@ -180,7 +180,7 @@ Rate limits aim to stop a runaway or malicious app from saturating a BLE link,
 Over-limit is **slow-down, not hard-fail** where possible (queue/delay rather
 than reject), so a chatty moment degrades gracefully instead of dropping messages.
 
-The auth service on `:4871` follows the same lenient spirit with its own limits,
+The auth service on `:4873` follows the same lenient spirit with its own limits,
 since it is the only port an unpaired device can reach
 ([identity-pairing.md](./identity-pairing.md)).
 

--- a/docs/design/nsite-permissions.md
+++ b/docs/design/nsite-permissions.md
@@ -1,55 +1,155 @@
-# nsite permissions: per-application capabilities
+# Permissions: per-peer grants and per-application capabilities
 
-> Status: DESIGN / proposal for a not-yet-built feature. Voice is "the app
-> will…". Open questions are marked **TBD / open**.
+> Status: MIXED. **Per-peer permissions (§2) are built** — the record ships on
+> every circle contact and is enforced on both content ports, though no UI
+> exposes it yet. **Per-application capabilities (§3 onward) are still a
+> proposal**: the `Origin` → siteKey mapping and the rate gate are not
+> implemented. Open questions are marked **TBD / open**.
 
 An nsite is a static web app served from the local gateway
 ([nsite-layer.md](./nsite-layer.md)). Most just render; some want to do more —
 publish into the mesh ([event-gossip.md](./event-gossip.md)), read location, hold
-blobs. This doc defines a **per-application capability model** and where the
-native layer enforces it.
+blobs.
 
-The v1 stance is deliberately **permissive (default-allow)**: the chat MVP must
-just work, and there is no grant UI yet. What goes in now are the **enforcement
-hooks** (so tightening later is config, not replumbing) and sane, lenient limits
-that stop runaway abuse without throttling normal use. A later Android-style
-request/grant flow (§5) layers on top.
+There are two different permission questions here, and conflating them is the
+main thing this doc is trying to prevent.
 
-> **Scope.** Enforcement is native (`myco-core` / `myco-relay` / the Android
-> shell). The WebView/nsite JS is untrusted, so a capability can never live in
-> JS — only be *requested* from there.
+| Layer | Question it answers | Subject | Status |
+| --- | --- | --- | --- |
+| **Per-peer** (§2) | What may a paired *device* do to us? | A circle contact, identified by its mesh address | Built |
+| **Per-application** (§3–§6) | What may an *app we run* do on our behalf? | An nsite, identified by its `siteKey` | Proposed |
+
+They are independent. A peer with full grants still cannot make our device gossip
+a kind an app is not allowed to publish, and a fully-trusted app still cannot get
+data out of a peer that has revoked our reads.
+
+> **Scope.** Enforcement is native, in the **mesh relay proxy**
+> ([`myco-core/src/mesh_relay.rs`](../../myco-core/src/mesh_relay.rs)) and the
+> Blossom server. The WebView/nsite JS is untrusted, so a capability can never
+> live in JS — only be *requested* from there.
 
 ---
 
-## 1. The unit is the application, identified by `Origin`
+## 1. Where enforcement lives
+
+Both layers are enforced in the same place: the **mesh relay proxy**, the one
+piece of Myco-specific code on the content path. It terminates both sockets — the
+loopback socket the WebView talks to and the `.fips` socket peers talk to — so it
+is the only component that can see an `Origin` header *and* a peer's mesh address.
+The store behind it is a plain NIP-01 relay with no Myco concepts in it, and is
+meant to be swappable, so policy cannot live there.
+
+The blob plane is the same shape: `myco-blossom` is a generic BUD-01 store and
+takes an access function from `myco-core`, so it stays free of circle knowledge.
+
+Pairing itself is enforced nowhere on the content path, because it does not travel
+there any more — it has its own service on `:4871`
+([identity-pairing.md](./identity-pairing.md)).
+
+---
+
+## 2. Per-peer permissions
+
+Paired used to be all-or-nothing: a peer in the circle could read everything,
+publish anything, and upload blobs. It is now six flags on the peer's circle
+record, persisted in `circle.json`.
+
+| Plane | Flag | Default | Meaning |
+| --- | --- | --- | --- |
+| Relay | `relayRead` | on | May open a `REQ` and receive our stored events |
+| Relay | `relayReadMultihop` | on | Their `REQ` may be forwarded to our other peers |
+| Relay | `relayWrite` | on | May publish events to us |
+| Relay | `relayWriteMultihop` | on | Events from them may be forwarded onward by us |
+| Blossom | `blossomRead` | on | May `GET` / `HEAD` blobs from us |
+| Blossom | `blossomWrite` | **off** | May `PUT /upload` to us |
+
+Read every flag as a grant **we** make to **them**. "Multihop" means specifically
+whether *their* traffic travels further through *us* — not anything we send them.
+
+### 2.1 Two checks, not one
+
+- **At accept.** A peer that is not in the circle is refused **before the
+  WebSocket upgrade**, with a plain `403`. There are no exceptions on either
+  content port. A stranger costs a TCP accept and one small response rather than
+  an upgrade and a round of frames, which matters on a BLE link.
+- **Per message / per route.** An admitted peer's flags then apply: read against
+  `REQ`, write against `EVENT`, and on Blossom the read/write split falls out of
+  the HTTP method.
+
+Membership and flags are consulted **live** on every request, so adding a peer,
+removing one, or changing a grant takes effect immediately. Revocation also drops
+connections that are already open, rather than only blocking the next one.
+
+### 2.2 The multihop flags are hop-budget clamps
+
+Neither multihop flag is a separate check. They are per-peer values for the hop
+budgets the push and pull planes already carry
+([event-gossip.md §3, §7](./event-gossip.md)):
+
+- `relayWriteMultihop` off → an inbound event's budget is treated as **0**: store
+  it, show it, never pass it on.
+- `relayReadMultihop` off → an inbound `REQ`'s budget is clamped to **0**: answer
+  from our own store, forward nothing.
+
+So `MAX_EVENT_TTL` and `MAX_REQ_TTL` stop being global constants and become
+per-peer ceilings, and the pull plane's amplification bound gets a per-peer dial.
+
+### 2.3 Why Blossom write defaults off
+
+Uploads cost us disk, and nothing in normal operation needs them: propagation is
+pull-based, so peers fetch blobs from the holder rather than being handed them.
+Serde defaults are written so a missing field cannot silently grant it — an older
+`circle.json` loads with uploads off.
+
+The one casualty is the dev-menu peer speedtest, which works by `PUT`ting a
+payload to the target peer's Blossom. It is not exempted: it works only against a
+peer who has granted uploads, and the dev menu should say so plainly rather than
+report a generic failure.
+
+### 2.4 Not in the UI yet
+
+Every peer gets the defaults. The record exists now so that turning a knob later
+is a UI change rather than a storage migration.
+
+---
+
+## 3. The unit of the application layer is the `Origin`
 
 An nsite **is** an application, identified by its `siteKey` (the `npub` for a root
 site, `npub:dTag` for a named one — [nsite-layer.md §3.2](./nsite-layer.md)).
-Permissions are a record stored **per-siteKey** on the device.
+Per-application permissions are a record stored **per-siteKey** on the device.
 
 The enforcement hook is the **WebSocket / HTTP `Origin`**. The nsite loads at
 `http://<host>.nsite` and talks to the localhost relay (`ws://localhost:4870`) and
 Blossom (`http://localhost:24243`); every request carries
-`Origin: http://<host>.nsite`. The native side maps **`Origin → siteKey →
-permission record`** and applies it. (The relay does no `Origin` check today —
-this is where it is added.)
+`Origin: http://<host>.nsite`. The proxy maps **`Origin → siteKey → permission
+record`** and applies it.
+
+**Not built.** The proxy does no `Origin` check today; a loopback connection is
+simply trusted. This is where it is added.
 
 ---
 
-## 2. The capability record
+## 4. The capability record (proposed)
 
 | Capability | v1 default | Meaning | Enforced at |
 | --- | --- | --- | --- |
-| `gossip-kinds` | **all kinds** | which event kinds may be fanned out to the mesh | relay fan-out path (`FanoutSink`), keyed by `Origin` |
-| `event-ttl` | **3** | max reach for this app's pushed events (the `max-event-ttl` clamp of [event-gossip.md §3](./event-gossip.md), per-app) | relay fan-out path |
-| `req-ttl` | **2** | max reach for this app's discovery `REQ` floods ([event-gossip.md §7](./event-gossip.md)) | relay query path |
-| `rate` | lenient (§4) | publish / subscribe rate caps | relay ingress, per `Origin` |
+| `gossip-kinds` | **all kinds** | which event kinds may be fanned out to the mesh | proxy fan-out path, keyed by `Origin` |
+| `event-hops` | **3** | max reach for this app's pushed events — a per-app version of `MAX_EVENT_TTL` ([event-gossip.md §3](./event-gossip.md)) | proxy fan-out path |
+| `rate` | lenient (§5) | publish / subscribe rate caps | proxy ingress, per `Origin` |
 | `location` | *(future)* | geolocation, granted at a **chosen accuracy** (coarse → fine), e.g. for geohash rooms | WebView geolocation bridge (Kotlin) |
 | `blob-quota` | *(future)* | Blossom storage budget for app-authored blobs | Blossom `PUT` path |
 
-The `event-ttl` / `req-ttl` defaults match the protocol defaults in
-[event-gossip.md](./event-gossip.md); here they are the **per-app clamp**, so a
-single app cannot exceed them even if its client asks for more.
+The hop default matches the protocol default in
+[event-gossip.md](./event-gossip.md); here it is the **per-app clamp**, so a
+single app cannot exceed it even if its client asks for more.
+
+**There is no per-app pull-hop capability.** An nsite's `REQ` never fans out to
+peers at all — it is answered from the local store and returns `EOSE` at
+local-store speed. Multi-hop pull is a core-driven operation (discovery, update
+checks), so there is nothing for an app-level clamp to bite on. If an nsite ever
+needs transitive reach, it gets an explicit API, and that API is where the
+capability would attach.
 
 `location` is **graded, not boolean.** The grant carries a precision — naturally
 expressed as a **geohash length** (fewer chars = coarser; e.g. ~5 chars ≈
@@ -61,37 +161,34 @@ and the product behaviour the same control.
 
 ---
 
-## 3. v1 policy: default-allow
+## 5. v1 policy: default-allow, lenient limits
 
 Every app is granted everything by default — **all kinds gossip-eligible**, the
-default TTLs, lenient rate limits — with **no prompts**. nsites stay "pure static
-content that just works." The point of writing the record down now is purely that
-the *enforcement points* (Origin attribution, the TTL clamps, the rate gate) ship
-with P1/P2 of the fan-out, so flipping any default to deny later is configuration,
-not new plumbing.
+default hop budget, lenient rate limits — with **no prompts**. nsites stay "pure
+static content that just works." The point of writing the record down is that the
+*enforcement points* (Origin attribution, the hop clamp, the rate gate) can ship
+before any policy does, so flipping a default to deny later is configuration, not
+new plumbing.
 
----
-
-## 4. Rate limits — sane, not strict
-
-The goal is to stop a runaway or malicious app from saturating a BLE link, **not**
-to throttle a person chatting. Start lenient and tighten by observation.
-
-Proposed starting caps, **per `Origin`** (all *experimental*):
+Rate limits aim to stop a runaway or malicious app from saturating a BLE link,
+**not** to throttle a person chatting. Proposed starting caps, **per `Origin`**
+(all *experimental*):
 
 - **Publish (`EVENT`):** ~20 events / 10 s burst, ~100 / min sustained.
 - **Subscriptions (`REQ`):** up to ~32 concurrent open subscriptions.
-- **Discovery floods (`req-ttl` > 0):** a much tighter cap (e.g. a few / min) —
-  a flooded read is far costlier than a local one ([event-gossip.md §7](./event-gossip.md)).
 
 Over-limit is **slow-down, not hard-fail** where possible (queue/delay rather
 than reject), so a chatty moment degrades gracefully instead of dropping messages.
 
+The auth service on `:4871` follows the same lenient spirit with its own limits,
+since it is the only port an unpaired device can reach
+([identity-pairing.md](./identity-pairing.md)).
+
 ---
 
-## 5. Future: Android-style request / grant
+## 6. Future: Android-style request / grant
 
-Additive, layered on §3 — turns default-allow into default-deny-for-sensitive +
+Additive, layered on §5 — turns default-allow into default-deny-for-sensitive +
 prompt:
 
 1. **Declare.** The nsite manifest declares the capabilities it wants, so the user
@@ -99,29 +196,38 @@ prompt:
 2. **Grant.** Declaration is only a *request* — the manifest is author-signed and
    could claim anything. The **user grants**, per-siteKey; sensitive caps
    (`location`) prompt at first use. Grants are revocable in Settings.
-3. **Enforce.** Same native points as §2 — only the *default* changes from allow
+3. **Enforce.** Same native points as §4 — only the *default* changes from allow
    to deny-until-granted for the sensitive subset.
+
+The same UI problem exists one layer down: per-peer flags (§2) also need a place
+to live, and the two lists are different enough ("this device" vs "this app") that
+they probably want separate screens.
 
 ---
 
-## 6. Open questions
+## 7. Open questions
 
 - **Prompt model** — per-use vs. install-time for sensitive caps; how revocation
   surfaces. **TBD / open.**
 - **Default-deny for unknown kinds?** Whether `gossip-kinds` should ever narrow
-  from "all" to an allow-list for apps the user hasn't explicitly trusted, and how
-  that interacts with the mutual-pairing handshake
-  ([identity-pairing.md](./identity-pairing.md)). **TBD / open.**
+  from "all" to an allow-list for apps the user hasn't explicitly trusted.
+  **TBD / open.**
 - **Trust tiers** — should a paired-circle app get a more generous record than a
   freshly-installed one? Ties into [security.md](./security.md). **TBD / open.**
+- **Surfacing per-peer flags** — which of the six are worth showing a user at all,
+  and what a sensible preset ("read-only peer", "no relaying") looks like.
+  **TBD / open.**
 
 ---
 
 ## See also
 
-- [./event-gossip.md](./event-gossip.md) — `event-ttl` / `req-ttl`, the fan-out
-  path these caps gate.
+- [./event-gossip.md](./event-gossip.md) — the push and pull planes these clamp,
+  and the `MESH` envelope the hop budgets travel in.
 - [./nsite-layer.md](./nsite-layer.md) — the gateway, `siteKey` resolution, and
   the JS sandbox / capability open question (§7) this answers.
-- [./security.md](./security.md), [./identity-pairing.md](./identity-pairing.md) —
-  trust model and pairing the grant flow builds on.
+- [./identity-pairing.md](./identity-pairing.md) — the auth service that creates
+  the circle these per-peer grants attach to.
+- [./security.md](./security.md) — the trust model both layers sit inside.
+- [../../reference/thinning-custom-relay.md](../../reference/thinning-custom-relay.md) —
+  D10, where the per-peer flags were decided.

--- a/docs/design/nsite-updates.md
+++ b/docs/design/nsite-updates.md
@@ -1,7 +1,14 @@
 # nsite updates: staged activation + mesh propagation
 
-> Status: DESIGN / proposal for a not-yet-built feature. Voice is "the app
-> will…". Open questions are marked **TBD / open**.
+> Status: PARTLY BUILT. Discovery (§3), staging (§2), mesh propagation (§4) and
+> auto-activation ship today. Open-instance gating (§5.2) and version
+> history/pinning/revert (§6) are still proposals. Open questions are marked
+> **TBD / open**.
+>
+> **Wire note.** Mesh hop state travels in a `MESH` envelope *beside* the NIP-01
+> message, never inside the event or a filter. Two links stay plain NIP-01: the
+> nsite ↔ `localhost:4870` link and the proxy ↔ backing-relay link. See
+> [event-gossip.md §0 and §2](./event-gossip.md).
 
 An nsite is a set of author-signed manifest events (kinds 15128/35128) plus
 content-addressed blobs ([nsite-layer.md](./nsite-layer.md),
@@ -103,13 +110,13 @@ pipeline (§2) and treated identically once a candidate is in hand:
 
 - **Pull (we poll).** A bounded subscription we initiate — manual or background
   (§3.1–3.2).
-- **Push (a peer tells us).** Because manifests propagate over the *same*
-  `event-ttl` push plane as chat (§4), a peer can gossip a newer manifest to us
-  **unsolicited, up to 3 hops** away — we don't have to ask. It arrives over the
-  EVENT socket, our relay stores it (NIP-01) and re-propagates it, and core
-  notices it exactly as it would a polled candidate (§4.2). So a device often
-  learns of an update from a nearby peer before it ever runs a check — and even
-  fully offline.
+- **Push (a peer tells us).** Because manifests propagate over the *same* push
+  plane as chat (§4), a peer can gossip a newer manifest to us **unsolicited, up
+  to 3 hops** away — we don't have to ask. It arrives as a `MESH`-wrapped `EVENT`
+  on the mesh socket, the proxy stores the canonical event and re-propagates it,
+  and core notices it exactly as it would a polled candidate (§4.2). So a device
+  often learns of an update from a nearby peer before it ever runs a check — and
+  even fully offline.
 
 The rest of §3 covers the pull channel; the push channel is §4.
 
@@ -142,18 +149,28 @@ the union of:
 single connection. For each unique relay, send **one** filter union'd across all
 sites — `{ kinds: [15128, 35128], authors: [...all site authors...], "#d":
 [...all named d-tags...] }` — then read events until **EOSE** and close. (One
-combined REQ, not one per site; the relay returns each slot's newest. This is the
-read/pull shape from [event-gossip.md §7](./event-gossip.md), bounded by EOSE
-rather than kept live.)
+combined REQ, not one per site; the relay returns each slot's newest.)
+
+**The check is core-driven, not client-driven.** It goes straight to the
+peer-relay pool rather than through the loopback relay socket, which is the same
+route discovery takes. That split is deliberate: a `REQ` from an nsite never fans
+out to peers, so multi-hop reads only ever happen where the core asks for them
+([event-gossip.md §7](./event-gossip.md)).
 
 A returned manifest is a candidate iff `candidate.created_at > active.created_at`
 for its slot (and newer than any already-staged candidate). Each such candidate is
-**stored into our own relay** (`store_event`) — which (a) keeps us NIP-01-faithful
-so peers REQ-ing us get the newest, (b) propagates it onward via the normal
-gossip path (§4), and (c) lets core notice it and open a `PendingUpdate` to stage
-its blobs (preferring the manifest's `["server", …]` hints, then
+**published into our own relay** — which (a) keeps us NIP-01-faithful so peers
+REQ-ing us get the newest, (b) propagates it onward via the normal gossip path
+(§4), and (c) lets core notice it and open a `PendingUpdate` to stage its blobs
+(preferring the manifest's `["server", …]` hints, then
 `default_blossom_servers()` when online, or the mesh peer that surfaced it). The
 active pointer does not move until staging completes (§5).
+
+> **Known gap.** Discovery sends its mesh `REQ` inside a `MESH` envelope with
+> `ttl: 1`, so it reaches two hops. The update check currently sends a **plain**
+> `REQ` to each peer and therefore reaches **one** hop, even though the code
+> comment beside it still claims parity with discovery. Either the check should
+> carry the same envelope or the comment should go; as written the two disagree.
 
 > **TBD / open:** where a manifest's relay hints live (NIP-65 author relay list
 > vs. tags on the manifest event) and the fallback when a manifest lists none
@@ -176,8 +193,8 @@ long-press sheet offers "Update now" (a no-op nudge if it'll auto-apply on close
 
 > **Rule:** **storing** a newer manifest is always immediate and
 > protocol-faithful — it enters our relay at once and is answerable to peers'
-> REQs; we never withhold a version. **Forwarding** (the active `event-ttl` push to
-> peers) is *interest-aware*:
+> REQs; we never withhold a version. **Forwarding** (the active hop-bounded push
+> to peers) is *interest-aware*:
 > - **Not interested** (we don't have this nsite in our Library): forward
 >   **immediately** — a pure relay passthrough; we won't download the blobs, so
 >   there's nothing to wait for.
@@ -192,25 +209,27 @@ long-press sheet offers "Update now" (a no-op nudge if it'll auto-apply on close
 
 ### 4.1 Manifests gossip like any event — with an interest check on forward
 
-The relay change is just making manifest kinds **gossip-eligible**
-([`is_gossip_eligible`](../../myco-core/src/gossip.rs)); the relay still merely
-**stores** the newer manifest and hands it to the gossiper, exactly as for chat
-(no interceptor, no deferral in the relay). The *forward policy* lives in core's
-gossiper, which branches on interest:
+The proxy treats manifest kinds like any other event: it stores the canonical
+event and hands it to the gossiper, exactly as for chat (no interceptor, no
+deferral in the proxy). The *forward policy* lives in core's gossiper, which
+routes manifest kinds to their own handler and branches on interest:
 
-- **Not interested** → build `["EVENT", { …manifest, "event-ttl": n }]` and fan to
-  connected circle peers immediately, split-horizon, `event-ttl` decremented
-  ([event-gossip.md §2–3](./event-gossip.md)).
+- **Not interested** → build `["MESH", {"ttl": n}, ["EVENT", <manifest>]]` and fan
+  to connected circle peers immediately, split-horizon, with the hop budget
+  decremented ([event-gossip.md §2–3](./event-gossip.md)). The manifest event
+  itself is canonical NIP-01 — nothing is added to it and nothing has to be
+  stripped before storing.
 - **Interested** → open a `PendingUpdate { source: Mesh(sender_ip) }`, download
   the blobs (best-effort, from the peer that sent it), and fan out when the
   download completes **or** a bound elapses — whichever first. Then activate (§5)
   if/when complete.
 
-The loop guard is the same as chat: only a *newly-stored* (newer-than-known)
-manifest is handed to the gossiper, so duplicates and older versions die on
-arrival and `event-ttl` bounds the wave. Locally-originated candidates (an online
-check, §3.2) are "interested" by definition — we checked because we run the site —
-so they follow the download-then-forward path.
+The loop guard is the same as chat: the proxy's **seen-set** decides novelty, so
+only a first sighting is handed to the gossiper and a copy arriving by a second
+path is stored but never re-forwarded. The hop budget then bounds the wave's
+reach ([event-gossip.md §4](./event-gossip.md)). Locally-originated candidates
+(an online check, §3.2) are "interested" by definition — we checked because we run
+the site — so they follow the download-then-forward path.
 
 ### 4.2 Blob availability is the natural gate
 
@@ -229,11 +248,11 @@ the next hop usually succeeds against us instead of falling back.
 
 ### 4.3 Why reuse the push plane
 
-Manifests *are* just events. Reusing `event-ttl` push + neighbour pull means an
-offline cluster gets author updates the same way it gets chat: whoever next meets a
-peer that holds the newer manifest gets it and re-spreads it, then each device
-downloads the blobs and activates on its own schedule. No separate
-update-distribution protocol, and no special-casing in the relay.
+Manifests *are* just events. Reusing the hop-bounded push plane plus neighbour
+pull means an offline cluster gets author updates the same way it gets chat:
+whoever next meets a peer that holds the newer manifest gets it and re-spreads
+it, then each device downloads the blobs and activates on its own schedule. No
+separate update-distribution protocol, and no special-casing in the store.
 
 ---
 

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -200,7 +200,7 @@ Three ports are exposed, and only one of them answers a stranger.
 | --- | --- | --- |
 | `4870` | Relay (the mesh proxy's NIP-01 socket) | Circle members only |
 | `24243` | Blossom blob store | Circle members only |
-| `4871` | Auth service — `POST /pair`, nothing else | **Anyone** |
+| `4873` | Auth service — `POST /pair`, nothing else | **Anyone** |
 
 **Open question:** confirm that no other localhost service on the phone is
 inadvertently reachable via FSP port-multiplexing on a paired path, and whether
@@ -222,7 +222,7 @@ Pairing now terminates at its own service ([identity-pairing.md
   which matters on a BLE link.
 - **The relay refuses the pairing kinds from every source**, paired or not.
   Nothing writes control traffic into the event store.
-- **`:4871` is the only unauthenticated surface in the app**, so hardening and
+- **`:4873` is the only unauthenticated surface in the app**, so hardening and
   rate limiting have a single address instead of emerging from a whitelist.
 
 **Revocation closes live connections.** Because admission is checked once, at the
@@ -281,7 +281,7 @@ Pairing is the one moment a human asserts "this is who I think it is."
 - **The trust model is scan-and-confirm over an already-encrypted channel, not
   bare TOFU.** Scanning the QR does not merely bind an npub on faith — it initiates
   the mandatory **invite-pairing handshake** against the inviter's on-device auth
-  service at `<npub>.fips:4871`. That channel is already **Noise-XK authenticated and
+  service at `<npub>.fips:4873`. That channel is already **Noise-XK authenticated and
   encrypted** to the inviter's device key, so the scanner just **echoes the
   `pairSecret` back** inside it; the inviter matches the (single-use) secret and the
   human taps **OK** to confirm the memorable name
@@ -295,7 +295,7 @@ Pairing is the one moment a human asserts "this is who I think it is."
   man-in-the-middle without the private key cannot impersonate the paired peer on
   subsequent connections.
 - **The handshake closes the relay-MITM / malicious-QR gap by default.** Three
-  things stack up: the channel to `<npub>.fips:4871` is Noise-authenticated to the
+  things stack up: the channel to `<npub>.fips:4873` is Noise-authenticated to the
   inviter's key (a passive relay between the two devices learns nothing and cannot
   impersonate either end), the `pairSecret` is a single-use, unguessable random
   string echoed *inside* that encrypted channel (a captured or relayed invite cannot
@@ -391,8 +391,8 @@ capability.
 | **Storage-exhaustion DoS** | Floods your cache with junk blobs/events to evict your data or fill the disk | Only circle members reach the content ports at all, and **blob upload is off by default per peer** (§3.3), so a peer cannot push bytes onto your disk unless you grant it. Plus: LRU cache (default cap **2 GB**); Library sites are **pinned** (exempt from eviction); per-source relay rate limits (TBD). Junk that fails verification is never stored (§1). |
 | **Identity / link spoofing** | Pretends to be a paired peer | Noise IK/XK over secp256k1; identity is pubkey not MAC; spoof cannot complete handshake (§2). |
 | **Replay** | Re-injects captured datagrams | 2048-entry sliding replay window at both FMP and FSP layers (§2). |
-| **Malicious / relayed QR at pairing** | Tries to bind the attacker's npub as your paired peer | Scan-and-confirm over Noise: the single-use, unguessable `pairSecret` is echoed back inside the Noise-authenticated channel to the inviter's `<npub>.fips:4871` and confirmed by the inviter's OK prompt, so a captured/relayed invite cannot bind (§4). Optional out-of-band safety-string check on top is an open proposal (§4). |
-| **DoS on the auth port** | Floods `:4871`, the one port open to strangers, to burn a BLE radio | Per-source token bucket (1/s, burst 5), a global in-flight ceiling of 8, and an 8 KiB body cap. Over-limit is a delay, not a ban — there is no identity to ban that costs a mesh peer anything to replace (§3.2, [identity-pairing.md §6.2](./identity-pairing.md)). |
+| **Malicious / relayed QR at pairing** | Tries to bind the attacker's npub as your paired peer | Scan-and-confirm over Noise: the single-use, unguessable `pairSecret` is echoed back inside the Noise-authenticated channel to the inviter's `<npub>.fips:4873` and confirmed by the inviter's OK prompt, so a captured/relayed invite cannot bind (§4). Optional out-of-band safety-string check on top is an open proposal (§4). |
+| **DoS on the auth port** | Floods `:4873`, the one port open to strangers, to burn a BLE radio | Per-source token bucket (1/s, burst 5), a global in-flight ceiling of 8, and an 8 KiB body cap. Over-limit is a delay, not a ban — there is no identity to ban that costs a mesh peer anything to replace (§3.2, [identity-pairing.md §6.2](./identity-pairing.md)). |
 | **Stranger writing to your event store** | Gets data into a store you may not own | Pairing kinds are refused on the relay from every source; the handshake never touches the store. Unpaired peers are refused before the WebSocket upgrade (§3.2). |
 | **Revoked peer keeps reading** | An unpaired peer's open subscription keeps streaming | Membership is re-checked on delivery and the connection is dropped, so revocation reaches connections that already exist (§3.2). |
 | **Malicious nsite content** | Untrusted JS in the WebView | Pure-static v1, no capability API; per-nsite origin isolation + CSP; WebView never resolves `.fips` (§5). |

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -2,9 +2,8 @@
 
 This document describes the security posture proposed for Myco: what is
 authenticated, what is authorized, who is trusted, and what is explicitly out
-of scope. It is a design document for a not-yet-built app; statements about
-behaviour are proposals ("the app will…") unless they cite verified reference
-source.
+of scope. Where a section describes something not yet built it says so;
+everything else describes the app as it stands.
 
 The short version: **Myco trusts data, not peers.** Every artifact it
 exchanges — Nostr events and Blossom blobs — is self-authenticating, so any
@@ -60,6 +59,31 @@ Carl is not trusting *you* — he is verifying Alice's signature and the blob
 hashes himself. A new source is as good as the original source. This is the
 property that lets relays and blobs hop across "crappy links in all directions"
 without a trusted intermediary.
+
+### 1.1 Where signatures are checked
+
+Transport authenticity and event authorship are different claims, and
+store-and-forward pulls them apart. FIPS Noise IK plus the identity-derived
+`fd00::` address proves **who sent the frame**. It says nothing about **who
+signed the event**, because peers routinely hand us events authored by third
+parties they have never met.
+
+Manifests are the sharp case. An nsite manifest is authored by its publisher and
+the peer relaying it is only a courier, so without verification any paired peer
+could hand us a forged manifest for anyone's nsite and we would stage and
+activate it as that publisher's site. Content-addressing does not save us: blob
+hashes are checked against the manifest, and the manifest is the forged part.
+
+So verification happens **once, at ingress** — the points where a remote event
+enters the process. It used to be a habit repeated at nine scattered call sites,
+which is a pattern where a single missed one is a silent forgery hole.
+
+Events read back **out** of our own store are not re-verified. NIP-01 already
+makes signature checking mandatory for a relay accepting an `EVENT`, so paying
+Schnorr again per event on a phone buys nothing. That trade is worth restating if
+Myco is ever pointed at a relay it does not own — see
+[nsite-layer.md §2.1](./nsite-layer.md), where that is a planned setting with a
+warning attached.
 
 What self-authentication does **not** give you:
 
@@ -132,6 +156,11 @@ What this changes:
   network is not private. Anyone you pair with (Section 4) becomes a peer and,
   by virtue of being a peer, a data source and a data sink. "Paired" is the
   only relationship.
+- **There *is* an "is this peer in my circle" check on the content ports.** That
+  is not a roster: it is a purely local list, symmetric, with no signer, no
+  admin, and no authority beyond this device. It gates who may talk to *our*
+  relay and *our* Blossom, and it changes nothing about who may be on the mesh
+  (§3.1).
 - **Authorization collapses to data semantics.** Because all data is
   self-authenticating (Section 1), there is little a peer is "authorized" to do
   beyond exchange verifiable artifacts. A peer cannot impersonate an author,
@@ -154,37 +183,86 @@ Myco's v1 stance is *default-allow* — pairing is the gesture, and we do not
 ship a roster-like allowlist UI. Re-exposing the ACL as a "block this peer"
 control is a candidate later feature (TBD / open).
 
-**Inbound surface on the mesh.** FIPS FSP port-multiplexing delivers mesh
-datagrams to localhost ports, so a paired peer can reach your services at
-`<npub>.fips:4870` (relay) and `<npub>.fips:24243` (Blossom)
-([../../reference/fips/docs/design/fips-session-layer.md](../../reference/fips/docs/design/fips-session-layer.md)).
-On Linux, FIPS recommends a default-deny nftables baseline to bound this
-surface; **on Android there is no nftables equivalent the app controls.** The
-app's mitigation is to expose *only* the relay and Blossom ports over the mesh
-and nothing else — the VpnService/TUN routes only `fd00::/8` and DNS-intercepts
-`*.fips`/`*.nsite`; it does **not** capture `0.0.0.0/0`, and the WebView never
-resolves `.fips`. So the only inbound app surface a peer sees is "fetch signed
-events and content-addressed blobs," which is exactly the self-authenticating
-surface from Section 1. **Open question:** confirm that no other localhost
-service on the phone is inadvertently reachable via FSP port-multiplexing on a
-paired path, and whether the app should enforce an explicit port allowlist on
-the inbound mesh side.
+### 3.1 Inbound surface on the mesh
 
-**v0: the relay and Blossom are open-read to any connected peer.** There is **no
-relay/Blossom auth in v0** — the embedded relay answers any connected peer's `REQ`
-with its stored events, and Blossom answers any `GET /<sha256>`. No NIP-42 `AUTH`,
-no per-peer read scoping. This is deliberate and aligned with propagation: a peer
-*must* be able to read your relay/Blossom to become a new source, and the data is
-public-by-design (author-signed manifests, content-addressed blobs) — so open-read
-leaks no secret. The honest exposure is **metadata, not confidentiality**: a
-connected peer can issue a broad `REQ` and **enumerate your whole manifest set** —
-learning *which sites you hold, installed, or cached for others*. That is the same
-privacy signal as *which manifests you choose to replicate* (see
-[propagation.md](./propagation.md)), not a content leak. Mitigations — NIP-42 `AUTH`
-on the relay, per-peer read-scoping, unlisted/private nsites, selective
-replication — are **additive and deferred to a later milestone** (NIP-42 is
-non-breaking on the wire). The only coarse knob today is the FIPS peer ACL ("block
-this peer", above).
+FIPS FSP port-multiplexing delivers mesh datagrams to localhost ports, so a peer
+can reach your services over `.fips`
+([../../reference/fips/docs/design/fips-session-layer.md](../../reference/fips/docs/design/fips-session-layer.md)).
+On Linux, FIPS recommends a default-deny nftables baseline to bound this surface;
+**on Android there is no nftables equivalent the app controls.** The app's
+mitigation is to expose *only* its own ports over the mesh — the VpnService/TUN
+routes only `fd00::/8` and DNS-intercepts `*.fips`/`*.nsite`; it does **not**
+capture `0.0.0.0/0`, and the WebView never resolves `.fips`.
+
+Three ports are exposed, and only one of them answers a stranger.
+
+| Port | Service | Who may reach it |
+| --- | --- | --- |
+| `4870` | Relay (the mesh proxy's NIP-01 socket) | Circle members only |
+| `24243` | Blossom blob store | Circle members only |
+| `4871` | Auth service — `POST /pair`, nothing else | **Anyone** |
+
+**Open question:** confirm that no other localhost service on the phone is
+inadvertently reachable via FSP port-multiplexing on a paired path, and whether
+the app should enforce an explicit port allowlist on the inbound mesh side.
+
+### 3.2 One open port, one membership predicate
+
+The content ports have **no exceptions**. Pairing used to need one — an unpaired
+peer had to be able to publish the three handshake kinds so pairing could
+bootstrap — which meant a kind whitelist inside the relay's frame handling.
+Pairing now terminates at its own service ([identity-pairing.md
+§6.2](./identity-pairing.md)), so:
+
+- **Admission is one predicate:** is this mesh address in my circle? The same
+  question answers for relay and Blossom alike.
+- **It is checked at accept, not per frame.** An unpaired peer is refused
+  **before** the WebSocket upgrade, with a plain `403`. A stranger costs a TCP
+  accept and one small response rather than an upgrade and a round of frames,
+  which matters on a BLE link.
+- **The relay refuses the pairing kinds from every source**, paired or not.
+  Nothing writes control traffic into the event store.
+- **`:4871` is the only unauthenticated surface in the app**, so hardening and
+  rate limiting have a single address instead of emerging from a whitelist.
+
+**Revocation closes live connections.** Because admission is checked once, at the
+upgrade, removing a peer also drops the connections it already holds rather than
+only blocking the next request. Membership is consulted live, so the change takes
+effect immediately.
+
+### 3.3 Per-peer permissions
+
+Paired is no longer all-or-nothing. Each circle contact carries six flags —
+relay read, relay read-multihop, relay write, relay write-multihop, Blossom read,
+Blossom write — all on by default **except Blossom write**, which is off. Full
+table and rationale: [nsite-permissions.md §2](./nsite-permissions.md).
+
+Two consequences worth stating here:
+
+- **Uploads are not granted by default.** Nothing in normal operation pushes
+  blobs to a peer (propagation is pull-based), so accepting bytes onto our disk
+  is opt-in. A missing field in an older `circle.json` cannot silently grant it.
+- **Relaying for a peer is a separate grant from talking to it.** The two
+  multihop flags are per-peer clamps on the hop budgets, so "I will hold your
+  data but not carry it further" is expressible.
+
+The flags are stored per peer today but **not exposed in the UI**; every peer gets
+the defaults.
+
+### 3.4 What a circle member can still learn
+
+Read access is deliberately broad for members, because a peer *must* be able to
+read your relay/Blossom to become a new source, and the data is public-by-design
+(author-signed manifests, content-addressed blobs) — so it leaks no secret.
+
+The honest exposure is **metadata, not confidentiality**: a member can issue a
+broad `REQ` and **enumerate your whole manifest set**, learning *which sites you
+hold, installed, or cached for others*. That is the same privacy signal as *which
+manifests you choose to replicate* (see [propagation.md](./propagation.md)), not a
+content leak. Narrower read scoping — unlisted/private nsites, selective
+replication, filtering by kind per peer — remains **additive and deferred**. The
+coarse knobs today are unpairing, the per-peer read flag, and the FIPS peer ACL
+("block this peer", above).
 
 ## 4. Pairing trust: scan-and-confirm, mutual by default
 
@@ -202,8 +280,8 @@ Pairing is the one moment a human asserts "this is who I think it is."
   [../../reference/nostr-vpn/android/app/src/main/java/org/nostrvpn/app/QrScannerDialog.kt](../../reference/nostr-vpn/android/app/src/main/java/org/nostrvpn/app/QrScannerDialog.kt)).
 - **The trust model is scan-and-confirm over an already-encrypted channel, not
   bare TOFU.** Scanning the QR does not merely bind an npub on faith — it initiates
-  the mandatory **invite-pairing handshake** against the inviter's on-device
-  `<npub>.fips` endpoint. That channel is already **Noise-XK authenticated and
+  the mandatory **invite-pairing handshake** against the inviter's on-device auth
+  service at `<npub>.fips:4871`. That channel is already **Noise-XK authenticated and
   encrypted** to the inviter's device key, so the scanner just **echoes the
   `pairSecret` back** inside it; the inviter matches the (single-use) secret and the
   human taps **OK** to confirm the memorable name
@@ -217,7 +295,7 @@ Pairing is the one moment a human asserts "this is who I think it is."
   man-in-the-middle without the private key cannot impersonate the paired peer on
   subsequent connections.
 - **The handshake closes the relay-MITM / malicious-QR gap by default.** Three
-  things stack up: the channel to `<npub>.fips` is Noise-authenticated to the
+  things stack up: the channel to `<npub>.fips:4871` is Noise-authenticated to the
   inviter's key (a passive relay between the two devices learns nothing and cannot
   impersonate either end), the `pairSecret` is a single-use, unguessable random
   string echoed *inside* that encrypted channel (a captured or relayed invite cannot
@@ -232,8 +310,10 @@ Pairing is the one moment a human asserts "this is who I think it is."
   round-trip, so inviter and scanner must both be online to each other when the
   QR is scanned. In practice they are physically together, so the BLE link is up
   — the handshake runs over BLE (or IP). There is no deferred / offline pairing:
-  if the inviter's `<npub>.fips` endpoint is not reachable, pairing does not
-  complete.
+  if the inviter's auth service is not reachable, pairing does not complete. It
+  does, however, survive a broken content plane: a taken relay port or a
+  misconfigured store does not stop two phones pairing, which is the one
+  operation that could repair the situation.
 - **`pairSecret` authenticates, it does not authorize.** Holding the secret lets
   a peer complete the handshake; it confers **no membership and no admin
   authority** (there is no roster or admin to join — §3). After pairing, the
@@ -308,10 +388,13 @@ capability.
 | ------ | ---------------------- | ---------- |
 | **Malicious / forging relay or peer** | Tries to serve forged content | **Cannot forge.** Signatures + SHA-256 verified locally (§1); bad artifacts are rejected. |
 | **Withholding / availability attack** | Refuses to serve, serves stale, hides a newer event | Pull-from-many: query all reachable relays, keep newest valid event; manifests flood widely (announce-wide) while large blobs are pulled on demand. Best-effort, no freshness guarantee (§1). |
-| **Storage-exhaustion DoS** | Floods your cache with junk blobs/events to evict your data or fill the disk | LRU cache (default cap **2 GB**); Library sites are **pinned** (exempt from eviction); per-source caps / rate limits (TBD). Junk that fails verification is never stored (§1). |
+| **Storage-exhaustion DoS** | Floods your cache with junk blobs/events to evict your data or fill the disk | Only circle members reach the content ports at all, and **blob upload is off by default per peer** (§3.3), so a peer cannot push bytes onto your disk unless you grant it. Plus: LRU cache (default cap **2 GB**); Library sites are **pinned** (exempt from eviction); per-source relay rate limits (TBD). Junk that fails verification is never stored (§1). |
 | **Identity / link spoofing** | Pretends to be a paired peer | Noise IK/XK over secp256k1; identity is pubkey not MAC; spoof cannot complete handshake (§2). |
 | **Replay** | Re-injects captured datagrams | 2048-entry sliding replay window at both FMP and FSP layers (§2). |
-| **Malicious / relayed QR at pairing** | Tries to bind the attacker's npub as your paired peer | Scan-and-confirm over Noise: the single-use, unguessable `pairSecret` is echoed back inside the Noise-authenticated channel to the inviter's `<npub>.fips` and confirmed by the inviter's OK prompt, so a captured/relayed invite cannot bind (§4). Optional out-of-band safety-string check on top is an open proposal (§4). |
+| **Malicious / relayed QR at pairing** | Tries to bind the attacker's npub as your paired peer | Scan-and-confirm over Noise: the single-use, unguessable `pairSecret` is echoed back inside the Noise-authenticated channel to the inviter's `<npub>.fips:4871` and confirmed by the inviter's OK prompt, so a captured/relayed invite cannot bind (§4). Optional out-of-band safety-string check on top is an open proposal (§4). |
+| **DoS on the auth port** | Floods `:4871`, the one port open to strangers, to burn a BLE radio | Per-source token bucket (1/s, burst 5), a global in-flight ceiling of 8, and an 8 KiB body cap. Over-limit is a delay, not a ban — there is no identity to ban that costs a mesh peer anything to replace (§3.2, [identity-pairing.md §6.2](./identity-pairing.md)). |
+| **Stranger writing to your event store** | Gets data into a store you may not own | Pairing kinds are refused on the relay from every source; the handshake never touches the store. Unpaired peers are refused before the WebSocket upgrade (§3.2). |
+| **Revoked peer keeps reading** | An unpaired peer's open subscription keeps streaming | Membership is re-checked on delivery and the connection is dropped, so revocation reaches connections that already exist (§3.2). |
 | **Malicious nsite content** | Untrusted JS in the WebView | Pure-static v1, no capability API; per-nsite origin isolation + CSP; WebView never resolves `.fips` (§5). |
 | **Capability-API abuse** (future) | nsite JS reaches host affordances (query peers, write blobs) | Out of scope for v1; the app never signs/publishes events, so no `sign()` capability exists; needs explicit permission model if any capability is ever introduced (§5). |
 | **Propagation-privacy leak** | Observers learn what you host / re-serve | See below — partial mitigation only (open). |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -138,7 +138,7 @@ enabled = true             # master switch for the L2CAP CoC transport
 # ---------------------------------------------------------------------------
 [wifi_aware]
 enabled = false            # master switch for the bulk lane (adds a UDP transport)
-# The port is a fixed app constant (4871), carried where it already
+# The port is a fixed app constant (4873), carried where it already
 # belongs — the fips UDP transport's bind_addr. There is no role and no PSK.
 
 # ---------------------------------------------------------------------------

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -20,7 +20,7 @@ sync-over-FIPS), [../design/nsite-layer.md §3.2](../design/nsite-layer.md)
 | --- | --- | --- | --- | --- |
 | Embedded Nostr relay | `127.0.0.1` (localhost) | **4870** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:4870`, paired peers only |
 | Auth service (pairing) | `[::]` (mesh only) | **4871** | peers asking to pair | **Yes** — at `<npub>.fips:4871`, and the only port open to a peer we have never met |
-| Embedded Blossom server | `127.0.0.1` (localhost) | **24243** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:24243`, paired peers only |
+| Embedded Blossom server | `127.0.0.1` (localhost) | **24243** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:24243`, paired peers only. Not bound at all when a custom Blossom is configured |
 | Local HTTP gateway | `127.0.0.1` (localhost) | **80** | any browser on the device (system-wide `*.nsite` interception) | **No** — localhost-only, never over the mesh |
 | DNS interceptor | inside the VpnService/TUN reader (not a bound socket) | n/a | the whole device's resolver | n/a — it *produces* the addresses below |
 | FIPS IPv6 adapter | FSP port **256** (internal mesh port, not a localhost socket) | 256 | FIPS session layer | n/a — this is the mesh transport that *carries* IPv6 to `fd00::` |

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -19,7 +19,7 @@ sync-over-FIPS), [../design/nsite-layer.md §3.2](../design/nsite-layer.md)
 | Service | Listen address | Default port | Reached by | Exposed over FIPS? |
 | --- | --- | --- | --- | --- |
 | Embedded Nostr relay | `127.0.0.1` (localhost) | **4870** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:4870`, paired peers only |
-| Auth service (pairing) | `[::]` (mesh only) | **4871** | peers asking to pair | **Yes** — at `<npub>.fips:4871`, and the only port open to a peer we have never met |
+| Auth service (pairing) | `[::]` (mesh only) | **4873** | peers asking to pair | **Yes** — at `<npub>.fips:4873`, and the only port open to a peer we have never met |
 | Embedded Blossom server | `127.0.0.1` (localhost) | **24243** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:24243`, paired peers only. Not bound at all when a custom Blossom is configured |
 | Local HTTP gateway | `127.0.0.1` (localhost) | **80** | any browser on the device (system-wide `*.nsite` interception) | **No** — localhost-only, never over the mesh |
 | DNS interceptor | inside the VpnService/TUN reader (not a bound socket) | n/a | the whole device's resolver | n/a — it *produces* the addresses below |
@@ -62,9 +62,9 @@ unchanged.
   See
   [../design/nsite-layer.md §5.2](../design/nsite-layer.md).
 
-## 1a. Auth service — `4871`
+## 1a. Auth service — `4873`
 
-- **Listen:** `http://[::]:4871` on the mesh only (IPV6_V6ONLY, so it cannot
+- **Listen:** `http://[::]:4873` on the mesh only (IPV6_V6ONLY, so it cannot
   collide with a loopback squatter). There is no localhost listener: nothing on
   this device needs to pair with itself.
 - **Route:** `POST /pair`, body a signed pairing event (kinds 9101 / 9102 /
@@ -78,14 +78,15 @@ Because bootstrap lives here, the relay and Blossom ports have **no exceptions**
 an unpaired peer is refused before the WebSocket upgrade, and the relay rejects
 the pairing kinds from every source so they never reach the event store.
 
-`4871` sits just past the relay's `4870` and clear of `4869`, which public Nostr
-relays commonly take.
+`4873` is the first number clear of everything already spoken for: `4869` is what
+public Nostr relays commonly take, `4870` is our relay, `4871` is the LAN / `!FIPS`
+AP lane (and where pre-`4872` Wi-Fi Aware peers still listen), and `4872` is the
+Aware lane.
 
-**Note the overlap.** `4871/udp` is [`LEGACY_UDP_PORT`](../../android/app/src/main/java/app/myco/aware/AwareRadio.kt),
-where pre-`4872` Wi-Fi Aware peers still listen, so the number appears twice in
-this codebase for unrelated reasons. There is no bind conflict — TCP and UDP have
-separate port spaces, and the auth service is TCP — but anyone reading a packet
-capture or a `netstat` should know both exist before concluding one is the other. It is a Myco constant rather than something negotiated;
+Those neighbours are all UDP and this is TCP, so sharing a number would not have
+collided at the socket level. It was moved anyway: a port number that means two
+different things in one codebase is a trap for whoever next reads a packet
+capture or a `netstat`. It is a Myco constant rather than something negotiated;
 peers agree by running the same version.
 
 See [../design/identity-pairing.md](../design/identity-pairing.md) and

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -79,7 +79,13 @@ an unpaired peer is refused before the WebSocket upgrade, and the relay rejects
 the pairing kinds from every source so they never reach the event store.
 
 `4871` sits just past the relay's `4870` and clear of `4869`, which public Nostr
-relays commonly take. It is a Myco constant rather than something negotiated;
+relays commonly take.
+
+**Note the overlap.** `4871/udp` is [`LEGACY_UDP_PORT`](../../android/app/src/main/java/app/myco/aware/AwareRadio.kt),
+where pre-`4872` Wi-Fi Aware peers still listen, so the number appears twice in
+this codebase for unrelated reasons. There is no bind conflict — TCP and UDP have
+separate port spaces, and the auth service is TCP — but anyone reading a packet
+capture or a `netstat` should know both exist before concluding one is the other. It is a Myco constant rather than something negotiated;
 peers agree by running the same version.
 
 See [../design/identity-pairing.md](../design/identity-pairing.md) and

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -18,8 +18,9 @@ sync-over-FIPS), [../design/nsite-layer.md §3.2](../design/nsite-layer.md)
 
 | Service | Listen address | Default port | Reached by | Exposed over FIPS? |
 | --- | --- | --- | --- | --- |
-| Embedded Nostr relay | `127.0.0.1` (localhost) | **4870** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:4870` |
-| Embedded Blossom server | `127.0.0.1` (localhost) | **24243** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:24243` |
+| Embedded Nostr relay | `127.0.0.1` (localhost) | **4870** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:4870`, paired peers only |
+| Auth service (pairing) | `[::]` (mesh only) | **4871** | peers asking to pair | **Yes** — at `<npub>.fips:4871`, and the only port open to a peer we have never met |
+| Embedded Blossom server | `127.0.0.1` (localhost) | **24243** | local gateway + sync engine; peer sync engines | **Yes** — at `<npub>.fips:24243`, paired peers only |
 | Local HTTP gateway | `127.0.0.1` (localhost) | **80** | any browser on the device (system-wide `*.nsite` interception) | **No** — localhost-only, never over the mesh |
 | DNS interceptor | inside the VpnService/TUN reader (not a bound socket) | n/a | the whole device's resolver | n/a — it *produces* the addresses below |
 | FIPS IPv6 adapter | FSP port **256** (internal mesh port, not a localhost socket) | 256 | FIPS session layer | n/a — this is the mesh transport that *carries* IPv6 to `fd00::` |
@@ -60,6 +61,29 @@ unchanged.
   identified by the **holder's device** npub (the mesh address) — different keys.
   See
   [../design/nsite-layer.md §5.2](../design/nsite-layer.md).
+
+## 1a. Auth service — `4871`
+
+- **Listen:** `http://[::]:4871` on the mesh only (IPV6_V6ONLY, so it cannot
+  collide with a loopback squatter). There is no localhost listener: nothing on
+  this device needs to pair with itself.
+- **Route:** `POST /pair`, body a signed pairing event (kinds 9101 / 9102 /
+  9103). Answers `200 paired`, `202 pending` (a request waiting on the user), or
+  `403 declined`.
+- **Reached by:** any peer, paired or not. This is deliberate and it is the only
+  such port — pairing is what *creates* the circle that gates everything else,
+  so it cannot itself require membership.
+
+Because bootstrap lives here, the relay and Blossom ports have **no exceptions**:
+an unpaired peer is refused before the WebSocket upgrade, and the relay rejects
+the pairing kinds from every source so they never reach the event store.
+
+`4871` sits just past the relay's `4870` and clear of `4869`, which public Nostr
+relays commonly take. It is a Myco constant rather than something negotiated;
+peers agree by running the same version.
+
+See [../design/identity-pairing.md](../design/identity-pairing.md) and
+[../../reference/thinning-custom-relay.md](../../reference/thinning-custom-relay.md) (D6).
 
 ## 2. Embedded Blossom server — `24243`
 

--- a/myco-blossom/src/lib.rs
+++ b/myco-blossom/src/lib.rs
@@ -1,7 +1,12 @@
 //! `myco-blossom` — a generic embedded **Blossom blob store**: a content-
 //! addressed filesystem store keyed by sha256, implementing `nsite-deck`'s
-//! [`BlobStore`] seam. **Always embedded** (there is no good Android Blossom app
-//! to forward to). See `docs/design/nsite-layer.md` §2.2.
+//! [`BlobStore`] seam. See `docs/design/nsite-layer.md` §2.2.
+//!
+//! This is currently the **only** implementation of that seam, and the default.
+//! A second one that reads through to an external Blossom server is planned but
+//! **not built** (`reference/thinning-custom-relay.md`, D9); the read fast path
+//! below is written on the assumption that this store owns its own directory,
+//! and that assumption is what a shared store would break.
 //!
 //! Storage shape (matching the Go reference's `blobs/` dir): each blob is a file
 //! named by its lowercase-hex sha256 under `root/`. Blobs are immutable and

--- a/myco-blossom/src/server.rs
+++ b/myco-blossom/src/server.rs
@@ -20,11 +20,23 @@ use nsite_deck::seams::BlobStore;
 
 use crate::FsBlobStore;
 
-/// Decides whether a non-loopback (mesh) source may touch our Blossom. `myco-core`
-/// backs this with the Circle so only paired peers can pull/push blobs; loopback
-/// (the in-app gateway) always bypasses it. Behind an `Arc` so the **live** Circle
-/// is consulted per request — membership changes at runtime.
-pub type AccessFn = Arc<dyn Fn(IpAddr) -> bool + Send + Sync>;
+/// What a request wants to do, so a gate can allow reads while refusing writes.
+/// Uploads cost us disk and nothing in normal operation needs them (propagation
+/// is pull-based), so the two are worth separating.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlobOp {
+    /// `GET` / `HEAD` a blob.
+    Read,
+    /// `PUT /upload`.
+    Write,
+}
+
+/// Decides whether a non-loopback (mesh) source may perform `op` on our Blossom.
+/// `myco-core` backs this with the Circle and its per-peer permissions, so only
+/// paired peers can pull, and only peers granted upload can push; loopback (the
+/// in-app gateway) always bypasses it. Behind an `Arc` so the **live** Circle is
+/// consulted per request — membership and permissions change at runtime.
+pub type AccessFn = Arc<dyn Fn(IpAddr, BlobOp) -> bool + Send + Sync>;
 
 /// Shared handler state: the blob store plus an optional mesh access gate.
 #[derive(Clone)]
@@ -34,10 +46,11 @@ struct BlossomState {
 }
 
 impl BlossomState {
-    /// Loopback is always allowed; a mesh source must pass the gate (if one is set).
-    fn allows(&self, addr: SocketAddr) -> bool {
+    /// Loopback is always allowed; a mesh source must pass the gate (if one is
+    /// set) for the operation it is attempting.
+    fn allows(&self, addr: SocketAddr, op: BlobOp) -> bool {
         let ip = addr.ip();
-        ip.is_loopback() || self.access.as_ref().is_none_or(|a| a(ip))
+        ip.is_loopback() || self.access.as_ref().is_none_or(|a| a(ip, op))
     }
 }
 
@@ -132,7 +145,7 @@ async fn get_blob(
     State(st): State<BlossomState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> Response {
-    if !st.allows(addr) {
+    if !st.allows(addr, BlobOp::Read) {
         return StatusCode::FORBIDDEN.into_response();
     }
     match st.store.get(&blob_hash(&sha256)).await {
@@ -151,7 +164,7 @@ async fn head_blob(
     State(st): State<BlossomState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> StatusCode {
-    if !st.allows(addr) {
+    if !st.allows(addr, BlobOp::Read) {
         return StatusCode::FORBIDDEN;
     }
     if st.store.has(&blob_hash(&sha256)).await {
@@ -166,7 +179,9 @@ async fn upload(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     body: Bytes,
 ) -> Response {
-    if !st.allows(addr) {
+    // Uploads are the one operation a paired peer is not granted by default:
+    // nothing in normal operation pushes blobs to a peer, and it costs us disk.
+    if !st.allows(addr, BlobOp::Write) {
         return StatusCode::FORBIDDEN.into_response();
     }
     match st.store.put(&body).await {

--- a/myco-blossom/src/server.rs
+++ b/myco-blossom/src/server.rs
@@ -1,6 +1,8 @@
 //! The BUD-01 Blossom HTTP server over [`FsBlobStore`], so the node can serve its
-//! blobs to mesh peers at `http://[fd00::self]:24243`. No auth on the mesh-local
-//! server (the blob hash is self-authenticating). Routes:
+//! blobs to mesh peers at `http://[fd00::self]:24243`. Blobs are
+//! self-authenticating, so there is no per-blob auth; access is decided per
+//! request by an [`AccessFn`] taking the [`BlobOp`], which is how `myco-core`
+//! grants reads to paired peers while withholding uploads. Routes:
 //!
 //! - `GET  /<sha256>` → blob bytes (`application/octet-stream`; the gateway infers
 //!   the real content-type from the manifest path, not from Blossom).

--- a/myco-core/Cargo.toml
+++ b/myco-core/Cargo.toml
@@ -35,6 +35,9 @@ socket2 = { workspace = true }
 simple-dns = "0.11.2"
 
 [dev-dependencies]
+# Drive the axum routers directly in tests, so a handler can be exercised with a
+# synthetic peer address (a real socket can only ever be loopback here).
+tower = { version = "0.5", features = ["util"] }
 nsite-deck = { path = "../nsite-deck", features = ["testing"] }
 tokio-tungstenite = { workspace = true }
 

--- a/myco-core/Cargo.toml
+++ b/myco-core/Cargo.toml
@@ -26,6 +26,10 @@ tokio = { workspace = true }
 reqwest = { workspace = true }
 tokio-tungstenite = { workspace = true }
 futures-util = { workspace = true }
+# The mesh relay proxy (`mesh_relay`) is an axum WebSocket server, bound
+# IPV6_V6ONLY via socket2 so `[::]:4870` does not collide with the loopback bind.
+axum = { workspace = true }
+socket2 = { workspace = true }
 # `dns_intercept` synthesises the AAAA query it sends to the node's built-in
 # `.fips` responder for route warming. Matches fips's pin.
 simple-dns = "0.11.2"

--- a/myco-core/src/action.rs
+++ b/myco-core/src/action.rs
@@ -110,6 +110,11 @@ pub enum NativeAppAction {
     /// rather than pretending the change is immediate.
     SetCustomRelay { url: String },
 
+    /// Point the blob store at a **custom Blossom server**, or back at the
+    /// built-in one with an empty `url`. Persisted and applied on the next
+    /// launch, like [`NativeAppAction::SetCustomRelay`].
+    SetCustomBlossom { url: String },
+
     /// Set this device's human label (memorable name). Stamped on outgoing pair
     /// request/accept events so peers show the name the user chose. The Android
     /// app owns the value (persisted there) and re-applies it on launch.

--- a/myco-core/src/action.rs
+++ b/myco-core/src/action.rs
@@ -101,6 +101,15 @@ pub enum NativeAppAction {
     /// when this device has internet (e.g. it's acting as a hotspot).
     SetOfflineOnly { enabled: bool },
 
+    /// Point the event store at a **custom relay**, or back at the built-in one
+    /// with an empty `url`.
+    ///
+    /// Persisted and applied on the next launch: the backend is chosen when the
+    /// content layer is constructed, so swapping it live would mean tearing down
+    /// and rebuilding everything holding state on top of it. The UI says so
+    /// rather than pretending the change is immediate.
+    SetCustomRelay { url: String },
+
     /// Set this device's human label (memorable name). Stamped on outgoing pair
     /// request/accept events so peers show the name the user chose. The Android
     /// app owns the value (persisted there) and re-applies it on launch.

--- a/myco-core/src/auth_service.rs
+++ b/myco-core/src/auth_service.rs
@@ -1,4 +1,4 @@
-//! The **auth plane**: a small HTTP service on `:4871` whose only job is the
+//! The **auth plane**: a small HTTP service on `:4873` whose only job is the
 //! pairing handshake.
 //!
 //! Pairing is what *creates* the circle, and the circle is what gates everything
@@ -46,9 +46,15 @@ use nostr::Event;
 use crate::content::Content;
 
 /// The auth plane's port. A Myco constant, not negotiated: peers agree by running
-/// the same version, which is fine pre-1.0. Chosen just past the relay's 4870 and
-/// clear of 4869, which public Nostr relays commonly take.
-pub const AUTH_PORT: u16 = 4871;
+/// the same version, which is fine pre-1.0.
+///
+/// Clear of every number already spoken for: 4869 is what public Nostr relays
+/// commonly take, 4870 is our relay, 4871 is the LAN/AP lane (and where
+/// pre-4872 Wi-Fi Aware peers still listen), and 4872 is the Aware lane. Those
+/// are UDP and this is TCP, so an overlap would not have collided — but a number
+/// that means two things in one codebase is a trap for whoever next reads a
+/// packet capture.
+pub const AUTH_PORT: u16 = 4873;
 
 /// A signed pair event is a few hundred bytes; anything larger is not one.
 const MAX_BODY: usize = 8 * 1024;

--- a/myco-core/src/auth_service.rs
+++ b/myco-core/src/auth_service.rs
@@ -224,7 +224,17 @@ async fn pair(
 
     // Membership is committed **before** we reply, so a peer that dials the relay
     // the instant it sees a 200 is already admitted by the gate.
-    st.content.handle_pair_event(&event);
+    //
+    // A refusal here is an authorisation failure, not a malformed request: the
+    // event was signed and fresh, but it was addressed to someone else, or it
+    // is an accept for an invite we never sent.
+    if !st.content.handle_pair_event(&event) {
+        tracing::warn!(peer = %ip, kind, "auth: pair event refused");
+        return json(
+            StatusCode::FORBIDDEN,
+            serde_json::json!({ "status": "declined", "reason": "not authorised" }),
+        );
+    }
 
     let status = match kind {
         crate::content::KIND_PAIR_ACCEPT => (StatusCode::OK, "paired"),
@@ -303,9 +313,13 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         tokio::spawn(serve_on(content.clone(), listener));
 
+        // This device's identity — a pair event is only honoured if it names us.
+        let us_keys = nostr::Keys::generate();
+        content.set_device_keys(&us_keys.secret_key().to_bech32().unwrap());
+        let us = us_keys.public_key().to_bech32().unwrap();
+
         // A device we have never seen asks to pair.
         let stranger = nostr::Keys::generate();
-        let us = nostr::Keys::generate().public_key().to_bech32().unwrap();
         let event = crate::content::build_pair_event(
             &stranger,
             crate::content::KIND_PAIR_REQUEST,
@@ -345,6 +359,126 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// **An accept nobody asked for must not join the Circle.**
+    ///
+    /// A signature proves who wrote an event, never that we wanted it. Without
+    /// this check anyone could sign a kind-9102, POST it to the one port open to
+    /// strangers, and be admitted — which by default grants relay read/write,
+    /// blob reads, and multihop forwarding. The accept is only honoured against
+    /// an invite we actually sent.
+    #[tokio::test]
+    async fn an_accept_we_never_invited_is_refused() {
+        use nostr::nips::nip19::ToBech32;
+
+        let dir = std::env::temp_dir().join(format!("myco-auth-unsol-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let content = Arc::new(Content::open(&dir).unwrap());
+        let us_keys = nostr::Keys::generate();
+        content.set_device_keys(&us_keys.secret_key().to_bech32().unwrap());
+        let us = us_keys.public_key().to_bech32().unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_on(content.clone(), listener));
+
+        let stranger = nostr::Keys::generate();
+        let accept = crate::content::build_pair_event(
+            &stranger,
+            crate::content::KIND_PAIR_ACCEPT,
+            &us,
+            "Stranger",
+            "",
+        )
+        .unwrap();
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://{addr}/pair"))
+            .body(serde_json::to_string(&accept).unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+        assert!(
+            content.circle_snapshot().is_empty(),
+            "an uninvited accept must not put anyone in the circle"
+        );
+
+        // The same accept *is* honoured once we have actually invited them. The
+        // invite is recorded before the dial, and the dial retries for a minute
+        // against a peer that is not there, so let it run in the background and
+        // wait for the record rather than the delivery.
+        let inviting = content.clone();
+        let target = stranger.public_key().to_bech32().unwrap();
+        tokio::spawn(async move { inviting.send_pair_request(&target, "Stranger", "").await });
+        for _ in 0..50 {
+            if !content.outbound_pairs_snapshot().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            !content.outbound_pairs_snapshot().is_empty(),
+            "the invite was recorded"
+        );
+        let resp = reqwest::Client::new()
+            .post(format!("http://{addr}/pair"))
+            .body(serde_json::to_string(&accept).unwrap())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(content.circle_snapshot().len(), 1, "the invited peer joins");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A pair event addressed to somebody else must not be usable against us.
+    ///
+    /// The signature covers the `p` tag but says nothing about who the event was
+    /// *for*, so one captured off the wire verifies perfectly when replayed at a
+    /// third party.
+    #[tokio::test]
+    async fn a_pair_event_for_someone_else_is_refused() {
+        use nostr::nips::nip19::ToBech32;
+
+        let dir = std::env::temp_dir().join(format!("myco-auth-replay-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let content = Arc::new(Content::open(&dir).unwrap());
+        content.set_device_keys(&nostr::Keys::generate().secret_key().to_bech32().unwrap());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_on(content.clone(), listener));
+
+        // Addressed to a third device, not to us.
+        let stranger = nostr::Keys::generate();
+        let someone_else = nostr::Keys::generate().public_key().to_bech32().unwrap();
+        let event = crate::content::build_pair_event(
+            &stranger,
+            crate::content::KIND_PAIR_REQUEST,
+            &someone_else,
+            "Stranger",
+            "s3cret",
+        )
+        .unwrap();
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://{addr}/pair"))
+            .body(serde_json::to_string(&event).unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+        assert!(
+            content.pending_pairs_snapshot().is_empty(),
+            "a replayed request must not raise a prompt here"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// A tampered pair event must be refused. The signature is the only thing
     /// tying a request to an npub, so this is the door itself.
     #[tokio::test]
@@ -359,8 +493,11 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         tokio::spawn(serve_on(content.clone(), listener));
 
+        let us_keys = nostr::Keys::generate();
+        content.set_device_keys(&us_keys.secret_key().to_bech32().unwrap());
+        let us = us_keys.public_key().to_bech32().unwrap();
+
         let stranger = nostr::Keys::generate();
-        let us = nostr::Keys::generate().public_key().to_bech32().unwrap();
         let event = crate::content::build_pair_event(
             &stranger,
             crate::content::KIND_PAIR_ACCEPT,

--- a/myco-core/src/auth_service.rs
+++ b/myco-core/src/auth_service.rs
@@ -1,0 +1,401 @@
+//! The **auth plane**: a small HTTP service on `:4871` whose only job is the
+//! pairing handshake.
+//!
+//! Pairing is what *creates* the circle, and the circle is what gates everything
+//! else — so bootstrap has no business travelling on the plane it authorises.
+//! Before this, an unpaired stranger could publish to the relay port (a kind
+//! whitelist in the access gate let the three pairing kinds through), and the
+//! handshake event was written into the event store as a side effect even though
+//! nothing ever read it back. With a swappable relay behind us that would mean
+//! handing a stranger a write path into a store we do not own.
+//!
+//! So pairing terminates here instead, and the content ports (`:4870` relay,
+//! `:24243` Blossom) can require membership with no exceptions.
+//!
+//! ```text
+//! POST /pair    body: a signed pair event (9101 request / 9102 accept / 9103 remove)
+//!   200 {"status":"paired"}     an accept, processed — they are in our circle
+//!   202 {"status":"pending"}    a request, waiting on the user
+//!   403 {"status":"declined"}   refused
+//! ```
+//!
+//! One route, not three: the kind is already in the event. The payload stays a
+//! signed Nostr event because the signature *is* the pairing identity proof —
+//! what changed is where it stops, not what it looks like.
+//!
+//! **No tokens, no sessions.** FIPS addresses are identity-derived and Noise-IK
+//! authenticated, so the mesh address already *is* the authenticated npub. The
+//! only output of this service is a circle membership commit, which is exactly
+//! what the content gates read. A session credential would be redundant crypto
+//! over an already-authenticated channel.
+//!
+//! See `reference/thinning-custom-relay.md` (D6).
+
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use axum::extract::{ConnectInfo, DefaultBodyLimit, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::Router;
+use nostr::Event;
+
+use crate::content::Content;
+
+/// The auth plane's port. A Myco constant, not negotiated: peers agree by running
+/// the same version, which is fine pre-1.0. Chosen just past the relay's 4870 and
+/// clear of 4869, which public Nostr relays commonly take.
+pub const AUTH_PORT: u16 = 4871;
+
+/// A signed pair event is a few hundred bytes; anything larger is not one.
+const MAX_BODY: usize = 8 * 1024;
+
+/// Sustained rate per source address, and the burst it may spend at once.
+/// Pairing is user-driven — a human never exceeds this — so the limit only ever
+/// bites on something automated.
+const RATE_PER_SEC: f64 = 1.0;
+const RATE_BURST: f64 = 5.0;
+
+/// Ceiling on pair requests being handled at once, across all sources, so a burst
+/// cannot saturate a BLE radio.
+const MAX_IN_FLIGHT: usize = 8;
+
+/// Per-source token bucket. A source that empties its bucket is delayed, not
+/// banned: there is no identity to ban that costs a mesh peer anything to
+/// replace, and a failed attempt is not evidence of bad intent. Failures cost the
+/// same as successes for the same reason.
+struct Bucket {
+    tokens: f64,
+    last: Instant,
+}
+
+#[derive(Default)]
+struct Limiter {
+    buckets: Mutex<HashMap<IpAddr, Bucket>>,
+    in_flight: Mutex<usize>,
+}
+
+impl Limiter {
+    /// Take a token for `ip`, or `false` if the bucket is empty.
+    fn take(&self, ip: IpAddr, now: Instant) -> bool {
+        let mut buckets = self.buckets.lock().unwrap();
+        // Bound the table itself: without this a hostile peer could grow it by
+        // dialling from many addresses. Sources at full tokens are idle by
+        // definition, so dropping them loses nothing.
+        if buckets.len() > 1024 {
+            buckets.retain(|_, b| b.tokens < RATE_BURST);
+        }
+        let bucket = buckets.entry(ip).or_insert(Bucket {
+            tokens: RATE_BURST,
+            last: now,
+        });
+        let elapsed = now.saturating_duration_since(bucket.last).as_secs_f64();
+        bucket.tokens = (bucket.tokens + elapsed * RATE_PER_SEC).min(RATE_BURST);
+        bucket.last = now;
+        if bucket.tokens < 1.0 {
+            return false;
+        }
+        bucket.tokens -= 1.0;
+        true
+    }
+}
+
+/// Shared handler state.
+#[derive(Clone)]
+struct AuthState {
+    content: Arc<Content>,
+    limiter: Arc<Limiter>,
+}
+
+/// Bind the auth listener. IPv6 binds are `IPV6_V6ONLY` so `[::]:port` does not
+/// collide with a loopback squatter, matching the other mesh servers.
+pub fn bind(addr: SocketAddr) -> anyhow::Result<tokio::net::TcpListener> {
+    let domain = if addr.is_ipv6() {
+        socket2::Domain::IPV6
+    } else {
+        socket2::Domain::IPV4
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
+    if addr.is_ipv6() {
+        socket.set_only_v6(true)?;
+    }
+    socket.set_reuse_address(true)?;
+    socket.set_nonblocking(true)?;
+    socket.bind(&addr.into())?;
+    socket.listen(128)?;
+    Ok(tokio::net::TcpListener::from_std(socket.into())?)
+}
+
+/// Serve the auth plane on an already-bound listener.
+pub async fn serve_on(
+    content: Arc<Content>,
+    listener: tokio::net::TcpListener,
+) -> anyhow::Result<()> {
+    let state = AuthState {
+        content,
+        limiter: Arc::new(Limiter::default()),
+    };
+    let app = Router::new()
+        .route("/pair", post(pair))
+        .layer(DefaultBodyLimit::max(MAX_BODY))
+        .with_state(state);
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
+    Ok(())
+}
+
+fn json(status: StatusCode, body: serde_json::Value) -> Response {
+    (status, axum::Json(body)).into_response()
+}
+
+async fn pair(
+    State(st): State<AuthState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    body: String,
+) -> Response {
+    let ip = addr.ip();
+
+    if !st.limiter.take(ip, Instant::now()) {
+        return json(
+            StatusCode::TOO_MANY_REQUESTS,
+            serde_json::json!({ "status": "slow down" }),
+        );
+    }
+    // Concurrency ceiling, released when this handler returns.
+    let _guard = match InFlight::acquire(&st.limiter) {
+        Some(g) => g,
+        None => {
+            return json(
+                StatusCode::SERVICE_UNAVAILABLE,
+                serde_json::json!({ "status": "busy" }),
+            )
+        }
+    };
+
+    let Ok(event) = serde_json::from_str::<Event>(&body) else {
+        return json(
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({ "status": "malformed" }),
+        );
+    };
+
+    // The signature is the identity proof: it is what says this pair request
+    // really comes from that npub, and it is checked before anything is touched.
+    if event.verify().is_err() {
+        return json(
+            StatusCode::FORBIDDEN,
+            serde_json::json!({ "status": "declined", "reason": "bad signature" }),
+        );
+    }
+
+    // Freshness is now an explicit check rather than a side effect of the store
+    // GCing expired events, since nothing is stored any more.
+    if myco_relay::expiration(&event).is_some_and(|exp| exp <= crate::content::now_secs()) {
+        return json(
+            StatusCode::FORBIDDEN,
+            serde_json::json!({ "status": "declined", "reason": "expired" }),
+        );
+    }
+
+    let kind = event.kind.as_u16();
+    if !matches!(
+        kind,
+        crate::content::KIND_PAIR_REQUEST
+            | crate::content::KIND_PAIR_ACCEPT
+            | crate::content::KIND_PAIR_REMOVE
+    ) {
+        return json(
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({ "status": "declined", "reason": "not a pairing event" }),
+        );
+    }
+
+    // Membership is committed **before** we reply, so a peer that dials the relay
+    // the instant it sees a 200 is already admitted by the gate.
+    st.content.handle_pair_event(&event);
+
+    let status = match kind {
+        crate::content::KIND_PAIR_ACCEPT => (StatusCode::OK, "paired"),
+        crate::content::KIND_PAIR_REMOVE => (StatusCode::OK, "unpaired"),
+        // A request needs a human, so it is accepted-for-processing, not done.
+        _ => (StatusCode::ACCEPTED, "pending"),
+    };
+    tracing::info!(peer = %ip, kind, status = status.1, "auth: pair handled");
+    json(status.0, serde_json::json!({ "status": status.1 }))
+}
+
+/// RAII guard for the in-flight ceiling.
+struct InFlight(Arc<Limiter>);
+
+impl InFlight {
+    fn acquire(limiter: &Arc<Limiter>) -> Option<Self> {
+        let mut n = limiter.in_flight.lock().unwrap();
+        if *n >= MAX_IN_FLIGHT {
+            return None;
+        }
+        *n += 1;
+        Some(Self(limiter.clone()))
+    }
+}
+
+impl Drop for InFlight {
+    fn drop(&mut self) {
+        *self.0.in_flight.lock().unwrap() -= 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(n: u8) -> IpAddr {
+        IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, n))
+    }
+
+    /// The bucket has to allow a normal human pairing burst and still stop a
+    /// runaway, and it must refill over time rather than latching shut.
+    #[test]
+    fn rate_limit_allows_a_burst_then_refills() {
+        let limiter = Limiter::default();
+        let t0 = Instant::now();
+
+        for i in 0..RATE_BURST as usize {
+            assert!(limiter.take(ip(1), t0), "burst token {i} should be allowed");
+        }
+        assert!(!limiter.take(ip(1), t0), "burst exhausted");
+
+        // A second later, one token is back.
+        let t1 = t0 + std::time::Duration::from_secs(1);
+        assert!(limiter.take(ip(1), t1), "bucket refills");
+        assert!(!limiter.take(ip(1), t1));
+
+        // One source running dry does not affect another.
+        assert!(limiter.take(ip(2), t1), "limits are per source");
+    }
+
+    /// An unpaired stranger must be able to pair here — and only here.
+    ///
+    /// This is the whole point of the auth plane: the handshake lands, membership
+    /// is committed, and nothing was written to the event store on the way. The
+    /// relay's gate refusing the same event is the other half, covered by
+    /// `content::tests`.
+    #[tokio::test]
+    async fn a_stranger_can_pair_and_nothing_is_stored() {
+        use nostr::nips::nip19::ToBech32;
+
+        let dir = std::env::temp_dir().join(format!("myco-auth-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let content = Arc::new(Content::open(&dir).unwrap());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_on(content.clone(), listener));
+
+        // A device we have never seen asks to pair.
+        let stranger = nostr::Keys::generate();
+        let us = nostr::Keys::generate().public_key().to_bech32().unwrap();
+        let event = crate::content::build_pair_event(
+            &stranger,
+            crate::content::KIND_PAIR_REQUEST,
+            &us,
+            "Stranger",
+            "s3cret",
+        )
+        .expect("build pair request");
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://{addr}/pair"))
+            .body(serde_json::to_string(&event).unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::ACCEPTED,
+            "a request is pending a human, not yet paired"
+        );
+
+        let pending = content.pending_pairs_snapshot();
+        assert_eq!(pending.len(), 1, "the request surfaced for the user");
+        assert_eq!(pending[0].npub, stranger.public_key().to_bech32().unwrap());
+        assert_eq!(pending[0].secret, "s3cret");
+
+        assert_eq!(
+            content.relay().count(),
+            0,
+            "the handshake is control traffic — nothing reaches the event store"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A tampered pair event must be refused. The signature is the only thing
+    /// tying a request to an npub, so this is the door itself.
+    #[tokio::test]
+    async fn a_forged_pair_event_is_refused() {
+        use nostr::nips::nip19::ToBech32;
+
+        let dir = std::env::temp_dir().join(format!("myco-auth-forge-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let content = Arc::new(Content::open(&dir).unwrap());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_on(content.clone(), listener));
+
+        let stranger = nostr::Keys::generate();
+        let us = nostr::Keys::generate().public_key().to_bech32().unwrap();
+        let event = crate::content::build_pair_event(
+            &stranger,
+            crate::content::KIND_PAIR_ACCEPT,
+            &us,
+            "Stranger",
+            "",
+        )
+        .unwrap();
+        // Claim a different display name after signing.
+        let mut raw = serde_json::to_value(&event).unwrap();
+        raw["tags"] = serde_json::json!([["n", "Someone Else"]]);
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://{addr}/pair"))
+            .body(raw.to_string())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+        assert!(
+            content.circle_snapshot().is_empty(),
+            "a forged accept must not put anyone in the circle"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The ceiling must release as handlers finish, or the service latches at
+    /// "busy" after the first burst.
+    #[test]
+    fn in_flight_ceiling_releases() {
+        let limiter = Arc::new(Limiter::default());
+        let guards: Vec<_> = (0..MAX_IN_FLIGHT)
+            .map(|_| InFlight::acquire(&limiter).expect("under the ceiling"))
+            .collect();
+        assert!(
+            InFlight::acquire(&limiter).is_none(),
+            "at the ceiling, further requests are refused"
+        );
+        drop(guards);
+        assert!(
+            InFlight::acquire(&limiter).is_some(),
+            "capacity returns once handlers finish"
+        );
+    }
+}

--- a/myco-core/src/auth_service.rs
+++ b/myco-core/src/auth_service.rs
@@ -328,7 +328,10 @@ mod tests {
         assert_eq!(pending[0].secret, "s3cret");
 
         assert_eq!(
-            content.relay().count(),
+            content
+                .relay_store()
+                .expect("embedded store in tests")
+                .count(),
             0,
             "the handshake is control traffic — nothing reaches the event store"
         );

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -345,7 +345,16 @@ impl crate::mesh_relay::PeerGate for CircleGate {
 /// The content layer. Cheap to `Arc`-clone; the gateway path clones one out of the
 /// `AppRuntime` mutex and serves without holding it.
 pub struct Content {
-    relay: Arc<RelayStore>,
+    /// The event store, through the seam — so it can be the embedded relay or
+    /// any other NIP-01 relay (`reference/thinning-custom-relay.md`, D3).
+    relay: Arc<dyn RelayBackend>,
+    /// The embedded store, when that is what `relay` points at.
+    ///
+    /// Held separately because two things it answers are not NIP-01 and cannot
+    /// be asked of an arbitrary relay: the usage counts the Storage screen
+    /// shows, and the selective retain the cache wipe needs. `None` once a
+    /// custom relay is configured, which is exactly what the screen reports.
+    relay_store: Option<Arc<RelayStore>>,
     blobs: Arc<FsBlobStore>,
     /// The pull source for not-yet-present sites. `None` in P2 M2 (local only);
     /// set to the IP online-fallback source in M3, the FIPS source in P3.
@@ -413,7 +422,7 @@ pub struct Content {
 /// straight through to the relay. This is what keeps a working app serving while a
 /// newer manifest is still downloading. See `docs/design/nsite-updates.md` §1.
 struct ActiveBackend<'a> {
-    relay: &'a RelayStore,
+    relay: &'a dyn RelayBackend,
     active: &'a Mutex<HashMap<String, Event>>,
 }
 
@@ -500,7 +509,25 @@ fn event_d_tag(ev: &Event) -> Option<String> {
 impl Content {
     /// Open the content layer under `data_dir` (relay + blossom subdirs).
     pub fn open(data_dir: &Path) -> anyhow::Result<Self> {
-        let relay = Arc::new(RelayStore::open(data_dir.join("relay"))?);
+        Self::open_with_relay(data_dir, None)
+    }
+
+    /// Open with events stored on a **custom relay** instead of the embedded one.
+    ///
+    /// The embedded store is still opened and still occupies disk — it simply
+    /// stops serving, which is what the Storage screen reports. Nothing else in
+    /// the content layer changes: it reads and writes through the seam either
+    /// way (`reference/thinning-custom-relay.md`, D3).
+    pub fn open_with_relay(
+        data_dir: &Path,
+        custom: Option<Arc<dyn RelayBackend>>,
+    ) -> anyhow::Result<Self> {
+        let embedded = Arc::new(RelayStore::open(data_dir.join("relay"))?);
+        let using_custom = custom.is_some();
+        let relay: Arc<dyn RelayBackend> = custom.unwrap_or_else(|| embedded.clone());
+        // Kept only while it is the thing serving: the usage counts and the
+        // selective retain it backs describe our store, not someone else's.
+        let relay_store = (!using_custom).then_some(embedded);
         let blobs = Arc::new(FsBlobStore::open(data_dir.join("blossom"))?);
         let library_path = data_dir.join("library.json");
         let library = load_library(&library_path);
@@ -510,6 +537,7 @@ impl Content {
         let active_manifests = load_active(&active_path);
         Ok(Self {
             relay,
+            relay_store,
             blobs,
             source: Mutex::new(None),
             offline_only: AtomicBool::new(false),
@@ -548,9 +576,16 @@ impl Content {
         self.offline_only.load(Ordering::Relaxed)
     }
 
-    /// The relay store (shared), for the mesh WS server.
-    pub fn relay(&self) -> Arc<RelayStore> {
+    /// The event store (shared), for the mesh WS proxy in front of it.
+    pub fn relay(&self) -> Arc<dyn RelayBackend> {
         self.relay.clone()
+    }
+
+    /// The embedded store, if that is what we are using. `None` once a custom
+    /// relay is configured — the caller decides what an absent one means, since
+    /// nothing here can be asked of an arbitrary relay.
+    pub fn relay_store(&self) -> Option<Arc<RelayStore>> {
+        self.relay_store.clone()
     }
 
     /// The blob store (shared), for the mesh Blossom server.
@@ -2032,7 +2067,11 @@ impl Content {
     /// Clear the local relay + Blossom + Library + status (the `WipeStores` dev
     /// action). Content-only; identity is untouched.
     pub async fn wipe(&self) -> anyhow::Result<()> {
-        nsite_deck::seams::AdminBackend::wipe(self.relay.as_ref()).await?;
+        // Only ours to clear. A custom relay's contents belong to whoever runs
+        // it, and NIP-01 has no "delete everything" to ask for anyway.
+        if let Some(store) = &self.relay_store {
+            nsite_deck::seams::AdminBackend::wipe(store.as_ref()).await?;
+        }
         self.blobs.wipe().await?;
         self.library.lock().unwrap().clear();
         self.sites.lock().unwrap().clear();
@@ -2087,7 +2126,9 @@ impl Content {
             }
         }
 
-        self.relay.retain_events(&keep_events);
+        if let Some(store) = &self.relay_store {
+            store.retain_events(&keep_events);
+        }
         self.blobs.retain_blobs(&keep_blobs);
 
         // Drop unpinned Library entries and the live status of anything unpinned.
@@ -2143,10 +2184,12 @@ impl Content {
         // here. Nothing external is configurable yet, so neither flag is set;
         // they follow the configured backend once that lands.
         CacheView {
-            relay_events: self.relay.count() as u64,
+            // The embedded store's own count, or nothing to count when a custom
+            // relay has taken over — which the flag tells the screen to say.
+            relay_events: self.relay_store.as_ref().map_or(0, |s| s.count() as u64),
             blob_count: self.blobs.count() as u64,
             used_bytes: self.blobs.total_bytes(),
-            external_relay: false,
+            external_relay: self.relay_store.is_none(),
             external_blobs: false,
         }
     }
@@ -2441,6 +2484,64 @@ mod tests {
         assert!(p.blossom_read, "reads stay on for an existing peer");
         assert!(p.relay_read && p.relay_write);
         assert!(p.relay_read_multihop && p.relay_write_multihop);
+    }
+
+    /// The content layer works with the store swapped for a relay we do not own.
+    ///
+    /// This is what every phase before it was for: the same import, gateway read
+    /// and library behaviour, with events living on a relay Myco only reaches
+    /// over NIP-01. It also pins what the Storage screen is told — the usage
+    /// counts stop describing what serves, and say so.
+    #[tokio::test]
+    async fn content_runs_on_a_relay_it_does_not_own() {
+        // A relay that is emphatically not ours: its own store, its own socket.
+        let theirs = Arc::new(myco_relay::RelayStore::in_memory());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(crate::mesh_relay::serve_on(theirs.clone(), listener));
+
+        let dir = tmp("custom-relay");
+        let _ = std::fs::remove_dir_all(&dir);
+        let backend: Arc<dyn nsite_deck::RelayBackend> = Arc::new(
+            crate::remote_backend::RemoteBackend::new(format!("ws://{addr}")),
+        );
+        let content = Content::open_with_relay(&dir, Some(backend)).unwrap();
+
+        // Publishing through the content layer lands on their relay, not ours.
+        let site = build_test_site(&[("/index.html", b"hi")], None, Some("Remote"));
+        content
+            .relay()
+            .publish(site.manifest.clone())
+            .await
+            .unwrap();
+        assert_eq!(theirs.count(), 1, "the event went to the custom relay");
+
+        // And reads come back through the seam.
+        let found = nsite_deck::seams::newest_in_slot(
+            content.relay().as_ref(),
+            nsite_deck::KIND_ROOT,
+            &site.author,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(found.map(|e| e.id), Some(site.manifest.id));
+
+        // The Storage screen is told the built-in store is no longer serving.
+        let cache = content.cache_view();
+        assert!(cache.external_relay, "usage must report the swap");
+        assert_eq!(cache.relay_events, 0, "our store holds nothing now");
+        assert!(content.relay_store().is_none());
+
+        // Wiping is ours only: their relay keeps its events.
+        content.wipe().await.unwrap();
+        assert_eq!(
+            theirs.count(),
+            1,
+            "a custom relay's contents are not ours to clear"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The content ports have no exceptions left.

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -111,13 +111,13 @@ pub struct PeerPerms {
     /// May open a `REQ` and receive our stored events.
     #[serde(default = "yes")]
     pub relay_read: bool,
-    /// Their `REQ` may be forwarded to our other peers (`req-ttl` clamp).
+    /// Their `REQ` may be forwarded to our other peers (a hop-budget clamp).
     #[serde(default = "yes")]
     pub relay_read_multihop: bool,
     /// May publish events to us.
     #[serde(default = "yes")]
     pub relay_write: bool,
-    /// Events from them may be forwarded onward by us (`event-ttl` clamp).
+    /// Events from them may be forwarded onward by us (a hop-budget clamp).
     #[serde(default = "yes")]
     pub relay_write_multihop: bool,
     /// May `GET` / `HEAD` blobs from us.
@@ -261,6 +261,12 @@ const PAIR_DIAL_RETRY_DELAY: std::time::Duration = std::time::Duration::from_sec
 /// Hop budget for manifest (update) propagation over the mesh — mirrors the chat
 /// push plane's default. See `docs/design/nsite-updates.md` §4.
 const MANIFEST_EVENT_TTL: u8 = 3;
+
+/// Time budget stamped on a pull this node originates. Relative, and only bounds
+/// how long a node downstream holds query state — late results are not an error,
+/// they simply arrive to whoever is still listening
+/// (`reference/thinning-custom-relay.md`, D8).
+const PULL_BUDGET_MS: u32 = 10_000;
 
 /// The mesh access gate backing the relay + Blossom servers: content (reads, chat,
 /// manifests, blobs) is restricted to **paired** (Circle) peers, and what a paired
@@ -1467,7 +1473,7 @@ impl Content {
         self.peer_relays.send(npub, &url, frame);
     }
 
-    /// Pull plane (req-ttl): forward a REQ's filters to connected Circle peers and
+    /// Pull plane: forward a REQ's filters to connected Circle peers and
     /// aggregate their matching events. `req_ttl` is the remaining forward budget
     /// *after* this hop — it is stamped back into each filter so the next relay
     /// decrements from here (without it the peer would re-read the original value).
@@ -1476,23 +1482,12 @@ impl Content {
     pub async fn pull_from_peers(
         &self,
         filters: Vec<serde_json::Value>,
-        req_ttl: u8,
+        meta: crate::mesh_wire::MeshMeta,
         exclude: Option<std::net::IpAddr>,
     ) -> Vec<Event> {
-        // Re-stamp req-ttl (or strip it at the last hop) on each filter object.
-        let filters: Vec<serde_json::Value> = filters
-            .into_iter()
-            .map(|mut f| {
-                if let Some(obj) = f.as_object_mut() {
-                    if req_ttl > 0 {
-                        obj.insert("req-ttl".to_string(), serde_json::json!(req_ttl));
-                    } else {
-                        obj.remove("req-ttl");
-                    }
-                }
-                f
-            })
-            .collect();
+        // The filters go out untouched — hops, query id, and budget ride the
+        // envelope. `meta` is the *incoming* one, already decremented, so the
+        // query id survives the hop and every node downstream serves it once.
 
         // All filters ride in one REQ per peer over the shared connection (the relay
         // any-matches across them), so a pull is a single round-trip, not one socket
@@ -1506,9 +1501,16 @@ impl Content {
             }
             let url = crate::ip_source::mesh_relay_url(&npub);
             let filters = filters.clone();
+            let meta = meta.clone();
             Some(async move {
-                pool.request(&npub, &url, filters, std::time::Duration::from_secs(8))
-                    .await
+                pool.request_with(
+                    &npub,
+                    &url,
+                    filters,
+                    Some(meta),
+                    std::time::Duration::from_secs(8),
+                )
+                .await
             })
         });
 
@@ -1529,18 +1531,22 @@ impl Content {
                 return Vec::new();
             };
             let relay_url = crate::ip_source::mesh_relay_url(&npub);
-            // Manifest kinds only; `req-ttl: 1` reaches our peers' peers (2 hops),
-            // matching the old `discover_manifests` helper.
+            // Manifest kinds only. One more hop reaches our peers' peers (2 hops
+            // in total), carried in the envelope so the filter stays canonical.
             let filter = serde_json::json!({
                 "kinds": [nsite_deck::KIND_ROOT, nsite_deck::KIND_NAMED],
                 "limit": 200,
-                "req-ttl": 1,
             });
             let events = pool
-                .request(
+                .request_with(
                     &npub,
                     &relay_url,
                     vec![filter],
+                    Some(crate::mesh_wire::MeshMeta::pull(
+                        1,
+                        crate::mesh_wire::new_query_id(),
+                        PULL_BUDGET_MS,
+                    )),
                     std::time::Duration::from_secs(15),
                 )
                 .await;
@@ -1601,13 +1607,12 @@ impl Content {
 
         // Query set, one combined REQ per relay read until EOSE
         // (docs/design/nsite-updates.md §3.2):
-        //  - connected peers' mesh relays, carrying `req-ttl: 1` so the check reaches
+        //  - connected peers' mesh relays, carrying one more hop so the check reaches
         //    2 hops just like discovery (their peers' manifests come back too);
         //  - online relays, unless mesh-only is on.
         let mesh_filter = serde_json::json!({
             "kinds": [nsite_deck::KIND_ROOT, nsite_deck::KIND_NAMED],
             "authors": authors,
-            "req-ttl": 1,
         });
         let online_filter = serde_json::json!({
             "kinds": [nsite_deck::KIND_ROOT, nsite_deck::KIND_NAMED],
@@ -1940,19 +1945,19 @@ impl Content {
     }
 
     /// Fan a manifest to connected Circle peers over the push plane (carrying a
-    /// decremented `event-ttl`), split-horizon. `exclude` is the peer it came from.
+    /// decremented hop budget), split-horizon. `exclude` is the peer it came from.
     fn forward_manifest(&self, manifest: &Event, out_ttl: u8, exclude: Option<IpAddr>) {
-        let mut ev_json = match serde_json::to_value(manifest) {
+        let ev_json = match serde_json::to_value(manifest) {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(error = %e, "manifest gossip: serialize failed");
                 return;
             }
         };
-        if let Some(obj) = ev_json.as_object_mut() {
-            obj.insert("event-ttl".to_string(), serde_json::json!(out_ttl));
-        }
-        let frame = serde_json::json!(["EVENT", ev_json]).to_string();
+        let frame = crate::mesh_wire::wrap(
+            &crate::mesh_wire::MeshMeta::push(out_ttl),
+            serde_json::json!(["EVENT", ev_json]),
+        );
         for npub in self.circle_npubs() {
             let ip = match fips::PeerIdentity::from_npub(&npub) {
                 Ok(p) => IpAddr::V6(p.address().to_ipv6()),

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -276,10 +276,6 @@ const PAIR_TTL_SECS: u64 = 120;
 const PAIR_DIAL_ATTEMPTS: usize = 15;
 const PAIR_DIAL_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(4);
 
-/// Hop budget for manifest (update) propagation over the mesh — mirrors the chat
-/// push plane's default. See `docs/design/nsite-updates.md` §4.
-const MANIFEST_EVENT_TTL: u8 = 3;
-
 /// Time budget stamped on a pull this node originates. Relative, and only bounds
 /// how long a node downstream holds query state — late results are not an error,
 /// they simply arrive to whoever is still listening
@@ -1943,7 +1939,11 @@ impl Content {
             .download_and_activate(addr, candidate.clone(), sources, true)
             .await;
         if activated {
-            self.forward_manifest(&candidate, MANIFEST_EVENT_TTL.saturating_sub(1), None);
+            self.forward_manifest(
+                &candidate,
+                crate::mesh_wire::EVENT_TTL.saturating_sub(1),
+                None,
+            );
         }
         activated
     }
@@ -2043,13 +2043,13 @@ impl Content {
         // check, so that grant was enforced on one plane but not the other (D10).
         let peer_cap = match inbound.sender {
             Some(ip) if !self.may_forward_from(ip) => 0,
-            _ => MANIFEST_EVENT_TTL,
+            _ => crate::mesh_wire::EVENT_TTL,
         };
         let effective = match inbound.origin {
-            Origin::Local => MANIFEST_EVENT_TTL,
+            Origin::Local => crate::mesh_wire::EVENT_TTL,
             Origin::Mesh => inbound.event_ttl.unwrap_or(0),
         }
-        .min(MANIFEST_EVENT_TTL)
+        .min(crate::mesh_wire::EVENT_TTL)
         .min(peer_cap);
         let out_ttl = effective.saturating_sub(1);
 

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -853,15 +853,6 @@ impl Content {
         Ok(outcome)
     }
 
-    /// Import from in-memory artifacts (the IP-sync mirror path / tests).
-    pub async fn import_event_blobs(
-        &self,
-        event: nostr::Event,
-        blobs: &[(String, Vec<u8>)],
-    ) -> anyhow::Result<SyncOutcome> {
-        sync::import_site(self.relay.as_ref(), self.blobs.as_ref(), event, blobs).await
-    }
-
     // --- library ---
 
     pub fn add_to_library(&self, addr: &SiteAddr, title: Option<&str>, added_at: u64) {
@@ -1039,19 +1030,15 @@ impl Content {
             .collect()
     }
 
-    /// Whether `ip` is the mesh ULA of a **current** Circle member. The relay +
-    /// Blossom access gates call this per request, so adding/removing a peer at
-    /// runtime takes effect immediately (no cached set). A peer's ULA is
-    /// `fd…+node_addr[0..15]` — `PeerIdentity::from_npub(npub).address()` — which is
-    /// exactly the source address the mesh sockets see.
-    pub fn is_paired_ip(&self, ip: IpAddr) -> bool {
-        self.perms_for_ip(ip).is_some()
-    }
-
     /// The permissions granted to the peer at `ip`, or `None` if `ip` is not a
     /// current Circle member. One lookup answers both "are they paired" and "what
     /// may they do", so the access checks never consult two sources that could
     /// disagree. See `reference/thinning-custom-relay.md` (D10).
+    ///
+    /// Consulted per request, so adding a peer, removing one, or changing a
+    /// permission takes effect immediately — there is no cached set. A peer's ULA
+    /// is `fd…+node_addr[0..15]` (`PeerIdentity::from_npub(npub).address()`),
+    /// which is exactly the source address the mesh sockets see.
     pub fn perms_for_ip(&self, ip: IpAddr) -> Option<PeerPerms> {
         let IpAddr::V6(v6) = ip else { return None };
         self.circle

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -27,7 +27,7 @@ use nsite_deck::{sync, GatewayResponse, SiteAddr, SyncOutcome};
 use serde::{Deserialize, Serialize};
 
 use myco_blossom::FsBlobStore;
-use myco_relay::server::{Inbound, Origin};
+use crate::mesh_relay::{Inbound, Origin};
 use myco_relay::RelayStore;
 
 /// Per-site sync/readiness, mirroring the FFI `SiteStatus` shape.
@@ -215,7 +215,7 @@ impl CircleGate {
     }
 }
 
-impl myco_relay::server::PeerGate for CircleGate {
+impl crate::mesh_relay::PeerGate for CircleGate {
     fn may_read(&self, ip: IpAddr) -> bool {
         self.content.is_paired_ip(ip)
     }

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -348,6 +348,10 @@ pub struct Content {
     /// The event store, through the seam — so it can be the embedded relay or
     /// any other NIP-01 relay (`reference/thinning-custom-relay.md`, D3).
     relay: Arc<dyn RelayBackend>,
+    /// The custom relay, when one is configured — kept so its reachability can
+    /// be reported. A backend that has gone away otherwise looks like an app
+    /// with no content, every site missing and no explanation.
+    relay_remote: Option<Arc<crate::remote_backend::RemoteBackend>>,
     /// The embedded store, when that is what `relay` points at.
     ///
     /// Held separately because two things it answers are not NIP-01 and cannot
@@ -520,11 +524,14 @@ impl Content {
     /// way (`reference/thinning-custom-relay.md`, D3).
     pub fn open_with_relay(
         data_dir: &Path,
-        custom: Option<Arc<dyn RelayBackend>>,
+        custom: Option<Arc<crate::remote_backend::RemoteBackend>>,
     ) -> anyhow::Result<Self> {
         let embedded = Arc::new(RelayStore::open(data_dir.join("relay"))?);
         let using_custom = custom.is_some();
-        let relay: Arc<dyn RelayBackend> = custom.unwrap_or_else(|| embedded.clone());
+        let relay: Arc<dyn RelayBackend> = match &custom {
+            Some(remote) => remote.clone(),
+            None => embedded.clone(),
+        };
         // Kept only while it is the thing serving: the usage counts and the
         // selective retain it backs describe our store, not someone else's.
         let relay_store = (!using_custom).then_some(embedded);
@@ -537,6 +544,7 @@ impl Content {
         let active_manifests = load_active(&active_path);
         Ok(Self {
             relay,
+            relay_remote: custom,
             relay_store,
             blobs,
             source: Mutex::new(None),
@@ -579,6 +587,15 @@ impl Content {
     /// The event store (shared), for the mesh WS proxy in front of it.
     pub fn relay(&self) -> Arc<dyn RelayBackend> {
         self.relay.clone()
+    }
+
+    /// What to tell the user about the configured relay: its URL, and why it is
+    /// unreachable if it is. Empty when the built-in store is in use.
+    pub fn relay_health(&self) -> crate::remote_backend::BackendHealth {
+        self.relay_remote
+            .as_ref()
+            .map(|r| r.health())
+            .unwrap_or_default()
     }
 
     /// The embedded store, if that is what we are using. `None` once a custom
@@ -2502,9 +2519,9 @@ mod tests {
 
         let dir = tmp("custom-relay");
         let _ = std::fs::remove_dir_all(&dir);
-        let backend: Arc<dyn nsite_deck::RelayBackend> = Arc::new(
-            crate::remote_backend::RemoteBackend::new(format!("ws://{addr}")),
-        );
+        let backend = Arc::new(crate::remote_backend::RemoteBackend::new(format!(
+            "ws://{addr}"
+        )));
         let content = Content::open_with_relay(&dir, Some(backend)).unwrap();
 
         // Publishing through the content layer lands on their relay, not ours.

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -249,7 +249,7 @@ pub struct PairRequestView {
 /// not met on the mesh is the normal case. Recording it means we can say
 /// "waiting" instead of silently dropping it, and refuse to send a second one
 /// for the same peer.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OutboundPairView {
     pub npub: String,
@@ -257,6 +257,13 @@ pub struct OutboundPairView {
     /// Unix seconds when we first tried, so the UI can age it.
     pub since: u64,
 }
+
+/// How long an invite stays valid as proof that we asked to pair.
+///
+/// An accept is only honoured while the matching invite is outstanding, so this
+/// bounds how long a captured accept could be replayed back at us — and stops
+/// invites nobody ever answered accumulating as standing authorisations.
+const INVITE_VALID_SECS: u64 = 7 * 24 * 60 * 60;
 
 /// Mutual-pairing handshake events, POSTed point-to-point to a peer's **auth
 /// service** at `:4873` (never gossiped, and never stored — the relay refuses
@@ -396,7 +403,11 @@ pub struct Content {
     /// Incoming pair requests awaiting the user's accept/decline (UI pop-up).
     pending_pairs: Mutex<Vec<PairRequestView>>,
     /// Invites we sent that are still unanswered (see [`OutboundPairView`]).
+    /// Invites we have sent and not yet had answered. **Persisted**, because an
+    /// accept is only honoured against one of these — an in-memory-only record
+    /// would refuse a legitimate accept that arrives after a restart.
     outbound_pairs: Mutex<Vec<OutboundPairView>>,
+    outbound_pairs_path: PathBuf,
     /// Persistent WS connections to peers' relays, so chat fan-out and manifest
     /// fetches don't pay a fresh connect per message (slow over BLE). `Arc` so a
     /// mesh `PeerSource` can borrow the same pool for its manifest REQs.
@@ -570,6 +581,8 @@ impl Content {
         let blobs_local = custom_blobs.is_none().then_some(embedded_blobs);
         let library_path = data_dir.join("library.json");
         let library = load_library(&library_path);
+        let outbound_pairs_path = data_dir.join("outbound_pairs.json");
+        let outbound_pairs = load_outbound_pairs(&outbound_pairs_path);
         let circle_path = data_dir.join("circle.json");
         let circle = load_circle(&circle_path);
         let active_path = data_dir.join("active.json");
@@ -593,7 +606,8 @@ impl Content {
             device_keys: device_keys.clone(),
             device_name_override: Mutex::new(None),
             pending_pairs: Mutex::new(Vec::new()),
-            outbound_pairs: Mutex::new(Vec::new()),
+            outbound_pairs: Mutex::new(outbound_pairs),
+            outbound_pairs_path,
             peer_relays: Arc::new(crate::peer_relay::PeerRelayPool::new()),
             active_local_subs: Mutex::new(HashMap::new()),
             prev_pool_connected: Mutex::new(HashSet::new()),
@@ -1098,11 +1112,9 @@ impl Content {
             return;
         }
         // Whether they accepted ours or we accepted theirs, any invite we were
-        // holding for this peer is answered.
-        self.outbound_pairs
-            .lock()
-            .unwrap()
-            .retain(|p| p.npub != npub);
+        // holding for this peer is answered — and spent, so it stops being an
+        // authorisation for a second accept.
+        self.drop_invite(npub);
         let mut circle = self.circle.lock().unwrap();
         if let Some(c) = circle.iter_mut().find(|c| c.npub == npub) {
             if !name.is_empty() {
@@ -1301,9 +1313,21 @@ impl Content {
     /// Route an incoming pair event (the gossiper hands us the pair kinds; they are
     /// point-to-point and never gossiped). A **request** surfaces a pop-up; an
     /// **accept** means a peer accepted *our* request → add them to the Circle.
-    pub fn handle_pair_event(self: &Arc<Self>, event: &Event) {
+    /// Returns whether the event was acted on. `false` means it was refused —
+    /// the caller answers the sender accordingly.
+    pub fn handle_pair_event(self: &Arc<Self>, event: &Event) -> bool {
         let Ok(from) = event.pubkey.to_bech32();
         let name = tag_value(event, "n").unwrap_or_else(|| short_name(&from));
+
+        // Addressed to us? Every pair event names its target in a `p` tag, and
+        // the signature covers it. Without this check an event addressed to
+        // someone else can be captured and replayed at us, and it verifies
+        // perfectly — the signature says who wrote it, never who it was for.
+        if !self.is_addressed_to_us(event) {
+            tracing::warn!(from = %from, "pair: refused, not addressed to this device");
+            return false;
+        }
+
         match event.kind.as_u16() {
             KIND_PAIR_REQUEST => {
                 tracing::info!(from = %from, "pair: request received (awaiting accept)");
@@ -1318,6 +1342,18 @@ impl Content {
                 }
             }
             KIND_PAIR_ACCEPT => {
+                // An accept is only meaningful as the answer to an invite we
+                // sent. Without this, anyone could sign one and add themselves
+                // to the Circle unprompted — which grants relay read/write,
+                // blob reads, and multihop forwarding. The signature proves who
+                // sent it, not that we ever asked.
+                if !self.has_outstanding_invite(&from) {
+                    tracing::warn!(
+                        from = %from,
+                        "pair: refused an accept we never invited"
+                    );
+                    return false;
+                }
                 tracing::info!(from = %from, "pair: our request accepted — added to circle");
                 self.add_to_circle(&from, &name);
                 self.pending_pairs
@@ -1341,8 +1377,32 @@ impl Content {
                     .unwrap()
                     .retain(|p| p.npub != from);
             }
-            _ => {}
+            _ => return false,
         }
+        true
+    }
+
+    /// Does this pair event name **us** in its `p` tag?
+    ///
+    /// `false` when the device key is not loaded yet: we cannot tell, and
+    /// guessing in the permissive direction is what this check exists to stop.
+    fn is_addressed_to_us(&self, event: &Event) -> bool {
+        let Some(keys) = self.device_keys.lock().unwrap().clone() else {
+            return false;
+        };
+        tag_value(event, "p").is_some_and(|target| target == keys.public_key().to_hex())
+    }
+
+    /// Is there an invite to `npub` still outstanding — and recent enough to
+    /// still count? Invites are persisted, so this survives a restart between
+    /// sending the request and the peer answering it.
+    fn has_outstanding_invite(&self, npub: &str) -> bool {
+        let now = now_secs();
+        self.outbound_pairs
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|p| p.npub == npub && now.saturating_sub(p.since) <= INVITE_VALID_SECS)
     }
 
     /// Scanned a peer's QR: send a signed pair request to their mesh relay. We do
@@ -1375,6 +1435,11 @@ impl Content {
                 name: name.to_string(),
                 since: now_secs(),
             });
+            let snapshot = outbound.clone();
+            drop(outbound);
+            // Persisted before the dial: the accept can arrive after a restart,
+            // and it is only honoured against a recorded invite.
+            save_outbound_pairs(&self.outbound_pairs_path, &snapshot);
         }
         self.dial_pair_event(target_npub, KIND_PAIR_REQUEST, secret)
             .await;
@@ -1387,10 +1452,18 @@ impl Content {
 
     /// Drop a waiting invite — the user withdrew it, or it is being retried.
     pub fn forget_outbound_pair(&self, npub: &str) {
-        self.outbound_pairs
-            .lock()
-            .unwrap()
-            .retain(|p| p.npub != npub);
+        self.drop_invite(npub);
+    }
+
+    /// Forget an invite, on disk as well as in memory. One place, so an invite
+    /// cannot survive on disk as a standing authorisation after being answered.
+    fn drop_invite(&self, npub: &str) {
+        let snapshot = {
+            let mut outbound = self.outbound_pairs.lock().unwrap();
+            outbound.retain(|p| p.npub != npub);
+            outbound.clone()
+        };
+        save_outbound_pairs(&self.outbound_pairs_path, &snapshot);
     }
 
     fn is_in_circle(&self, npub: &str) -> bool {
@@ -2521,6 +2594,20 @@ fn save_library(path: &Path, items: &[LibraryItem]) {
     }
 }
 
+fn load_outbound_pairs(path: &Path) -> Vec<OutboundPairView> {
+    std::fs::read(path)
+        .ok()
+        .and_then(|raw| serde_json::from_slice(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn save_outbound_pairs(path: &Path, items: &[OutboundPairView]) {
+    if let Ok(json) = serde_json::to_vec(items) {
+        let tmp = path.with_extension("json.tmp");
+        let _ = std::fs::write(&tmp, &json).and_then(|_| std::fs::rename(&tmp, path));
+    }
+}
+
 fn load_circle(path: &Path) -> Vec<CircleContact> {
     std::fs::read(path)
         .ok()
@@ -3057,16 +3144,22 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         let content = Content::open(&dir).unwrap();
 
+        // This device's own identity: a pair event is only honoured if it names
+        // us, so the test has to have one.
+        let us = Keys::generate();
+        content.set_device_keys(&us.secret_key().to_bech32().unwrap());
+        let us_npub = us.public_key().to_bech32().unwrap();
+
         let peer = Keys::generate();
         let peer_npub = peer.public_key().to_bech32().unwrap();
         let content = Arc::new(content);
         content.add_to_circle(&peer_npub, "Peer");
         assert_eq!(content.circle_snapshot().len(), 1);
 
-        // The peer signs a PAIR_REMOVE; handling it drops them from our Circle.
-        let event = build_pair_event(&peer, KIND_PAIR_REMOVE, &peer_npub, "Peer", "")
+        // The peer signs a PAIR_REMOVE addressed to us; handling it drops them.
+        let event = build_pair_event(&peer, KIND_PAIR_REMOVE, &us_npub, "Peer", "")
             .expect("build pair-remove event");
-        content.handle_pair_event(&event);
+        assert!(content.handle_pair_event(&event));
         assert!(
             content.circle_snapshot().is_empty(),
             "peer removed on unpair"

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -268,6 +268,11 @@ const MANIFEST_EVENT_TTL: u8 = 3;
 /// (`reference/thinning-custom-relay.md`, D8).
 const PULL_BUDGET_MS: u32 = 10_000;
 
+/// Longest a single forwarded hop will wait on a peer, used when no budget rode
+/// in (an older peer, or a pull that never carried one). A budget that did
+/// arrive only ever shortens this.
+const PULL_HOP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+
 /// The mesh access gate backing the relay + Blossom servers: content (reads, chat,
 /// manifests, blobs) is restricted to **paired** (Circle) peers, and what a paired
 /// peer may do is its own [`PeerPerms`] record.
@@ -1489,15 +1494,14 @@ impl Content {
             let url = crate::ip_source::mesh_relay_url(&npub);
             let filters = filters.clone();
             let meta = meta.clone();
+            // Wait only as long as the budget that arrived allows, not a fresh
+            // full-length timer. Otherwise this hop's window sits *inside* the
+            // one above it, and a peer further out returns after the requester
+            // has already given up (D8).
+            let timeout = meta.hop_timeout(PULL_HOP_TIMEOUT);
             Some(async move {
-                pool.request_with(
-                    &npub,
-                    &url,
-                    filters,
-                    Some(meta),
-                    std::time::Duration::from_secs(8),
-                )
-                .await
+                pool.request_with(&npub, &url, filters, Some(meta), timeout)
+                    .await
             })
         });
 

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -26,8 +26,8 @@ use nsite_deck::seams::{BlobStore, ManifestFilter, PeerSource, RelayBackend};
 use nsite_deck::{sync, GatewayResponse, SiteAddr, SyncOutcome};
 use serde::{Deserialize, Serialize};
 
-use myco_blossom::FsBlobStore;
 use crate::mesh_relay::{Inbound, Origin};
+use myco_blossom::FsBlobStore;
 use myco_relay::RelayStore;
 
 /// Per-site sync/readiness, mirroring the FFI `SiteStatus` shape.
@@ -1262,7 +1262,8 @@ impl Content {
                 .request(npub, &url, filters, std::time::Duration::from_secs(15))
                 .await;
             for ev in events {
-                if ev.verify().is_ok() && self.relay.store_event(ev).await.unwrap_or(false) {
+                // Signatures were checked by the pool at ingress.
+                if self.relay.store_event(ev).await.unwrap_or(false) {
                     stored += 1;
                 }
             }
@@ -1363,12 +1364,7 @@ impl Content {
             })
         });
 
-        join_all(queries)
-            .await
-            .into_iter()
-            .flatten()
-            .filter(|e: &Event| e.verify().is_ok())
-            .collect()
+        join_all(queries).await.into_iter().flatten().collect()
     }
 
     // --- discovery ("nsites around me") ---
@@ -1402,7 +1398,6 @@ impl Content {
                 .await;
             events
                 .into_iter()
-                .filter(|e| e.verify().is_ok())
                 .filter_map(|ev| nsite_deck::Manifest::from_event(ev).ok())
                 .map(|m| {
                     let addr = SiteAddr {
@@ -1532,9 +1527,6 @@ impl Content {
             for ev in batch {
                 let kind = ev.kind.as_u16();
                 if kind != nsite_deck::KIND_ROOT && kind != nsite_deck::KIND_NAMED {
-                    continue;
-                }
-                if ev.verify().is_err() {
                     continue;
                 }
                 let key = manifest_key(kind, &ev.pubkey, event_d_tag(&ev).as_deref());

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -259,7 +259,7 @@ pub struct OutboundPairView {
 }
 
 /// Mutual-pairing handshake events, POSTed point-to-point to a peer's **auth
-/// service** at `:4871` (never gossiped, and never stored — the relay refuses
+/// service** at `:4873` (never gossiped, and never stored — the relay refuses
 /// these kinds from every source). Signed by the **device** key, which is the
 /// pairing identity, and carrying a NIP-40 expiry the auth service checks on
 /// receipt. See `docs/design/identity-pairing.md`.
@@ -1434,7 +1434,7 @@ impl Content {
     /// attempt rebuilds (re-signs) the event so its NIP-40 expiration stays fresh
     /// across the retry window.
     ///
-    /// This goes to `:4871`, not the relay: pairing creates the circle that gates
+    /// This goes to `:4873`, not the relay: pairing creates the circle that gates
     /// the content ports, so it does not travel on them
     /// (`reference/thinning-custom-relay.md`, D6). Unlike a relay `OK`, the
     /// response distinguishes *delivered and waiting on them* from *never reached

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -359,7 +359,14 @@ pub struct Content {
     /// shows, and the selective retain the cache wipe needs. `None` once a
     /// custom relay is configured, which is exactly what the screen reports.
     relay_store: Option<Arc<RelayStore>>,
-    blobs: Arc<FsBlobStore>,
+    /// The blob store, through the seam — embedded or someone else's Blossom.
+    blobs: Arc<dyn BlobStore>,
+    /// The custom Blossom, when one is configured, so its reachability can be
+    /// reported the same way the relay's is.
+    blobs_remote: Option<Arc<crate::remote_blobs::RemoteBlobStore>>,
+    /// The embedded blob store, when that is what `blobs` points at. Holds the
+    /// usage counts and the selective retain, neither of which is BUD-01.
+    blobs_local: Option<Arc<FsBlobStore>>,
     /// The pull source for not-yet-present sites. `None` in P2 M2 (local only);
     /// set to the IP online-fallback source in M3, the FIPS source in P3.
     source: Mutex<Option<Arc<dyn PeerSource>>>,
@@ -383,7 +390,9 @@ pub struct Content {
     sites: Mutex<HashMap<String, SiteStatusView>>,
     /// The device's Nostr keypair (the pairing identity), used to sign pair
     /// request/accept events. Set once at startup from the persisted nsec.
-    device_keys: Mutex<Option<Keys>>,
+    /// The device keypair. Behind an `Arc` because a remote blob store needs it
+    /// to sign BUD-01 upload authorizations, and it is set after construction.
+    device_keys: Arc<Mutex<Option<Keys>>>,
     /// User-chosen device label (memorable name). Set by the app on launch and on
     /// rename; stamped on outgoing pair events so peers show the chosen name.
     /// Falls back to a name derived from the npub when unset.
@@ -526,6 +535,27 @@ impl Content {
         data_dir: &Path,
         custom: Option<Arc<crate::remote_backend::RemoteBackend>>,
     ) -> anyhow::Result<Self> {
+        Self::open_with_backends(data_dir, custom, None)
+    }
+
+    /// Open with either store — or both — pointed at something we do not own.
+    ///
+    /// The embedded relay and blob directory are still opened and still occupy
+    /// disk; they simply stop serving, which is what the Storage screen reports.
+    /// The two are independent: swapping the relay leaves blobs local, and vice
+    /// versa (`reference/thinning-custom-relay.md`, D3 and D9).
+    pub fn open_with_backends(
+        data_dir: &Path,
+        custom: Option<Arc<crate::remote_backend::RemoteBackend>>,
+        custom_blobs: Option<Arc<crate::remote_blobs::RemoteBlobStore>>,
+    ) -> anyhow::Result<Self> {
+        // A remote blob store signs its uploads with the device key, and the key
+        // is loaded after construction — so share one holder rather than keeping
+        // two copies that could fall out of step.
+        let device_keys: Arc<Mutex<Option<Keys>>> = custom_blobs
+            .as_ref()
+            .map(|b| b.keys())
+            .unwrap_or_else(|| Arc::new(Mutex::new(None)));
         let embedded = Arc::new(RelayStore::open(data_dir.join("relay"))?);
         let using_custom = custom.is_some();
         let relay: Arc<dyn RelayBackend> = match &custom {
@@ -535,7 +565,13 @@ impl Content {
         // Kept only while it is the thing serving: the usage counts and the
         // selective retain it backs describe our store, not someone else's.
         let relay_store = (!using_custom).then_some(embedded);
-        let blobs = Arc::new(FsBlobStore::open(data_dir.join("blossom"))?);
+
+        let embedded_blobs = Arc::new(FsBlobStore::open(data_dir.join("blossom"))?);
+        let blobs: Arc<dyn BlobStore> = match &custom_blobs {
+            Some(remote) => remote.clone(),
+            None => embedded_blobs.clone(),
+        };
+        let blobs_local = custom_blobs.is_none().then_some(embedded_blobs);
         let library_path = data_dir.join("library.json");
         let library = load_library(&library_path);
         let circle_path = data_dir.join("circle.json");
@@ -546,6 +582,8 @@ impl Content {
             relay,
             relay_remote: custom,
             relay_store,
+            blobs_remote: custom_blobs,
+            blobs_local,
             blobs,
             source: Mutex::new(None),
             offline_only: AtomicBool::new(false),
@@ -556,7 +594,7 @@ impl Content {
             connected_peers: Mutex::new(Vec::new()),
             discovered: Mutex::new(Vec::new()),
             sites: Mutex::new(HashMap::new()),
-            device_keys: Mutex::new(None),
+            device_keys: device_keys.clone(),
             device_name_override: Mutex::new(None),
             pending_pairs: Mutex::new(Vec::new()),
             outbound_pairs: Mutex::new(Vec::new()),
@@ -605,9 +643,25 @@ impl Content {
         self.relay_store.clone()
     }
 
-    /// The blob store (shared), for the mesh Blossom server.
-    pub fn blobs(&self) -> Arc<FsBlobStore> {
+    /// The blob store (shared), through the seam.
+    pub fn blobs(&self) -> Arc<dyn BlobStore> {
         self.blobs.clone()
+    }
+
+    /// The embedded blob store, if that is what we are using. The mesh Blossom
+    /// server needs the concrete one: it serves our own blobs to peers, and a
+    /// custom server is reached by its own URL rather than proxied through us.
+    pub fn blobs_local(&self) -> Option<Arc<FsBlobStore>> {
+        self.blobs_local.clone()
+    }
+
+    /// What to tell the user about a configured Blossom: its URL, and why it is
+    /// unreachable if it is.
+    pub fn blobs_health(&self) -> crate::remote_backend::BackendHealth {
+        self.blobs_remote
+            .as_ref()
+            .map(|b| b.health())
+            .unwrap_or_default()
     }
 
     // --- active version (what the gateway serves; docs/design/nsite-updates.md §1) ---
@@ -2146,7 +2200,9 @@ impl Content {
         if let Some(store) = &self.relay_store {
             store.retain_events(&keep_events);
         }
-        self.blobs.retain_blobs(&keep_blobs);
+        if let Some(store) = &self.blobs_local {
+            store.retain_blobs(&keep_blobs);
+        }
 
         // Drop unpinned Library entries and the live status of anything unpinned.
         let pinned_hosts: HashSet<String> = pinned.iter().map(|i| i.url_host.clone()).collect();
@@ -2204,10 +2260,10 @@ impl Content {
             // The embedded store's own count, or nothing to count when a custom
             // relay has taken over — which the flag tells the screen to say.
             relay_events: self.relay_store.as_ref().map_or(0, |s| s.count() as u64),
-            blob_count: self.blobs.count() as u64,
-            used_bytes: self.blobs.total_bytes(),
+            blob_count: self.blobs_local.as_ref().map_or(0, |b| b.count() as u64),
+            used_bytes: self.blobs_local.as_ref().map_or(0, |b| b.total_bytes()),
             external_relay: self.relay_store.is_none(),
-            external_blobs: false,
+            external_blobs: self.blobs_local.is_none(),
         }
     }
 

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -264,10 +264,12 @@ const MANIFEST_EVENT_TTL: u8 = 3;
 
 /// The mesh access gate backing the relay + Blossom servers: content (reads, chat,
 /// manifests, blobs) is restricted to **paired** (Circle) peers, and what a paired
-/// peer may do is its own [`PeerPerms`] record. The one remaining exception is the
-/// pairing handshake, which anyone may publish so a first-time request can
-/// bootstrap — that exception goes away when pairing moves to its own auth
-/// service (`reference/thinning-custom-relay.md`, D6).
+/// peer may do is its own [`PeerPerms`] record.
+///
+/// There are **no exceptions**. Pairing used to need one — an unpaired peer had
+/// to be able to publish the handshake kinds to bootstrap — but that now happens
+/// on the auth plane (`crate::auth_service`), so the content ports can simply
+/// require membership (`reference/thinning-custom-relay.md`, D6).
 ///
 /// Holds the [`Content`] so the live Circle is consulted per request: adding a
 /// peer, removing one, or changing a permission takes effect immediately.
@@ -286,11 +288,19 @@ impl crate::mesh_relay::PeerGate for CircleGate {
         self.content.perms_for_ip(ip).is_some_and(|p| p.relay_read)
     }
 
+    fn may_connect(&self, ip: IpAddr) -> bool {
+        // Membership alone, checked before the WebSocket upgrade. A peer with a
+        // narrower permission set still gets a socket; what it may do with it is
+        // decided per message below.
+        self.content.perms_for_ip(ip).is_some()
+    }
+
     fn may_publish(&self, ip: IpAddr, kind: u16) -> bool {
-        // Pairing handshake is allowed from anyone (it's how a peer becomes
-        // paired); everything else needs membership *and* the write grant.
+        // Pairing kinds are auth-plane control traffic, not content. They are
+        // refused here from every source, paired or not, so nothing writes them
+        // into a store that may not even be ours (D6).
         if kind == KIND_PAIR_REQUEST || kind == KIND_PAIR_ACCEPT || kind == KIND_PAIR_REMOVE {
-            return true;
+            return false;
         }
         self.content.perms_for_ip(ip).is_some_and(|p| p.relay_write)
     }
@@ -1163,7 +1173,7 @@ impl Content {
     /// Route an incoming pair event (the gossiper hands us the pair kinds; they are
     /// point-to-point and never gossiped). A **request** surfaces a pop-up; an
     /// **accept** means a peer accepted *our* request → add them to the Circle.
-    pub fn handle_pair_event(&self, event: &Event) {
+    pub fn handle_pair_event(self: &Arc<Self>, event: &Event) {
         let Ok(from) = event.pubkey.to_bech32();
         let name = tag_value(event, "n").unwrap_or_else(|| short_name(&from));
         match event.kind.as_u16() {
@@ -1186,6 +1196,14 @@ impl Content {
                     .lock()
                     .unwrap()
                     .retain(|p| p.npub != from);
+                // They are a reachable source *now*, so retry anything still
+                // waiting on a holder rather than idling until the next
+                // connected-peer poll edge.
+                for addr in self.retriable_library_addrs() {
+                    let content = self.clone();
+                    let holder = from.clone();
+                    tokio::spawn(async move { content.open_site(addr, Some(holder)).await });
+                }
             }
             KIND_PAIR_REMOVE => {
                 tracing::info!(from = %from, "pair: peer unpaired — removing from circle");
@@ -1280,13 +1298,20 @@ impl Content {
         self.dial_pair_event(npub, KIND_PAIR_REMOVE, "").await;
     }
 
-    /// Build + sign a pair event and publish it to the target's mesh relay,
-    /// **retrying** until the relay acks or we give up. A freshly-paired BLE session
-    /// is flaky (handshake collisions, "connection not ready"), so a single
+    /// Build + sign a pair event and POST it to the target's **auth service**,
+    /// **retrying** until it acks or we give up. A freshly-paired BLE session is
+    /// flaky (handshake collisions, "connection not ready"), so a single
     /// fire-and-forget dial often misses — leaving the Circles asymmetric, which the
     /// access gate then turns into a hard "can't see their apps" failure. Each
     /// attempt rebuilds (re-signs) the event so its NIP-40 expiration stays fresh
     /// across the retry window.
+    ///
+    /// This goes to `:4871`, not the relay: pairing creates the circle that gates
+    /// the content ports, so it does not travel on them
+    /// (`reference/thinning-custom-relay.md`, D6). Unlike a relay `OK`, the
+    /// response distinguishes *delivered and waiting on them* from *never reached
+    /// them*, so a pending request stops the retry loop instead of burning the
+    /// whole window on a peer who already has it.
     async fn dial_pair_event(&self, target_npub: &str, kind: u16, secret: &str) {
         let Some(keys) = self.device_keys.lock().unwrap().clone() else {
             tracing::warn!("pairing: device keys not set");
@@ -1301,7 +1326,7 @@ impl Content {
                 return;
             }
         };
-        let url = crate::ip_source::mesh_relay_url(target_npub);
+        let url = crate::ip_source::mesh_auth_url(target_npub);
         for attempt in 0..PAIR_DIAL_ATTEMPTS {
             if attempt > 0 {
                 tokio::time::sleep(PAIR_DIAL_RETRY_DELAY).await;
@@ -1310,13 +1335,28 @@ impl Content {
                 tracing::warn!(target_npub, "pairing: could not build event");
                 return;
             };
-            if crate::ip_source::publish_event(&url, &event, 0, std::time::Duration::from_secs(10))
-                .await
+            match crate::ip_source::post_pair_event(
+                &url,
+                &event,
+                std::time::Duration::from_secs(10),
+            )
+            .await
             {
-                tracing::info!(target = %target_npub, kind, attempt, "pair: dial delivered");
-                return;
+                crate::ip_source::PairDelivery::Accepted(status) => {
+                    tracing::info!(target = %target_npub, kind, attempt, status, "pair: delivered");
+                    return;
+                }
+                // They answered and said no. Retrying cannot change that, and
+                // hammering a peer that already refused is exactly what the
+                // retry loop must not do.
+                crate::ip_source::PairDelivery::Refused(status) => {
+                    tracing::warn!(target = %target_npub, kind, status, "pair: refused by peer");
+                    return;
+                }
+                crate::ip_source::PairDelivery::Unreachable => {
+                    tracing::debug!(target = %target_npub, kind, attempt, "pair: not delivered, retrying");
+                }
             }
-            tracing::debug!(target = %target_npub, kind, attempt, "pair: dial not delivered, retrying");
         }
         tracing::warn!(
             target = %target_npub,
@@ -2230,7 +2270,7 @@ fn library_addr(item: &LibraryItem) -> Option<SiteAddr> {
 }
 
 /// Seconds since the Unix epoch (Library `added_at`).
-fn now_secs() -> u64 {
+pub(crate) fn now_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -2262,7 +2302,7 @@ fn short_name(npub: &str) -> String {
 /// Build + sign a pair-request/accept event (device key), addressed to
 /// `target_npub` via a `p` tag, carrying our `n` name, the one-time `secret`
 /// (request only), and a short NIP-40 expiration.
-fn build_pair_event(
+pub(crate) fn build_pair_event(
     keys: &Keys,
     kind: u16,
     target_npub: &str,
@@ -2335,6 +2375,56 @@ mod tests {
         assert!(p.blossom_read, "reads stay on for an existing peer");
         assert!(p.relay_read && p.relay_write);
         assert!(p.relay_read_multihop && p.relay_write_multihop);
+    }
+
+    /// The content ports have no exceptions left.
+    ///
+    /// Pairing kinds used to be the one thing an unpaired peer could publish to
+    /// the relay, and the event landed in the store as a side effect. Both are
+    /// now refused: the handshake belongs to the auth plane, so a stranger has no
+    /// write path into a store that may not even be ours
+    /// (`reference/thinning-custom-relay.md`, D6).
+    #[test]
+    fn the_relay_gate_refuses_pairing_kinds_from_everyone() {
+        use crate::mesh_relay::PeerGate;
+
+        let dir = tmp("gate-no-exceptions");
+        let _ = std::fs::remove_dir_all(&dir);
+        let content = Arc::new(Content::open(&dir).unwrap());
+
+        // A paired peer, so this is not simply "unpaired is refused".
+        let peer = Keys::generate();
+        let peer_npub = peer.public_key().to_bech32().unwrap();
+        content.add_to_circle(&peer_npub, "Peer");
+        let ip = IpAddr::V6(
+            fips::PeerIdentity::from_npub(&peer_npub)
+                .unwrap()
+                .address()
+                .to_ipv6(),
+        );
+
+        let gate = CircleGate::new(content.clone());
+        assert!(gate.may_publish(ip, 9), "ordinary content still flows");
+        for kind in [KIND_PAIR_REQUEST, KIND_PAIR_ACCEPT, KIND_PAIR_REMOVE] {
+            assert!(
+                !gate.may_publish(ip, kind),
+                "kind {kind} is auth-plane traffic and must not reach the relay"
+            );
+        }
+
+        // And an unpaired stranger gets nothing at all.
+        let stranger = Keys::generate().public_key().to_bech32().unwrap();
+        let stranger_ip = IpAddr::V6(
+            fips::PeerIdentity::from_npub(&stranger)
+                .unwrap()
+                .address()
+                .to_ipv6(),
+        );
+        assert!(!gate.may_read(stranger_ip));
+        assert!(!gate.may_publish(stranger_ip, KIND_PAIR_REQUEST));
+        assert!(!gate.may_publish(stranger_ip, 9));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The defaults are the whole permission model until the UI exposes them, so
@@ -2630,6 +2720,7 @@ mod tests {
 
         let peer = Keys::generate();
         let peer_npub = peer.public_key().to_bech32().unwrap();
+        let content = Arc::new(content);
         content.add_to_circle(&peer_npub, "Peer");
         assert_eq!(content.circle_snapshot().len(), 1);
 

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -88,6 +88,67 @@ pub struct CircleContact {
     /// A human label for the contact (from the share QR; a placeholder for now).
     pub name: String,
     pub added_at: u64,
+    /// What this peer may do to us. Not exposed in the UI yet — every peer gets
+    /// the defaults — but stored per peer so turning a knob later is a UI change
+    /// rather than a storage migration.
+    #[serde(default)]
+    pub perms: PeerPerms,
+}
+
+/// Per-peer permissions: what a **paired** peer is allowed to do against this
+/// node. Pairing itself is not covered here — that is the auth plane's job, and
+/// it happens before any of these apply.
+///
+/// Read every flag as a grant *we* make to *them*. "Multihop" is ambiguous on
+/// its own, so it means specifically whether their traffic travels further
+/// through us — not anything we send them. Both multihop flags are expressed as
+/// per-peer ttl clamps rather than a separate check, so they reuse the machinery
+/// the push and pull planes already have. See
+/// `reference/thinning-custom-relay.md` (D10).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PeerPerms {
+    /// May open a `REQ` and receive our stored events.
+    #[serde(default = "yes")]
+    pub relay_read: bool,
+    /// Their `REQ` may be forwarded to our other peers (`req-ttl` clamp).
+    #[serde(default = "yes")]
+    pub relay_read_multihop: bool,
+    /// May publish events to us.
+    #[serde(default = "yes")]
+    pub relay_write: bool,
+    /// Events from them may be forwarded onward by us (`event-ttl` clamp).
+    #[serde(default = "yes")]
+    pub relay_write_multihop: bool,
+    /// May `GET` / `HEAD` blobs from us.
+    #[serde(default = "yes")]
+    pub blossom_read: bool,
+    /// May `PUT /upload` to us. **Off by default** — this is the one that costs
+    /// us disk, and nothing in normal operation needs it: propagation is
+    /// pull-based, so peers fetch blobs from the holder rather than pushing them.
+    /// The dev-menu speedtest is the only caller, and it reports the refusal.
+    #[serde(default = "no")]
+    pub blossom_write: bool,
+}
+
+fn yes() -> bool {
+    true
+}
+fn no() -> bool {
+    false
+}
+
+impl Default for PeerPerms {
+    fn default() -> Self {
+        Self {
+            relay_read: yes(),
+            relay_read_multihop: yes(),
+            relay_write: yes(),
+            relay_write_multihop: yes(),
+            blossom_read: yes(),
+            blossom_write: no(),
+        }
+    }
 }
 
 /// An nsite **discovered** on a Circle peer's mesh relay ("nsites around me").
@@ -202,9 +263,14 @@ const PAIR_DIAL_RETRY_DELAY: std::time::Duration = std::time::Duration::from_sec
 const MANIFEST_EVENT_TTL: u8 = 3;
 
 /// The mesh access gate backing the relay + Blossom servers: content (reads, chat,
-/// manifests, blobs) is restricted to **paired** (Circle) peers, but *anyone* may
-/// publish the pairing handshake so a first-time pair request can bootstrap. Holds
-/// the [`Content`] so the live Circle is consulted per request (`docs/design`).
+/// manifests, blobs) is restricted to **paired** (Circle) peers, and what a paired
+/// peer may do is its own [`PeerPerms`] record. The one remaining exception is the
+/// pairing handshake, which anyone may publish so a first-time request can
+/// bootstrap — that exception goes away when pairing moves to its own auth
+/// service (`reference/thinning-custom-relay.md`, D6).
+///
+/// Holds the [`Content`] so the live Circle is consulted per request: adding a
+/// peer, removing one, or changing a permission takes effect immediately.
 pub struct CircleGate {
     content: Arc<Content>,
 }
@@ -217,16 +283,23 @@ impl CircleGate {
 
 impl crate::mesh_relay::PeerGate for CircleGate {
     fn may_read(&self, ip: IpAddr) -> bool {
-        self.content.is_paired_ip(ip)
+        self.content.perms_for_ip(ip).is_some_and(|p| p.relay_read)
     }
 
     fn may_publish(&self, ip: IpAddr, kind: u16) -> bool {
-        // Pairing handshake is allowed from anyone (it's how a peer becomes paired);
-        // all other kinds require an established Circle membership.
-        kind == KIND_PAIR_REQUEST
-            || kind == KIND_PAIR_ACCEPT
-            || kind == KIND_PAIR_REMOVE
-            || self.content.is_paired_ip(ip)
+        // Pairing handshake is allowed from anyone (it's how a peer becomes
+        // paired); everything else needs membership *and* the write grant.
+        if kind == KIND_PAIR_REQUEST || kind == KIND_PAIR_ACCEPT || kind == KIND_PAIR_REMOVE {
+            return true;
+        }
+        self.content.perms_for_ip(ip).is_some_and(|p| p.relay_write)
+    }
+
+    fn max_req_ttl(&self, ip: IpAddr) -> u8 {
+        match self.content.perms_for_ip(ip) {
+            Some(p) if p.relay_read_multihop => crate::mesh_relay::MAX_REQ_TTL,
+            _ => 0,
+        }
     }
 }
 
@@ -898,6 +971,7 @@ impl Content {
                 npub: npub.to_string(),
                 name: name.to_string(),
                 added_at: now_secs(),
+                perms: PeerPerms::default(),
             });
         }
         let snapshot = circle.clone();
@@ -955,12 +1029,45 @@ impl Content {
     /// `fd…+node_addr[0..15]` — `PeerIdentity::from_npub(npub).address()` — which is
     /// exactly the source address the mesh sockets see.
     pub fn is_paired_ip(&self, ip: IpAddr) -> bool {
-        let IpAddr::V6(v6) = ip else { return false };
-        self.circle.lock().unwrap().iter().any(|c| {
-            fips::PeerIdentity::from_npub(&c.npub)
-                .map(|p| p.address().to_ipv6() == v6)
-                .unwrap_or(false)
-        })
+        self.perms_for_ip(ip).is_some()
+    }
+
+    /// The permissions granted to the peer at `ip`, or `None` if `ip` is not a
+    /// current Circle member. One lookup answers both "are they paired" and "what
+    /// may they do", so the access checks never consult two sources that could
+    /// disagree. See `reference/thinning-custom-relay.md` (D10).
+    pub fn perms_for_ip(&self, ip: IpAddr) -> Option<PeerPerms> {
+        let IpAddr::V6(v6) = ip else { return None };
+        self.circle
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|c| {
+                fips::PeerIdentity::from_npub(&c.npub)
+                    .map(|p| p.address().to_ipv6() == v6)
+                    .unwrap_or(false)
+            })
+            .map(|c| c.perms.clone())
+    }
+
+    /// Whether events arriving from the peer at `ip` may be forwarded onward by
+    /// us. Without the grant their events are still stored and shown locally —
+    /// they simply stop here (`reference/thinning-custom-relay.md`, D10).
+    pub fn may_forward_from(&self, ip: IpAddr) -> bool {
+        self.perms_for_ip(ip)
+            .is_some_and(|p| p.relay_write_multihop)
+    }
+
+    /// Whether the peer at `ip` may upload blobs to our Blossom. Off by default:
+    /// propagation is pull-based, so nothing in normal operation pushes blobs to
+    /// a peer, and an upload costs us disk.
+    pub fn may_upload_blobs(&self, ip: IpAddr) -> bool {
+        self.perms_for_ip(ip).is_some_and(|p| p.blossom_write)
+    }
+
+    /// Whether the peer at `ip` may read blobs from our Blossom.
+    pub fn may_read_blobs(&self, ip: IpAddr) -> bool {
+        self.perms_for_ip(ip).is_some_and(|p| p.blossom_read)
     }
 
     /// Library sites worth (re)trying right now: not yet `ready`, and not already
@@ -2211,6 +2318,37 @@ mod tests {
     use super::*;
     use nostr::nips::nip19::ToBech32;
     use nsite_deck::testing::build_test_site;
+
+    /// A `circle.json` written before per-peer permissions existed must load with
+    /// the defaults — and crucially with `blossom.write` **off**. A missing field
+    /// must never read as a grant, so serde's default has to be `false` rather
+    /// than `bool::default()` by accident (`reference/thinning-custom-relay.md`,
+    /// D10).
+    #[test]
+    fn a_pre_permissions_circle_loads_with_upload_denied() {
+        let legacy = r#"[{"npub":"npub1abc","name":"Old Phone","addedAt":1}]"#;
+        let loaded: Vec<CircleContact> = serde_json::from_str(legacy).unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        let p = &loaded[0].perms;
+        assert!(!p.blossom_write, "upload must not be granted by omission");
+        assert!(p.blossom_read, "reads stay on for an existing peer");
+        assert!(p.relay_read && p.relay_write);
+        assert!(p.relay_read_multihop && p.relay_write_multihop);
+    }
+
+    /// The defaults are the whole permission model until the UI exposes them, so
+    /// pin them rather than trusting the struct to stay as written.
+    #[test]
+    fn default_permissions_are_open_except_uploads() {
+        let p = PeerPerms::default();
+        assert!(p.relay_read);
+        assert!(p.relay_read_multihop);
+        assert!(p.relay_write);
+        assert!(p.relay_write_multihop);
+        assert!(p.blossom_read);
+        assert!(!p.blossom_write);
+    }
 
     fn tmp(tag: &str) -> PathBuf {
         std::env::temp_dir().join(format!("myco-content-test-{}-{}", std::process::id(), tag))

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -2561,6 +2561,55 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// An nsite actually renders with its manifest on a relay we do not own.
+    ///
+    /// The seam test above proves publish and slot-read work. This proves the
+    /// thing a user would notice: manifest on the remote relay, blobs local,
+    /// and the gateway serving the page. That split is the normal shape when
+    /// only the relay is swapped, so it is worth pinning rather than assuming.
+    #[tokio::test]
+    async fn the_gateway_serves_a_site_whose_manifest_lives_on_a_custom_relay() {
+        let theirs = Arc::new(myco_relay::RelayStore::in_memory());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(crate::mesh_relay::serve_on(theirs.clone(), listener));
+
+        let dir = tmp("custom-relay-gateway");
+        let _ = std::fs::remove_dir_all(&dir);
+        let backend = Arc::new(crate::remote_backend::RemoteBackend::new(format!(
+            "ws://{addr}"
+        )));
+        let content = Content::open_with_relay(&dir, Some(backend)).unwrap();
+
+        // Import the usual way: blobs to the local store, manifest to the relay
+        // — which now happens to be someone else's.
+        let site = build_test_site(&[("/index.html", b"<h1>remote</h1>")], None, None);
+        nsite_deck::import_site(
+            content.relay().as_ref(),
+            content.blobs().as_ref(),
+            site.manifest.clone(),
+            &site.blobs,
+        )
+        .await
+        .expect("import");
+        assert_eq!(theirs.count(), 1, "the manifest went to the custom relay");
+
+        let host = format!("{}.nsite", site.author.to_bech32().unwrap());
+        let resp = nsite_deck::serve(
+            &content.active_backend(),
+            content.blobs().as_ref(),
+            &host,
+            "/",
+            None,
+        )
+        .await;
+
+        assert_eq!(resp.status, 200, "the page must render");
+        assert_eq!(resp.body, b"<h1>remote</h1>");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// The content ports have no exceptions left.
     ///
     /// Pairing kinds used to be the one thing an unpaired peer could publish to

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -20,9 +20,9 @@ use futures_util::future::join_all;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use nostr::nips::nip19::{FromBech32, ToBech32};
-use nostr::{Event, EventBuilder, Keys, Kind, PublicKey, Tag};
+use nostr::{Event, EventBuilder, Filter, Keys, Kind, PublicKey, Tag};
 use nsite_deck::gateway::{self, Readiness};
-use nsite_deck::seams::{BlobStore, ManifestFilter, PeerSource, RelayBackend};
+use nsite_deck::seams::{BlobStore, PeerSource, RelayBackend};
 use nsite_deck::{sync, GatewayResponse, SiteAddr, SyncOutcome};
 use serde::{Deserialize, Serialize};
 
@@ -404,24 +404,31 @@ impl RelayBackend for ActiveBackend<'_> {
     async fn publish(&self, event: Event) -> anyhow::Result<()> {
         self.relay.publish(event).await
     }
-    async fn get_manifest(
-        &self,
-        kind: u16,
-        author: &PublicKey,
-        d_tag: Option<&str>,
-    ) -> anyhow::Result<Option<Event>> {
-        let key = manifest_key(kind, author, d_tag);
-        let pinned = self.active.lock().unwrap().get(&key).cloned();
-        if pinned.is_some() {
-            return Ok(pinned);
+    /// Serve the **pinned** version of any site that has one, rather than the
+    /// newest the store holds.
+    ///
+    /// The substitution happens here, on the way out, because the seam no longer
+    /// has a slot-shaped read to override — everything goes through `query` now.
+    /// A pinned event shares its slot with the one it replaces (same kind,
+    /// author, and `d` tag), so anything that matched the newer one matches it.
+    async fn query(&self, filters: &[Filter]) -> anyhow::Result<Vec<Event>> {
+        let mut out = self.relay.query(filters).await?;
+        let active = self.active.lock().unwrap().clone();
+        if active.is_empty() {
+            return Ok(out);
         }
-        self.relay.get_manifest(kind, author, d_tag).await
-    }
-    async fn query(&self, filter: &ManifestFilter) -> anyhow::Result<Vec<Event>> {
-        self.relay.query(filter).await
-    }
-    async fn wipe(&self) -> anyhow::Result<()> {
-        self.relay.wipe().await
+        for event in out.iter_mut() {
+            let key = manifest_key(
+                event.kind.as_u16(),
+                &event.pubkey,
+                event_d_tag(event).as_deref(),
+            );
+            if let Some(pinned) = active.get(&key) {
+                *event = pinned.clone();
+            }
+        }
+        out.dedup_by(|a, b| a.id == b.id);
+        Ok(out)
     }
 }
 
@@ -778,10 +785,13 @@ impl Content {
                         // newest) — pull it back to make it the active version.
                         None => {
                             let kind = nsite_deck::kind_for(addr.d_tag.as_deref());
-                            if let Ok(Some(ev)) = self
-                                .relay
-                                .get_manifest(kind, &addr.author, addr.d_tag.as_deref())
-                                .await
+                            if let Ok(Some(ev)) = nsite_deck::seams::newest_in_slot(
+                                self.relay.as_ref(),
+                                kind,
+                                &addr.author,
+                                addr.d_tag.as_deref(),
+                            )
+                            .await
                             {
                                 self.set_active(&ev);
                             }
@@ -1693,14 +1703,17 @@ impl Content {
             };
             // Compare against the version we actually serve (the active pointer),
             // not merely the relay's newest.
-            let active_ts = self
-                .active_backend()
-                .get_manifest(kind, &addr.author, addr.d_tag.as_deref())
-                .await
-                .ok()
-                .flatten()
-                .map(|e| e.created_at.as_secs())
-                .unwrap_or(0);
+            let active_ts = nsite_deck::seams::newest_in_slot(
+                &self.active_backend(),
+                kind,
+                &addr.author,
+                addr.d_tag.as_deref(),
+            )
+            .await
+            .ok()
+            .flatten()
+            .map(|e| e.created_at.as_secs())
+            .unwrap_or(0);
             if cand.created_at.as_secs() > active_ts {
                 candidates.push((addr, cand.clone()));
             }
@@ -1760,14 +1773,17 @@ impl Content {
     /// blobs). Returns whether it activated.
     async fn stage_update(self: Arc<Self>, addr: SiteAddr, candidate: Event) -> bool {
         let kind = nsite_deck::kind_for(addr.d_tag.as_deref());
-        let active_ts = self
-            .active_backend()
-            .get_manifest(kind, &addr.author, addr.d_tag.as_deref())
-            .await
-            .ok()
-            .flatten()
-            .map(|e| e.created_at.as_secs())
-            .unwrap_or(0);
+        let active_ts = nsite_deck::seams::newest_in_slot(
+            &self.active_backend(),
+            kind,
+            &addr.author,
+            addr.d_tag.as_deref(),
+        )
+        .await
+        .ok()
+        .flatten()
+        .map(|e| e.created_at.as_secs())
+        .unwrap_or(0);
         if candidate.created_at.as_secs() <= active_ts {
             return false;
         }
@@ -1977,7 +1993,7 @@ impl Content {
     /// Clear the local relay + Blossom + Library + status (the `WipeStores` dev
     /// action). Content-only; identity is untouched.
     pub async fn wipe(&self) -> anyhow::Result<()> {
-        self.relay.wipe().await?;
+        nsite_deck::seams::AdminBackend::wipe(self.relay.as_ref()).await?;
         self.blobs.wipe().await?;
         self.library.lock().unwrap().clear();
         self.sites.lock().unwrap().clear();
@@ -2016,9 +2032,13 @@ impl Content {
                 continue;
             };
             let kind = nsite_deck::kind_for(addr.d_tag.as_deref());
-            if let Ok(Some(ev)) = backend
-                .get_manifest(kind, &addr.author, addr.d_tag.as_deref())
-                .await
+            if let Ok(Some(ev)) = nsite_deck::seams::newest_in_slot(
+                &backend,
+                kind,
+                &addr.author,
+                addr.d_tag.as_deref(),
+            )
+            .await
             {
                 keep_events.insert(ev.id.to_bytes());
                 if let Ok(m) = nsite_deck::Manifest::from_event(ev) {
@@ -2130,20 +2150,26 @@ impl Content {
 
     async fn lookup_title(&self, addr: &SiteAddr) -> Option<String> {
         let kind = nsite_deck::kind_for(addr.d_tag.as_deref());
-        let event = self
-            .relay
-            .get_manifest(kind, &addr.author, addr.d_tag.as_deref())
-            .await
-            .ok()??;
+        let event = nsite_deck::seams::newest_in_slot(
+            self.relay.as_ref(),
+            kind,
+            &addr.author,
+            addr.d_tag.as_deref(),
+        )
+        .await
+        .ok()??;
         nsite_deck::Manifest::from_event(event).ok()?.title
     }
 
     async fn manifest_file_count(&self, addr: &SiteAddr) -> u64 {
         let kind = nsite_deck::kind_for(addr.d_tag.as_deref());
-        match self
-            .relay
-            .get_manifest(kind, &addr.author, addr.d_tag.as_deref())
-            .await
+        match nsite_deck::seams::newest_in_slot(
+            self.relay.as_ref(),
+            kind,
+            &addr.author,
+            addr.d_tag.as_deref(),
+        )
+        .await
         {
             Ok(Some(event)) => nsite_deck::Manifest::from_event(event)
                 .map(|m| m.paths.len() as u64)

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -196,12 +196,26 @@ fn dedup_by_host(found: Vec<DiscoveredNsite>) -> Vec<DiscoveredNsite> {
 }
 
 /// Cache/store counts for the UI.
+///
+/// These always describe the **embedded** store and blob directory, which is
+/// what occupies space on this device. Configuring a custom relay or Blossom
+/// does not change these numbers — it means they stop describing what is
+/// actually serving, because a remote store's size is not something NIP-01 or
+/// BUD-01 can report. The `external_*` flags let the screen note that the
+/// built-in store is no longer in use rather than quietly showing a figure for
+/// the wrong thing. See `reference/thinning-custom-relay.md` (D4).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CacheView {
     pub relay_events: u64,
     pub blob_count: u64,
     pub used_bytes: u64,
+    /// A custom relay is configured, so the embedded event store is not serving.
+    pub external_relay: bool,
+    /// A custom Blossom is configured, so the embedded blob store is not
+    /// serving. Separate from the relay flag because one can be swapped without
+    /// the other.
+    pub external_blobs: bool,
 }
 
 impl CacheView {
@@ -211,6 +225,8 @@ impl CacheView {
             relay_events: 0,
             blob_count: 0,
             used_bytes: 0,
+            external_relay: false,
+            external_blobs: false,
         }
     }
 }
@@ -2123,10 +2139,15 @@ impl Content {
     }
 
     pub fn cache_view(&self) -> CacheView {
+        // Always the embedded store's own figures — that is what takes up space
+        // here. Nothing external is configurable yet, so neither flag is set;
+        // they follow the configured backend once that lands.
         CacheView {
             relay_events: self.relay.count() as u64,
             blob_count: self.blobs.count() as u64,
             used_bytes: self.blobs.total_bytes(),
+            external_relay: false,
+            external_blobs: false,
         }
     }
 

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -307,8 +307,8 @@ struct ActiveBackend<'a> {
 
 #[async_trait]
 impl RelayBackend for ActiveBackend<'_> {
-    async fn store_event(&self, event: Event) -> anyhow::Result<bool> {
-        self.relay.store_event(event).await
+    async fn publish(&self, event: Event) -> anyhow::Result<()> {
+        self.relay.publish(event).await
     }
     async fn get_manifest(
         &self,
@@ -667,7 +667,7 @@ impl Content {
                         // it's stored (idempotent) and pin it as the active version;
                         // title/count come straight from the manifest we held.
                         Some(m) => {
-                            let _ = self.relay.store_event(m.event.clone()).await;
+                            let _ = self.relay.publish(m.event.clone()).await;
                             self.set_active(&m.event);
                             let n = m.paths.len() as u64;
                             self.set_status_titled(
@@ -1262,8 +1262,9 @@ impl Content {
                 .request(npub, &url, filters, std::time::Duration::from_secs(15))
                 .await;
             for ev in events {
-                // Signatures were checked by the pool at ingress.
-                if self.relay.store_event(ev).await.unwrap_or(false) {
+                // Signatures were checked by the pool at ingress. Storing is
+                // idempotent, so this counts events pulled, not new arrivals.
+                if self.relay.publish(ev).await.is_ok() {
                     stored += 1;
                 }
             }
@@ -1715,7 +1716,7 @@ impl Content {
                 p.pulled = p.total;
             }
             if store_in_relay {
-                let _ = self.relay.store_event(candidate.clone()).await;
+                let _ = self.relay.publish(candidate.clone()).await;
             }
             self.set_active(&candidate);
             let n = manifest.paths.len() as u64;

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -242,9 +242,11 @@ pub struct OutboundPairView {
     pub since: u64,
 }
 
-/// Mutual-pairing handshake events, delivered point-to-point over a peer's mesh
-/// relay (NOT gossiped). Both are signed by the **device** key (the pairing
-/// identity) and self-destruct (NIP-40). See `docs/design/event-gossip.md`.
+/// Mutual-pairing handshake events, POSTed point-to-point to a peer's **auth
+/// service** at `:4871` (never gossiped, and never stored — the relay refuses
+/// these kinds from every source). Signed by the **device** key, which is the
+/// pairing identity, and carrying a NIP-40 expiry the auth service checks on
+/// receipt. See `docs/design/identity-pairing.md`.
 pub const KIND_PAIR_REQUEST: u16 = 9101;
 pub const KIND_PAIR_ACCEPT: u16 = 9102;
 /// Sent when a peer forgets you, so both sides drop the pairing symmetrically.
@@ -1476,11 +1478,11 @@ impl Content {
     }
 
     /// Pull plane: forward a REQ's filters to connected Circle peers and
-    /// aggregate their matching events. `req_ttl` is the remaining forward budget
-    /// *after* this hop — it is stamped back into each filter so the next relay
-    /// decrements from here (without it the peer would re-read the original value).
-    /// `exclude` is the requester's mesh address (split-horizon). Per-peer queries
-    /// run in parallel, each hard-bounded so a dead relay can't stall discovery.
+    /// aggregate their matching events. `meta` is the incoming envelope, already
+    /// decremented, so the hop budget and query id carry onward while the filters
+    /// stay canonical NIP-01. `exclude` is the requester's mesh address
+    /// (split-horizon). Per-peer queries run in parallel, each bounded by the
+    /// budget that arrived so a dead relay can't stall discovery.
     pub async fn pull_from_peers(
         &self,
         filters: Vec<serde_json::Value>,
@@ -1609,7 +1611,8 @@ impl Content {
         // Query set, one combined REQ per relay read until EOSE
         // (docs/design/nsite-updates.md §3.2):
         //  - connected peers' mesh relays, carrying one more hop so the check reaches
-        //    2 hops just like discovery (their peers' manifests come back too);
+        //    2 hops just like discovery (their peers' manifests come back too),
+        //    which rides the envelope rather than the filter;
         //  - online relays, unless mesh-only is on.
         let mesh_filter = serde_json::json!({
             "kinds": [nsite_deck::KIND_ROOT, nsite_deck::KIND_NAMED],
@@ -1652,8 +1655,19 @@ impl Content {
         let mesh_q = mesh_peers.into_iter().map(|(npub, url)| {
             let f = mesh_filter.clone();
             async move {
-                pool.request(&npub, &url, vec![f], std::time::Duration::from_secs(15))
-                    .await
+                let meta = crate::mesh_wire::MeshMeta::pull(
+                    1,
+                    crate::mesh_wire::new_query_id(),
+                    PULL_BUDGET_MS,
+                );
+                pool.request_with(
+                    &npub,
+                    &url,
+                    vec![f],
+                    Some(meta),
+                    std::time::Duration::from_secs(15),
+                )
+                .await
             }
         });
         let online_q = online.into_iter().map(|url| {
@@ -1901,11 +1915,20 @@ impl Content {
 
         // Forward budget (mirrors chat): originate at the default for a local
         // publish, else the ttl that rode in. Clamp so a peer can't over-extend us.
+        // The same per-peer clamp the chat push plane applies: a peer we have not
+        // granted multihop writes still gets its manifest stored and served here,
+        // it simply travels no further through us. Manifests were missing this
+        // check, so that grant was enforced on one plane but not the other (D10).
+        let peer_cap = match inbound.sender {
+            Some(ip) if !self.may_forward_from(ip) => 0,
+            _ => MANIFEST_EVENT_TTL,
+        };
         let effective = match inbound.origin {
             Origin::Local => MANIFEST_EVENT_TTL,
             Origin::Mesh => inbound.event_ttl.unwrap_or(0),
         }
-        .min(MANIFEST_EVENT_TTL);
+        .min(MANIFEST_EVENT_TTL)
+        .min(peer_cap);
         let out_ttl = effective.saturating_sub(1);
 
         if !self.is_in_library(&addr) {
@@ -2445,6 +2468,56 @@ mod tests {
         assert!(!gate.may_read(stranger_ip));
         assert!(!gate.may_publish(stranger_ip, KIND_PAIR_REQUEST));
         assert!(!gate.may_publish(stranger_ip, 9));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A peer denied multihop writes must not have its **manifests** relayed
+    /// either.
+    ///
+    /// The chat push plane consulted the grant; the manifest push plane did not,
+    /// so the same permission was enforced on one plane and ignored on the other.
+    /// Both clamps read the same record, so testing the record is what pins the
+    /// invariant (`reference/thinning-custom-relay.md`, D10).
+    #[test]
+    fn revoking_multihop_writes_covers_both_push_planes() {
+        let dir = tmp("multihop-clamp");
+        let _ = std::fs::remove_dir_all(&dir);
+        let content = Arc::new(Content::open(&dir).unwrap());
+
+        let peer = Keys::generate();
+        let npub = peer.public_key().to_bech32().unwrap();
+        content.add_to_circle(&npub, "Peer");
+        let ip = IpAddr::V6(
+            fips::PeerIdentity::from_npub(&npub)
+                .unwrap()
+                .address()
+                .to_ipv6(),
+        );
+
+        assert!(
+            content.may_forward_from(ip),
+            "multihop writes are granted by default"
+        );
+
+        // Revoke it the way the UI eventually will.
+        {
+            let mut circle = content.circle.lock().unwrap();
+            circle[0].perms.relay_write_multihop = false;
+        }
+        assert!(
+            !content.may_forward_from(ip),
+            "a revoked peer's events stop here, on either plane"
+        );
+        // An unknown peer is not forwarded for either.
+        let stranger = Keys::generate().public_key().to_bech32().unwrap();
+        let stranger_ip = IpAddr::V6(
+            fips::PeerIdentity::from_npub(&stranger)
+                .unwrap()
+                .address()
+                .to_ipv6(),
+        );
+        assert!(!content.may_forward_from(stranger_ip));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -22,7 +22,6 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use nostr::nips::nip19::ToBech32;
 use nostr::Event;
 
 use crate::mesh_relay::{Gossiper, Inbound, Origin};
@@ -56,28 +55,6 @@ fn is_gossip_eligible(kind: u16) -> bool {
 impl Gossiper for MeshGossiper {
     async fn on_event(&self, event: Event, inbound: Inbound) {
         let kind = event.kind.as_u16();
-        // Pairing signals are point-to-point (dialed straight to the target's
-        // relay) — handle them, never gossip. Only act on mesh-delivered ones.
-        if kind == crate::content::KIND_PAIR_REQUEST
-            || kind == crate::content::KIND_PAIR_ACCEPT
-            || kind == crate::content::KIND_PAIR_REMOVE
-        {
-            if inbound.origin == Origin::Mesh {
-                self.content.handle_pair_event(&event);
-                // A peer just accepted our pair request → they're a reachable source
-                // *now*. Retry any not-yet-ready downloads from them immediately,
-                // rather than waiting for the next connected-peer poll edge.
-                if kind == crate::content::KIND_PAIR_ACCEPT {
-                    let Ok(npub) = event.pubkey.to_bech32();
-                    for addr in self.content.retriable_library_addrs() {
-                        let content = self.content.clone();
-                        let holder = npub.clone();
-                        tokio::spawn(async move { content.open_site(addr, Some(holder)).await });
-                    }
-                }
-            }
-            return;
-        }
         // nsite manifests propagate over this same push plane (the relay just stored
         // a newer one), but with an interest-aware download-then-forward policy and
         // the active-version gate. See docs/design/nsite-updates.md §4.

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -4,11 +4,11 @@
 //! **P2 — multi-hop flood.** An event is pushed to the whole Circle's relays
 //! (`ws://<npub>.fips:4870`) — every member, not just direct neighbours, so a
 //! peer reachable only multi-hop over the mesh still receives it — carrying a
-//! decrementing `event-ttl`:
+//! decrementing hop budget, carried in the `MESH` envelope:
 //!
 //! - **Local origin** (a loopback publish from the in-app nsite) originates at
 //!   `DEFAULT_EVENT_TTL`.
-//! - **Mesh origin** re-forwards with the TTL that rode in (`event-ttl`),
+//! - **Mesh origin** re-forwards with the budget that rode in,
 //!   **except back to the sender** (split-horizon), until the budget runs out.
 //!
 //! The loop guard is the relay's id-dedup: the gossiper is only ever called for an
@@ -34,7 +34,7 @@ const DEFAULT_EVENT_TTL: u8 = 3;
 /// turn us into a flood amplifier (`docs/design/event-gossip.md` §3).
 const MAX_EVENT_TTL: u8 = 3;
 
-/// Fans events to connected Circle peers' relays over the mesh, with `event-ttl`.
+/// Fans events to connected Circle peers' relays over the mesh, hop-bounded.
 pub struct MeshGossiper {
     content: Arc<Content>,
 }
@@ -84,19 +84,20 @@ impl Gossiper for MeshGossiper {
         }
         let out_ttl = fwd - 1;
 
-        // Build the outbound relay frame once: the canonical event plus the
-        // decremented transient `event-ttl` (a top-level field, stripped on store).
-        let mut ev_json = match serde_json::to_value(&event) {
+        // Build the outbound frame once: a canonical NIP-01 EVENT, with the
+        // decremented hop budget carried beside it in the envelope rather than
+        // added to the event. Nothing has to be stripped before storing.
+        let ev_json = match serde_json::to_value(&event) {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(error = %e, "gossip: serialize event failed");
                 return;
             }
         };
-        if let Some(obj) = ev_json.as_object_mut() {
-            obj.insert("event-ttl".to_string(), serde_json::json!(out_ttl));
-        }
-        let frame = serde_json::json!(["EVENT", ev_json]).to_string();
+        let frame = crate::mesh_wire::wrap(
+            &crate::mesh_wire::MeshMeta::push(out_ttl),
+            serde_json::json!(["EVENT", ev_json]),
+        );
 
         // Fan out to the *whole* Circle over persistent pooled connections (no
         // per-message connect), skipping the peer it came from (split-horizon). Not
@@ -115,18 +116,16 @@ impl Gossiper for MeshGossiper {
         }
     }
 
-    /// Pull plane (`docs/design/event-gossip.md`, req-ttl): forward the REQ's
+    /// Pull plane: forward the REQ's
     /// filters to connected Circle peers carrying the decremented `req_ttl`,
     /// aggregating their matching events. `exclude` is split-horizon.
     async fn on_req(
         &self,
         filters: Vec<serde_json::Value>,
-        req_ttl: u8,
+        meta: crate::mesh_wire::MeshMeta,
         exclude: Option<IpAddr>,
     ) -> Vec<Event> {
-        self.content
-            .pull_from_peers(filters, req_ttl, exclude)
-            .await
+        self.content.pull_from_peers(filters, meta, exclude).await
     }
 
     fn on_local_subscribe(&self, key: &str, filters: Vec<serde_json::Value>) {

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -11,9 +11,10 @@
 //! - **Mesh origin** re-forwards with the budget that rode in,
 //!   **except back to the sender** (split-horizon), until the budget runs out.
 //!
-//! The loop guard is the relay's id-dedup: the gossiper is only ever called for an
-//! event that was *new* to the store, so a copy arriving via a second path is
-//! never re-forwarded (`docs/design/event-gossip.md` §3–4). Manifest kinds
+//! The loop guard is the proxy's own seen-set: the gossiper is only ever called
+//! the first time this device sees an id, so a copy arriving via a second path is
+//! never re-forwarded — and unlike the store's dedup, that holds even after the
+//! event has been GC'd (`docs/design/event-gossip.md` §3–4). Manifest kinds
 //! (15128/35128) are excluded — they have their own path
 //! (`docs/design/nsite-layer.md` §2.1); everything else is gossip-eligible by
 //! default (`docs/design/nsite-permissions.md`).

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use nostr::nips::nip19::ToBech32;
 use nostr::Event;
 
-use myco_relay::server::{Gossiper, Inbound, Origin};
+use crate::mesh_relay::{Gossiper, Inbound, Origin};
 
 use crate::content::Content;
 

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -7,7 +7,7 @@
 //! decrementing hop budget, carried in the `MESH` envelope:
 //!
 //! - **Local origin** (a loopback publish from the in-app nsite) originates at
-//!   `DEFAULT_EVENT_TTL`.
+//!   `mesh_wire::EVENT_TTL`.
 //! - **Mesh origin** re-forwards with the budget that rode in,
 //!   **except back to the sender** (split-horizon), until the budget runs out.
 //!
@@ -28,12 +28,6 @@ use nostr::Event;
 use crate::mesh_relay::{Gossiper, Inbound, Origin};
 
 use crate::content::Content;
-
-/// Hop budget this device stamps on its **own** events (experimental default).
-const DEFAULT_EVENT_TTL: u8 = 3;
-/// Clamp on any TTL we'll honour/forward, so a peer can't set a huge value and
-/// turn us into a flood amplifier (`docs/design/event-gossip.md` §3).
-const MAX_EVENT_TTL: u8 = 3;
 
 /// Fans events to connected Circle peers' relays over the mesh, hop-bounded.
 pub struct MeshGossiper {
@@ -69,7 +63,7 @@ impl Gossiper for MeshGossiper {
         // Effective budget: originate at the default for our own publishes; for a
         // mesh-received event use the TTL it carried (absent => 0 => don't forward).
         let effective = match inbound.origin {
-            Origin::Local => DEFAULT_EVENT_TTL,
+            Origin::Local => crate::mesh_wire::EVENT_TTL,
             Origin::Mesh => inbound.event_ttl.unwrap_or(0),
         };
         // A peer we have not granted multihop writes still gets its events
@@ -77,9 +71,9 @@ impl Gossiper for MeshGossiper {
         // clamp of 0 is how that is expressed (D10).
         let peer_cap = match inbound.sender {
             Some(ip) if !self.content.may_forward_from(ip) => 0,
-            _ => MAX_EVENT_TTL,
+            _ => crate::mesh_wire::EVENT_TTL,
         };
-        let fwd = effective.min(MAX_EVENT_TTL).min(peer_cap);
+        let fwd = effective.min(crate::mesh_wire::EVENT_TTL).min(peer_cap);
         if fwd == 0 {
             return;
         }

--- a/myco-core/src/gossip.rs
+++ b/myco-core/src/gossip.rs
@@ -94,7 +94,14 @@ impl Gossiper for MeshGossiper {
             Origin::Local => DEFAULT_EVENT_TTL,
             Origin::Mesh => inbound.event_ttl.unwrap_or(0),
         };
-        let fwd = effective.min(MAX_EVENT_TTL);
+        // A peer we have not granted multihop writes still gets its events
+        // stored and shown here; they simply travel no further through us. A
+        // clamp of 0 is how that is expressed (D10).
+        let peer_cap = match inbound.sender {
+            Some(ip) if !self.content.may_forward_from(ip) => 0,
+            _ => MAX_EVENT_TTL,
+        };
+        let fwd = effective.min(MAX_EVENT_TTL).min(peer_cap);
         if fwd == 0 {
             return;
         }

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -196,6 +196,13 @@ async fn speedtest_blossom(
         .body(payload)
         .send()
         .await?;
+    if resp.status() == reqwest::StatusCode::FORBIDDEN {
+        // The speedtest is the only thing that pushes blobs to a peer, and blob
+        // upload is off by default (`reference/thinning-custom-relay.md`, D10).
+        // Say so plainly — this is a permission the peer has to grant, not a
+        // network fault to retry.
+        anyhow::bail!("peer does not allow uploads (blob write permission is off on their device)");
+    }
     if !resp.status().is_success() {
         anyhow::bail!("upload rejected ({})", resp.status());
     }

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -287,7 +287,7 @@ fn throughput_mbps(bytes: usize, elapsed: Duration) -> f64 {
 
 /// `n` pseudo-random bytes from a time-seeded xorshift64 — cheap and dependency-
 /// free; we only need the bytes to be fresh per run, not cryptographically random.
-fn random_bytes(n: usize) -> Vec<u8> {
+pub(crate) fn random_bytes(n: usize) -> Vec<u8> {
     let mut state = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos() as u64)
@@ -302,35 +302,6 @@ fn random_bytes(n: usize) -> Vec<u8> {
     }
     out.truncate(n);
     out
-}
-
-/// Publish one signed event to a relay (`["EVENT", …]`), best-effort: connect,
-/// send, briefly await the `OK`, close. The whole call is hard-bounded by
-/// `timeout` so an unreachable peer relay can't stall the fan-out. Returns whether
-/// the event was sent (not whether it was accepted — chat is fire-and-forget).
-pub async fn publish_event(
-    url: &str,
-    event: &nostr::Event,
-    event_ttl: u8,
-    timeout: Duration,
-) -> bool {
-    let send = async {
-        let (mut ws, _) = tokio_tungstenite::connect_async(url).await.ok()?;
-        // Carry the hop budget as a transient top-level `event-ttl` field (not a
-        // tag; doesn't touch the signature). The peer relay reads it for fan-out
-        // and strips it on store. See docs/design/event-gossip.md §2.
-        let mut ev_json = serde_json::to_value(event).ok()?;
-        if let Some(obj) = ev_json.as_object_mut() {
-            obj.insert("event-ttl".to_string(), serde_json::json!(event_ttl));
-        }
-        let frame = serde_json::json!(["EVENT", ev_json]).to_string();
-        ws.send(Message::Text(frame)).await.ok()?;
-        // Wait briefly for the OK, but don't depend on it; then close politely.
-        let _ = ws.next().await;
-        let _ = ws.send(Message::Close(None)).await;
-        Some(())
-    };
-    matches!(tokio::time::timeout(timeout, send).await, Ok(Some(())))
 }
 
 /// Query one relay for a single filter, collecting events until EOSE. The whole
@@ -567,26 +538,6 @@ mod tests {
             }
         });
         format!("http://{addr}")
-    }
-
-    #[tokio::test]
-    async fn publish_event_delivers_to_relay() {
-        // End-to-end against a real myco-relay: publish a chat event, then confirm
-        // it landed in the store.
-        let store = Arc::new(myco_relay::RelayStore::in_memory());
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(crate::mesh_relay::serve_on(store.clone(), listener));
-
-        let keys = nostr::Keys::generate();
-        let ev = nostr::EventBuilder::new(nostr::Kind::from(9u16), "hi over mesh")
-            .tags([nostr::Tag::identifier("mesh".to_string())])
-            .sign_with_keys(&keys)
-            .unwrap();
-
-        assert!(publish_event(&format!("ws://{addr}"), &ev, 3, Duration::from_secs(5)).await);
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        assert_eq!(store.count(), 1, "published event stored by the relay");
     }
 
     #[tokio::test]

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -125,6 +125,59 @@ pub(crate) fn mesh_blossom_url(npub: &str) -> String {
     format!("http://{npub}.fips:24243")
 }
 
+/// A peer's **auth service** endpoint, by name — the only port an unpaired peer
+/// can reach. See [`mesh_relay_url`] for why this is addressed by npub.
+pub(crate) fn mesh_auth_url(npub: &str) -> String {
+    format!("http://{npub}.fips:{}/pair", crate::auth_service::AUTH_PORT)
+}
+
+/// What came back from a peer's auth service.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairDelivery {
+    /// They took it: paired, unpaired, or pending a human. Carries the reported
+    /// status so the caller can log which.
+    Accepted(&'static str),
+    /// They answered and said no — a bad signature, an expired event, or a rate
+    /// limit. Retrying will not change it.
+    Refused(&'static str),
+    /// Never got an answer. The mesh session is probably still coming up, so
+    /// this is the case worth retrying.
+    Unreachable,
+}
+
+/// POST a signed pair event to a peer's auth service.
+///
+/// Unlike a relay `OK`, the reply distinguishes "they have it and a human is
+/// deciding" from "we never reached them", which is what lets the pairing retry
+/// loop stop early instead of re-sending to a peer that already answered.
+pub(crate) async fn post_pair_event(
+    url: &str,
+    event: &nostr::Event,
+    timeout: Duration,
+) -> PairDelivery {
+    let Ok(client) = reqwest::Client::builder().timeout(timeout).build() else {
+        return PairDelivery::Unreachable;
+    };
+    let body = match serde_json::to_string(event) {
+        Ok(b) => b,
+        Err(_) => return PairDelivery::Unreachable,
+    };
+    match client.post(url).body(body).send().await {
+        Ok(resp) if resp.status().is_success() => PairDelivery::Accepted("paired"),
+        Ok(resp) if resp.status() == reqwest::StatusCode::ACCEPTED => {
+            PairDelivery::Accepted("pending")
+        }
+        Ok(resp) if resp.status() == reqwest::StatusCode::FORBIDDEN => {
+            PairDelivery::Refused("declined")
+        }
+        Ok(resp) if resp.status() == reqwest::StatusCode::BAD_REQUEST => {
+            PairDelivery::Refused("rejected")
+        }
+        // 429 / 503 are "not now" rather than "no" — worth another attempt.
+        Ok(_) | Err(_) => PairDelivery::Unreachable,
+    }
+}
+
 /// Blossom over the FIPS mesh, addressed by the holder's npub — see
 /// [`mesh_relay_url`]. Requires the app-owned TUN to be up so the socket routes
 /// over the mesh. A longer timeout than the IP source absorbs BLE latency +

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -292,7 +292,13 @@ pub async fn query_relay(url: &str, filter: serde_json::Value) -> anyhow::Result
                     Some("EVENT") => {
                         if let Some(ev) = val.get(2) {
                             if let Ok(event) = serde_json::from_value::<Event>(ev.clone()) {
-                                events.push(event);
+                                // Verified here, at the point a public relay's
+                                // events enter the process, so callers downstream
+                                // do not each have to remember to check. See
+                                // `reference/thinning-custom-relay.md` (D7).
+                                if event.verify().is_ok() {
+                                    events.push(event);
+                                }
                             }
                         }
                     }
@@ -343,7 +349,8 @@ impl PeerSource for IpPeerSource {
             join_all(queries).await
         };
 
-        // Pick the newest event that verifies and matches the requested slot.
+        // Pick the newest event matching the requested slot. Signatures were
+        // already checked at ingress (the pool, or `query_relay`).
         let mut newest: Option<Event> = None;
         for events in results.into_iter() {
             for ev in events {
@@ -351,9 +358,6 @@ impl PeerSource for IpPeerSource {
                     continue;
                 }
                 if d_tag.is_some() && event_d_tag(&ev).as_deref() != d_tag {
-                    continue;
-                }
-                if ev.verify().is_err() {
                     continue;
                 }
                 if newest.as_ref().is_none_or(|n| ev.created_at > n.created_at) {

--- a/myco-core/src/ip_source.rs
+++ b/myco-core/src/ip_source.rs
@@ -512,7 +512,7 @@ mod tests {
         let store = Arc::new(myco_relay::RelayStore::in_memory());
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        tokio::spawn(myco_relay::server::serve_on(store.clone(), listener));
+        tokio::spawn(crate::mesh_relay::serve_on(store.clone(), listener));
 
         let keys = nostr::Keys::generate();
         let ev = nostr::EventBuilder::new(nostr::Kind::from(9u16), "hi over mesh")

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -47,6 +47,10 @@ mod mesh_wire;
 // Not wired to settings yet, so it reads as dead outside its own tests.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod remote_backend;
+// Settings that must survive a restart, because they decide how the content
+// layer is constructed rather than how it behaves.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod settings_store;
 // npub -> observed lane record (Wi-Fi Aware vs. LAN/AP), pushed by the
 // Android Aware JNI bridge and consumed by `AppRuntime::state()`'s
 // lane_by_npub override. Plain, non-JNI logic so it is unit-testable on the

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -47,6 +47,9 @@ mod mesh_wire;
 // Not wired to settings yet, so it reads as dead outside its own tests.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod remote_backend;
+// The blob half of the same idea: a BlobStore over someone else's Blossom.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod remote_blobs;
 // Settings that must survive a restart, because they decide how the content
 // layer is constructed rather than how it behaves.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -11,6 +11,10 @@
 
 mod action;
 mod attempt_store;
+// The auth plane: the only port an unpaired peer can reach. Bound by the Android
+// runtime, so it reads as dead on the host outside its own tests.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod auth_service;
 // Myco-owned BLE connect-attempt vocabulary. These used to be fips types read
 // out of a transport-global log; the restacked fips counts outcomes into
 // `BleStats` instead. Nothing produces these yet — see the module doc's

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -27,6 +27,12 @@ mod control_client;
 // the host it is exercised only by its own tests, so it reads as dead there.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod gossip;
+// The NIP-01 front door: live subscriptions, the mesh fan-out hook, and the
+// access gate. Bound to its sockets only by the Android runtime, so on the host
+// it reads as dead outside its own tests (and the tests that use it as a plain
+// relay). See `reference/thinning-custom-relay.md`.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod mesh_relay;
 mod identity_store;
 mod ip_source;
 // npub -> observed lane record (Wi-Fi Aware vs. LAN/AP), pushed by the

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -27,14 +27,14 @@ mod control_client;
 // the host it is exercised only by its own tests, so it reads as dead there.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod gossip;
+mod identity_store;
+mod ip_source;
 // The NIP-01 front door: live subscriptions, the mesh fan-out hook, and the
 // access gate. Bound to its sockets only by the Android runtime, so on the host
 // it reads as dead outside its own tests (and the tests that use it as a plain
 // relay). See `reference/thinning-custom-relay.md`.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod mesh_relay;
-mod identity_store;
-mod ip_source;
 // npub -> observed lane record (Wi-Fi Aware vs. LAN/AP), pushed by the
 // Android Aware JNI bridge and consumed by `AppRuntime::state()`'s
 // lane_by_npub override. Plain, non-JNI logic so it is unit-testable on the

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -43,6 +43,10 @@ mod mesh_relay;
 // NIP-01 message on the peer link. See `reference/thinning-custom-relay.md`.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod mesh_wire;
+// A RelayBackend backed by someone else's NIP-01 relay — the point of the seam.
+// Not wired to settings yet, so it reads as dead outside its own tests.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod remote_backend;
 // npub -> observed lane record (Wi-Fi Aware vs. LAN/AP), pushed by the
 // Android Aware JNI bridge and consumed by `AppRuntime::state()`'s
 // lane_by_npub override. Plain, non-JNI logic so it is unit-testable on the

--- a/myco-core/src/lib.rs
+++ b/myco-core/src/lib.rs
@@ -39,6 +39,10 @@ mod ip_source;
 // relay). See `reference/thinning-custom-relay.md`.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 mod mesh_relay;
+// The `MESH` envelope that carries mesh state alongside — never inside — a
+// NIP-01 message on the peer link. See `reference/thinning-custom-relay.md`.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+mod mesh_wire;
 // npub -> observed lane record (Wi-Fi Aware vs. LAN/AP), pushed by the
 // Android Aware JNI bridge and consumed by `AppRuntime::state()`'s
 // lane_by_npub override. Plain, non-JNI logic so it is unit-testable on the

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -18,7 +18,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
@@ -185,7 +184,7 @@ impl SeenSet {
     /// Record an id, returning `true` if this is the **first** time we have seen
     /// it — the caller's signal to fan out.
     fn insert(&self, event: &Event) -> bool {
-        let now = now_secs();
+        let now = crate::content::now_secs();
         // Remember an expiring event until it expires everywhere; a manifest (no
         // expiry) for a fixed window. Either way at least the floor, so an event
         // that arrives already stale cannot be re-forwarded on every hop.
@@ -270,14 +269,6 @@ impl SeenQueries {
         order.push_back(qid.to_string());
         true
     }
-}
-
-/// Seconds since the Unix epoch.
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
 }
 
 /// Shared per-relay state: the store, a broadcast bus that fans newly-stored

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -15,9 +15,10 @@
 //! built with no gossiper and no gate behaves as an ordinary NIP-01 relay, which
 //! is what the tests use.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
@@ -114,6 +115,98 @@ pub trait PeerGate: Send + Sync {
 /// unbounded query amplifier (mirrors `MAX_EVENT_TTL` on the push plane).
 const MAX_REQ_TTL: u8 = 2;
 
+/// How long a non-expiring event's id is remembered as seen. A push wave lives
+/// for seconds, so this only has to outlast retries and a slow multi-hop path.
+const SEEN_RETENTION_SECS: u64 = 30 * 60;
+/// Floor for an event that carries a NIP-40 expiry in the past or very near
+/// future — remember it briefly regardless, so a wave in flight still terminates.
+const SEEN_FLOOR_SECS: u64 = 60;
+/// Cap on remembered ids. At ~40 bytes an entry this is a few hundred KB worst
+/// case, and chat (the high-rate kind) expires itself out well before the cap.
+const SEEN_CAPACITY: usize = 4096;
+
+/// The ids this proxy has already handled, and therefore will not fan out again.
+///
+/// This is the mesh loop-guard, and it deliberately does **not** live in the
+/// store. Storage answers "do I hold this?", which is a different question: an
+/// id GC'd at NIP-40 expiry looks new again on the next pull, and a
+/// store-triggered fan-out would start a fresh wave for an old message every
+/// time someone new comes into range. Novelty is a property of this node's
+/// history, so this node keeps it. See `reference/thinning-custom-relay.md` (D2)
+/// and `docs/design/event-gossip.md` §4.
+#[derive(Default)]
+struct SeenSet {
+    inner: Mutex<SeenInner>,
+}
+
+#[derive(Default)]
+struct SeenInner {
+    /// id -> the second after which the id may be forgotten.
+    until: HashMap<[u8; 32], u64>,
+    /// Insertion order, so the oldest id is the one evicted at capacity.
+    order: VecDeque<[u8; 32]>,
+}
+
+impl SeenSet {
+    /// Record an id, returning `true` if this is the **first** time we have seen
+    /// it — the caller's signal to fan out.
+    fn insert(&self, event: &Event) -> bool {
+        let now = now_secs();
+        // Remember an expiring event until it expires everywhere; a manifest (no
+        // expiry) for a fixed window. Either way at least the floor, so an event
+        // that arrives already stale cannot be re-forwarded on every hop.
+        let until = myco_relay::expiration(event)
+            .unwrap_or(now + SEEN_RETENTION_SECS)
+            .max(now + SEEN_FLOOR_SECS);
+
+        let id = event.id.to_bytes();
+        let mut inner = self.inner.lock().unwrap();
+        inner.gc(now);
+        if inner.until.contains_key(&id) {
+            return false;
+        }
+        while inner.order.len() >= SEEN_CAPACITY {
+            let Some(oldest) = inner.order.pop_front() else {
+                break;
+            };
+            inner.until.remove(&oldest);
+        }
+        inner.until.insert(id, until);
+        inner.order.push_back(id);
+        true
+    }
+}
+
+impl SeenInner {
+    /// Drop ids whose retention has run out. Cheap in the common case: the queue
+    /// is in insertion order and retention is near-uniform, so this stops at the
+    /// first live entry.
+    fn gc(&mut self, now: u64) {
+        while let Some(id) = self.order.front() {
+            match self.until.get(id) {
+                Some(&until) if until > now => break,
+                Some(_) => {
+                    let id = *id;
+                    self.until.remove(&id);
+                    self.order.pop_front();
+                }
+                // Already evicted by capacity; drop the stale queue entry.
+                None => {
+                    self.order.pop_front();
+                }
+            }
+        }
+    }
+}
+
+/// Seconds since the Unix epoch.
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 /// Shared per-relay state: the store, a broadcast bus that fans newly-stored
 /// events to all live subscriptions on this device, and the optional mesh gossiper.
 ///
@@ -128,6 +221,9 @@ pub struct RelayHub {
     /// Mesh access policy. `None` = open (local/test default); `Some` restricts
     /// mesh peers to paired (Circle) devices. Loopback always bypasses it.
     gate: Option<Arc<dyn PeerGate>>,
+    /// Ids already handled here, so a copy arriving by a second path is stored
+    /// but not re-flooded. Shared across every listener on this hub.
+    seen: SeenSet,
 }
 
 impl RelayHub {
@@ -152,6 +248,7 @@ impl RelayHub {
             live,
             gossip,
             gate,
+            seen: SeenSet::default(),
         })
     }
 }
@@ -452,26 +549,32 @@ async fn handle_client_frame(
                     serde_json::json!(["OK", id, false, "invalid: bad signature"]).to_string(),
                 ];
             }
-            match hub.store.store_event(event.clone()).await {
-                Ok(true) => {
-                    // Fan to this device's live subscriptions (incl. the WebView).
-                    let _ = hub.live.send(event.clone());
-                    // Drive the mesh gossiper off the socket path (non-blocking).
-                    if let Some(gossip) = hub.gossip.clone() {
-                        let inbound = Inbound {
-                            origin,
-                            event_ttl,
-                            sender: (origin == Origin::Mesh).then_some(peer_ip),
-                        };
-                        tokio::spawn(async move { gossip.on_event(event, inbound).await });
-                    }
-                    vec![serde_json::json!(["OK", id, true, ""]).to_string()]
+            // Novelty is the proxy's own call, made *before* storing and
+            // independent of what the store does with the event. Storing is
+            // idempotent, so it happens either way; only a first sighting fans
+            // out. See `reference/thinning-custom-relay.md` (D2).
+            let first_sighting = hub.seen.insert(&event);
+            if let Err(e) = hub.store.publish(event.clone()).await {
+                return vec![
+                    serde_json::json!(["OK", id, false, format!("error: {e}")]).to_string()
+                ];
+            }
+            if first_sighting {
+                // Fan to this device's live subscriptions (incl. the WebView).
+                let _ = hub.live.send(event.clone());
+                // Drive the mesh gossiper off the socket path (non-blocking).
+                if let Some(gossip) = hub.gossip.clone() {
+                    let inbound = Inbound {
+                        origin,
+                        event_ttl,
+                        sender: (origin == Origin::Mesh).then_some(peer_ip),
+                    };
+                    tokio::spawn(async move { gossip.on_event(event, inbound).await });
                 }
-                // Duplicate / superseded: still an accepted outcome per NIP-01.
-                Ok(false) => vec![serde_json::json!(["OK", id, true, "duplicate:"]).to_string()],
-                Err(e) => {
-                    vec![serde_json::json!(["OK", id, false, format!("error: {e}")]).to_string()]
-                }
+                vec![serde_json::json!(["OK", id, true, ""]).to_string()]
+            } else {
+                // Duplicate: still an accepted outcome per NIP-01.
+                vec![serde_json::json!(["OK", id, true, "duplicate:"]).to_string()]
             }
         }
         Some("CLOSE") => {
@@ -547,7 +650,7 @@ mod tests {
         let store = Arc::new(RelayStore::in_memory());
         let keys = Keys::generate();
         let site = build_test_site_with_keys(&keys, &[("/index.html", b"x")], None, None);
-        store.store_event(site.manifest.clone()).await.unwrap();
+        store.admit_event(site.manifest.clone()).await.unwrap();
 
         let addr = spawn_relay(store.clone()).await;
         let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
@@ -702,6 +805,65 @@ mod tests {
         // 127.0.0.1 is loopback → Local origin, no sender (originator stamps TTL).
         assert_eq!(seen[0].1.origin, Origin::Local);
         assert_eq!(seen[0].1.sender, None);
+    }
+
+    /// An event the store no longer holds must still not be re-flooded.
+    ///
+    /// This is the failure the seen-set exists to prevent. When novelty came from
+    /// the store, an id GC'd at NIP-40 expiry — or any backend that forgot it —
+    /// read as new on the next pull, so a fresh wave went out for an old message
+    /// every time someone came into range. Novelty belongs to this node's
+    /// history, not to what storage currently holds
+    /// (`reference/thinning-custom-relay.md` D2, `event-gossip.md` §4).
+    #[tokio::test]
+    async fn a_forgotten_event_is_not_re_flooded() {
+        use std::sync::Mutex;
+
+        struct Count(Mutex<usize>);
+        #[async_trait]
+        impl Gossiper for Count {
+            async fn on_event(&self, _event: Event, _inbound: Inbound) {
+                *self.0.lock().unwrap() += 1;
+            }
+        }
+
+        let store = Arc::new(RelayStore::in_memory());
+        let count = Arc::new(Count(Mutex::new(0)));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_on_with(store.clone(), listener, Some(count.clone())));
+
+        let keys = Keys::generate();
+        let msg = chat_event(&keys, "mesh", "old news");
+        let frame = serde_json::json!(["EVENT", msg]).to_string();
+
+        let publish = |frame: String| async move {
+            let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+                .await
+                .unwrap();
+            ws.send(WsMessage::Text(frame)).await.unwrap();
+            let _ = ws.next().await; // await the OK
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        };
+
+        publish(frame.clone()).await;
+        assert_eq!(*count.0.lock().unwrap(), 1, "first sighting fans out");
+
+        // Empty the store, standing in for expiry GC or a backend that forgot.
+        store.wipe().await.unwrap();
+        assert_eq!(store.count(), 0);
+
+        publish(frame).await;
+        assert_eq!(
+            *count.0.lock().unwrap(),
+            1,
+            "the store forgot it, but we have not: no second wave"
+        );
+        assert_eq!(
+            store.count(),
+            1,
+            "still stored again — publishing is idempotent, only the fan-out is suppressed"
+        );
     }
 
     /// A loopback client's REQ is reported to the gossiper as a local subscription

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -48,9 +48,9 @@ pub enum Origin {
 pub struct Inbound {
     /// Where the event arrived from (loopback WebView vs a mesh peer).
     pub origin: Origin,
-    /// The `event-ttl` that rode on the inbound EVENT (transient, stripped on
-    /// store). `None` for a local publish — the gossiper stamps the originate
-    /// default. See `docs/design/event-gossip.md` §2.
+    /// The hop budget that rode in the `MESH` envelope. `None` for a local
+    /// publish — the gossiper stamps the originate default. The event itself is
+    /// canonical NIP-01, so there is nothing to strip before storing.
     pub event_ttl: Option<u8>,
     /// The mesh peer's address the event came from, for split-horizon (never
     /// forward back to the sender). `None` for a local publish.
@@ -68,7 +68,7 @@ pub trait Gossiper: Send + Sync {
 
     /// The **pull plane**, forwarding half: a mesh peer asked us with hops left,
     /// so pass its filters to our own circle peers carrying a decremented
-    /// `req-ttl` and return their matching events to fold into the backlog before
+    /// hop budget and return their matching events to fold into the backlog before
     /// `EOSE`. `exclude` is the requester's mesh address (split-horizon — never
     /// forward straight back to it).
     ///
@@ -76,11 +76,11 @@ pub trait Gossiper: Send + Sync {
     /// reach this, so its `EOSE` never waits on a peer; the core drives multi-hop
     /// pull itself, through the peer pool. The default does nothing, so a relay
     /// with no gossiper stays single-hop. See `docs/design/event-gossip.md`
-    /// (req-ttl) and `reference/thinning-custom-relay.md` (D8).
+    /// and `reference/thinning-custom-relay.md` (D8).
     async fn on_req(
         &self,
         _filters: Vec<serde_json::Value>,
-        _req_ttl: u8,
+        _meta: crate::mesh_wire::MeshMeta,
         _exclude: Option<IpAddr>,
     ) -> Vec<Event> {
         Vec::new()
@@ -144,9 +144,9 @@ pub trait PeerGate: Send + Sync {
     }
 }
 
-/// Default clamp on the `req-ttl` we'll honour, so a peer can't turn us into an
-/// unbounded query amplifier (mirrors `MAX_EVENT_TTL` on the push plane). A gate
-/// may lower it per peer — see [`PeerGate::max_req_ttl`].
+/// Default clamp on the pull hop budget we'll honour, so a peer can't turn us
+/// into an unbounded query amplifier (mirrors `MAX_EVENT_TTL` on the push plane).
+/// A gate may lower it per peer — see [`PeerGate::max_req_ttl`].
 pub(crate) const MAX_REQ_TTL: u8 = 2;
 
 /// How long a non-expiring event's id is remembered as seen. A push wave lives
@@ -233,6 +233,45 @@ impl SeenInner {
     }
 }
 
+/// Query ids this node has already served.
+///
+/// Without it a pull multiplies: a circle is a graph, so the same query arrives
+/// by several paths and each arrival re-fans it to every peer. Event-id dedup at
+/// merge hides that in the *results* while the cost has already been paid — at
+/// ttl 2 across a circle of ten, on the order of a hundred requests over BLE for
+/// one query. It is also the amplification bound.
+///
+/// Bounded and FIFO-evicted. Queries are short-lived, so there is no expiry to
+/// track beyond capacity — an id that falls out the back is one whose wave ended
+/// long ago. See `reference/thinning-custom-relay.md` (D8).
+#[derive(Default)]
+struct SeenQueries {
+    inner: Mutex<(std::collections::HashSet<String>, VecDeque<String>)>,
+}
+
+/// Cap on remembered query ids. A pull is rare next to an event, so this is
+/// generous relative to the traffic.
+const SEEN_QUERIES_CAPACITY: usize = 512;
+
+impl SeenQueries {
+    /// Record a query id, returning `true` if this node had not served it yet.
+    fn insert_query(&self, qid: &str) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        let (set, order) = &mut *inner;
+        if set.contains(qid) {
+            return false;
+        }
+        while order.len() >= SEEN_QUERIES_CAPACITY {
+            if let Some(oldest) = order.pop_front() {
+                set.remove(&oldest);
+            }
+        }
+        set.insert(qid.to_string());
+        order.push_back(qid.to_string());
+        true
+    }
+}
+
 /// Seconds since the Unix epoch.
 fn now_secs() -> u64 {
     SystemTime::now()
@@ -258,6 +297,9 @@ pub struct RelayHub {
     /// Ids already handled here, so a copy arriving by a second path is stored
     /// but not re-flooded. Shared across every listener on this hub.
     seen: SeenSet,
+    /// Query ids already served, so a pull that reaches us by several paths is
+    /// answered once instead of re-fanned each time.
+    seen_queries: SeenQueries,
 }
 
 impl RelayHub {
@@ -283,6 +325,7 @@ impl RelayHub {
             gossip,
             gate,
             seen: SeenSet::default(),
+            seen_queries: SeenQueries::default(),
         })
     }
 }
@@ -512,9 +555,30 @@ async fn handle_client_frame(
     conn_id: u64,
     subs: &mut HashMap<String, Vec<ManifestFilter>>,
 ) -> Vec<String> {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
+    let Ok(frame) = serde_json::from_str::<serde_json::Value>(text) else {
         return Vec::new();
     };
+
+    // Unwrap a MESH envelope, if this is one: mesh state travels beside the NIP-01
+    // message, never inside it, and what comes out is passed on untouched. A plain
+    // frame is equally valid here and carries no metadata — store it, do not
+    // forward it. See `reference/thinning-custom-relay.md` (D1).
+    let (meta, value) = match crate::mesh_wire::unwrap(&frame) {
+        // Boundary 1: the in-app client is an ordinary Nostr client and has no
+        // business speaking our framing. Refusing it here is what stops an nsite
+        // reaching the mesh planes through a hand-built frame.
+        Some(_) if origin == Origin::Local => {
+            tracing::debug!("relay: refusing a MESH frame from a local client");
+            return vec![serde_json::json!([
+                "NOTICE",
+                "MESH framing is mesh-only; this relay speaks plain NIP-01 here"
+            ])
+            .to_string()];
+        }
+        Some((meta, inner)) => (meta, inner),
+        None => (crate::mesh_wire::MeshMeta::default(), frame),
+    };
+
     let Some(array) = value.as_array() else {
         return Vec::new();
     };
@@ -540,34 +604,24 @@ async fn handle_client_frame(
                 }
             }
             let raw_filters: Vec<serde_json::Value> = array.iter().skip(2).cloned().collect();
-            // `req-ttl` is a **mesh-only** forward budget, honoured for a peer's
-            // REQ and ignored on the loopback socket. An nsite must not be able to
-            // turn one filter key into a circle-wide flood — a single key must not
-            // change a query's cost by orders of magnitude — so multi-hop pull is a
+            // The forward budget comes from the envelope, clamped to what this
+            // peer is granted. A loopback client cannot send an envelope at all,
+            // so an nsite's REQ is always single-hop: one filter key must never
+            // change a query's cost by orders of magnitude. Multi-hop pull is a
             // core-driven operation (discovery, update checks) that goes through
-            // the peer pool directly, never through a client's filter. See
-            // `reference/thinning-custom-relay.md` (D8).
-            //
-            // It rides inside a filter object today; the `MESH` envelope moves it
-            // out in P5. `parse_filter` ignores the key either way, so it never
-            // affects local matching.
-            let req_ttl = match origin {
-                Origin::Local => 0,
-                Origin::Mesh => {
-                    // The clamp is this peer's own, so a peer without the
-                    // multihop grant is answered from our store alone.
-                    let cap = hub
-                        .gate
-                        .as_ref()
-                        .map_or(MAX_REQ_TTL, |g| g.max_req_ttl(peer_ip));
-                    raw_filters
-                        .iter()
-                        .filter_map(|f| f.get("req-ttl").and_then(|v| v.as_u64()))
-                        .max()
-                        .map(|n| n.min(cap as u64) as u8)
-                        .unwrap_or(0)
-                }
-            };
+            // the peer pool directly. See `reference/thinning-custom-relay.md` (D8).
+            let cap = hub
+                .gate
+                .as_ref()
+                .map_or(MAX_REQ_TTL, |g| g.max_req_ttl(peer_ip));
+            let hop = meta.clone().clamped(cap.min(MAX_REQ_TTL));
+            // A circle is a graph, not a tree, so the same query reaches us by
+            // several paths. Serve each query id once: answer from our own store
+            // as usual, but do not fan it out again.
+            let repeat = hop
+                .qid
+                .as_deref()
+                .is_some_and(|qid| !hub.seen_queries.insert_query(qid));
             let filters: Vec<ManifestFilter> =
                 raw_filters.iter().filter_map(parse_filter).collect();
 
@@ -585,12 +639,16 @@ async fn handle_client_frame(
             // slow or unreachable peer — it arrives at local-store speed, and
             // anything a peer delivers later reaches the client through the live
             // subscription instead.
-            if req_ttl > 0 {
-                if let Some(gossip) = hub.gossip.clone() {
-                    let remote = gossip
-                        .on_req(raw_filters.clone(), req_ttl - 1, Some(peer_ip))
-                        .await;
-                    events.extend(remote);
+            if !repeat {
+                if let Some(next) = hop.next_hop() {
+                    if let Some(gossip) = hub.gossip.clone() {
+                        // `next` carries the incoming query id onward, so every
+                        // node downstream serves this query once.
+                        let remote = gossip
+                            .on_req(raw_filters.clone(), next, Some(peer_ip))
+                            .await;
+                        events.extend(remote);
+                    }
                 }
             }
 
@@ -622,13 +680,9 @@ async fn handle_client_frame(
             let Some(event_value) = array.get(1) else {
                 return Vec::new();
             };
-            // The transient `event-ttl` (top-level, not a tag) rides the EVENT for
-            // mesh fan-out; read it before parsing (parsing to Event drops it, so
-            // it is never stored). See docs/design/event-gossip.md §2.
-            let event_ttl = event_value
-                .get("event-ttl")
-                .and_then(|v| v.as_u64())
-                .map(|n| n.min(u8::MAX as u64) as u8);
+            // The hop budget rides the envelope, so the event itself is canonical
+            // NIP-01 and there is nothing to strip before storing it.
+            let event_ttl = (origin == Origin::Mesh).then_some(meta.ttl);
             let Ok(event) = serde_json::from_value::<Event>(event_value.clone()) else {
                 return Vec::new();
             };
@@ -971,6 +1025,194 @@ mod tests {
         );
     }
 
+    /// A wave crosses hops, decrements, and dies — and a hostile budget is clamped.
+    ///
+    /// Walks A→B→C by feeding each node the frame the previous one emitted, which
+    /// is the part that has to hold: the hop count has to survive the envelope, not
+    /// the event, and the event has to arrive canonical at every hop.
+    #[tokio::test]
+    async fn a_push_wave_decrements_and_terminates() {
+        use std::sync::Mutex;
+
+        struct Capture(Mutex<Vec<Option<u8>>>);
+        #[async_trait]
+        impl Gossiper for Capture {
+            async fn on_event(&self, _event: Event, inbound: Inbound) {
+                self.0.lock().unwrap().push(inbound.event_ttl);
+            }
+        }
+
+        // One node, fed a frame as if from a mesh peer; returns the ttl its
+        // gossiper saw, which is what decides how much further the wave goes.
+        async fn hop(frame: &str) -> Option<u8> {
+            let cap = Arc::new(Capture(Mutex::new(Vec::new())));
+            let hub = RelayHub::new(Arc::new(RelayStore::in_memory()), Some(cap.clone()));
+            let mut subs = HashMap::new();
+            let peer: IpAddr = "fd00::9".parse().unwrap();
+            handle_client_frame(frame, &hub, Origin::Mesh, peer, 0, &mut subs).await;
+            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            let seen = cap.0.lock().unwrap().clone();
+            assert_eq!(seen.len(), 1, "the event was accepted exactly once");
+            seen[0]
+        }
+
+        let keys = Keys::generate();
+        let msg = chat_event(&keys, "mesh", "ripple");
+        let event = serde_json::to_value(&msg).unwrap();
+
+        // A originates at ttl 2; B sees 2 and forwards 1; C sees 1 and forwards 0.
+        let at_b = hop(&crate::mesh_wire::wrap(
+            &crate::mesh_wire::MeshMeta::push(2),
+            serde_json::json!(["EVENT", event.clone()]),
+        ))
+        .await;
+        assert_eq!(at_b, Some(2));
+
+        let at_c = hop(&crate::mesh_wire::wrap(
+            &crate::mesh_wire::MeshMeta::push(1),
+            serde_json::json!(["EVENT", event.clone()]),
+        ))
+        .await;
+        assert_eq!(at_c, Some(1));
+
+        // The last hop has nothing left to spend.
+        let at_d = hop(&crate::mesh_wire::wrap(
+            &crate::mesh_wire::MeshMeta::push(0),
+            serde_json::json!(["EVENT", event.clone()]),
+        ))
+        .await;
+        assert_eq!(at_d, Some(0), "stored, but the wave stops here");
+
+        // A plain frame from a peer carries no budget and is equally terminal.
+        let plain = hop(&serde_json::json!(["EVENT", event]).to_string()).await;
+        assert_eq!(plain, Some(0));
+    }
+
+    /// One query id is served once per node, however many paths it arrives by.
+    ///
+    /// A circle is a graph, so the same pull reaches a node from several peers.
+    /// Without this the fan-out multiplies — at ttl 2 across a circle of ten, on
+    /// the order of a hundred requests over BLE for a single query
+    /// (`reference/thinning-custom-relay.md`, D8).
+    #[tokio::test]
+    async fn a_repeated_query_id_is_not_re_fanned() {
+        use std::sync::Mutex;
+
+        struct CountReq(Mutex<usize>);
+        #[async_trait]
+        impl Gossiper for CountReq {
+            async fn on_event(&self, _event: Event, _inbound: Inbound) {}
+            async fn on_req(
+                &self,
+                _filters: Vec<serde_json::Value>,
+                _meta: crate::mesh_wire::MeshMeta,
+                _exclude: Option<IpAddr>,
+            ) -> Vec<Event> {
+                *self.0.lock().unwrap() += 1;
+                Vec::new()
+            }
+        }
+
+        let counter = Arc::new(CountReq(Mutex::new(0)));
+        let hub = RelayHub::new(Arc::new(RelayStore::in_memory()), Some(counter.clone()));
+        let query = crate::mesh_wire::wrap(
+            &crate::mesh_wire::MeshMeta::pull(2, "q-loop", 10_000),
+            serde_json::json!(["REQ", "s1", { "kinds": [9] }]),
+        );
+
+        // The same query arriving from three different peers, as it would in a
+        // circle wired A–B, B–C, C–A.
+        for (i, peer) in ["fd00::1", "fd00::2", "fd00::3"].iter().enumerate() {
+            let mut subs = HashMap::new();
+            let out = handle_client_frame(
+                &query,
+                &hub,
+                Origin::Mesh,
+                peer.parse().unwrap(),
+                i as u64,
+                &mut subs,
+            )
+            .await;
+            assert!(
+                out.iter().any(|f| f.contains("EOSE")),
+                "every arrival is still answered from our own store"
+            );
+        }
+
+        assert_eq!(
+            *counter.0.lock().unwrap(),
+            1,
+            "the query is fanned out once, not once per path"
+        );
+    }
+
+    /// The two boundaries, asserted rather than left as a convention.
+    ///
+    /// Everything in this plan rests on two rules: the nsite link speaks plain
+    /// NIP-01, and so does the link to whatever relay sits behind us. If either
+    /// ever carries a `MESH` verb or a ttl key, the relay has stopped being
+    /// swappable and the design has quietly reversed itself. That is worth a test
+    /// rather than a comment (`reference/thinning-custom-relay.md`).
+    #[tokio::test]
+    async fn no_mesh_framing_crosses_the_client_or_backend_links() {
+        let store = Arc::new(RelayStore::in_memory());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_on(store.clone(), listener));
+
+        let keys = Keys::generate();
+        let msg = chat_event(&keys, "mesh", "hello");
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+            .await
+            .unwrap();
+        ws.send(WsMessage::Text(
+            serde_json::json!(["REQ", "s1", { "kinds": [9] }]).to_string(),
+        ))
+        .await
+        .unwrap();
+        ws.send(WsMessage::Text(
+            serde_json::json!(["EVENT", msg]).to_string(),
+        ))
+        .await
+        .unwrap();
+
+        // Collect everything the client link carries back.
+        let mut seen = Vec::new();
+        for _ in 0..4 {
+            match tokio::time::timeout(std::time::Duration::from_millis(300), ws.next()).await {
+                Ok(Some(Ok(WsMessage::Text(txt)))) => seen.push(txt.to_string()),
+                _ => break,
+            }
+        }
+        assert!(!seen.is_empty(), "the client link carried something");
+        for frame in &seen {
+            assert!(
+                !frame.contains(crate::mesh_wire::MESH)
+                    && !frame.contains("event-ttl")
+                    && !frame.contains("req-ttl"),
+                "boundary 1 must stay plain NIP-01, got: {frame}"
+            );
+        }
+
+        // The backend link: what actually landed in the store is a canonical
+        // event, with no mesh state smuggled into it.
+        let stored = store
+            .query(&ManifestFilter {
+                kinds: vec![9],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(stored.len(), 1);
+        let json = serde_json::to_string(&stored[0]).unwrap();
+        assert!(
+            !json.contains("event-ttl") && !json.contains(crate::mesh_wire::MESH),
+            "boundary 2 must store a canonical NIP-01 event, got: {json}"
+        );
+        assert_eq!(stored[0].id, msg.id, "and it is the same event");
+    }
+
     /// An unpaired peer never gets a socket at all.
     ///
     /// Refusing per frame would still hand a stranger a WebSocket upgrade and a
@@ -1081,14 +1323,16 @@ mod tests {
     /// An nsite cannot start a circle-wide pull, and its `EOSE` never waits on a
     /// peer.
     ///
-    /// `req-ttl` is a mesh-only forward budget. If a loopback client could set it,
-    /// one filter key would turn a plain chat query into a flood across the whole
-    /// circle, and the client would block until every peer answered or timed out.
-    /// The gossiper here would hang for a minute if it were ever consulted, so a
-    /// prompt `EOSE` is the assertion. See `reference/thinning-custom-relay.md`
-    /// (D8).
+    /// Two halves. A plain `REQ` — what every client actually sends — is answered
+    /// from the local store without touching the fan-out. And a hand-built `MESH`
+    /// frame, the only way a client could ask for hops, is refused outright:
+    /// boundary 1 says the loopback socket speaks plain NIP-01, so mesh framing
+    /// has no meaning there (`reference/thinning-custom-relay.md`, D1 and D8).
+    ///
+    /// The gossiper here hangs for a minute if consulted, so a prompt `EOSE` is
+    /// the assertion.
     #[tokio::test]
-    async fn client_req_ttl_is_ignored_and_never_blocks_eose() {
+    async fn a_client_cannot_reach_the_fan_out() {
         use std::sync::Mutex;
 
         struct Hang(Mutex<usize>);
@@ -1098,7 +1342,7 @@ mod tests {
             async fn on_req(
                 &self,
                 _filters: Vec<serde_json::Value>,
-                _req_ttl: u8,
+                _meta: crate::mesh_wire::MeshMeta,
                 _exclude: Option<IpAddr>,
             ) -> Vec<Event> {
                 *self.0.lock().unwrap() += 1;
@@ -1116,10 +1360,13 @@ mod tests {
         let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
             .await
             .unwrap();
-        // A client asking for two hops of reach — exactly what must not be honoured.
-        let req = serde_json::json!(["REQ", "s1", { "kinds": [9], "req-ttl": 2 }]);
-        ws.send(WsMessage::Text(req.to_string())).await.unwrap();
 
+        // The ordinary client path: a plain REQ, answered locally.
+        ws.send(WsMessage::Text(
+            serde_json::json!(["REQ", "s1", { "kinds": [9] }]).to_string(),
+        ))
+        .await
+        .unwrap();
         let eose = tokio::time::timeout(std::time::Duration::from_secs(2), async {
             while let Some(Ok(WsMessage::Text(txt))) = ws.next().await {
                 let v: serde_json::Value = serde_json::from_str(&txt).unwrap();
@@ -1130,16 +1377,35 @@ mod tests {
             false
         })
         .await;
-
         assert_eq!(
             eose,
             Ok(true),
             "EOSE must arrive at local-store speed, not after a peer round trip"
         );
+
+        // The only way to ask for hops is mesh framing, which does not belong on
+        // this socket.
+        ws.send(WsMessage::Text(crate::mesh_wire::wrap(
+            &crate::mesh_wire::MeshMeta::pull(2, "q1", 10_000),
+            serde_json::json!(["REQ", "s2", { "kinds": [9] }]),
+        )))
+        .await
+        .unwrap();
+        let notice = tokio::time::timeout(std::time::Duration::from_secs(2), ws.next())
+            .await
+            .expect("a prompt answer")
+            .expect("a frame")
+            .expect("text");
+        let WsMessage::Text(txt) = notice else {
+            panic!("expected a NOTICE")
+        };
+        let v: serde_json::Value = serde_json::from_str(&txt).unwrap();
+        assert_eq!(v.get(0).and_then(|x| x.as_str()), Some("NOTICE"));
+
         assert_eq!(
             *hang.0.lock().unwrap(),
             0,
-            "a client filter must not reach the peer fan-out at all"
+            "a client must not reach the peer fan-out by either route"
         );
     }
 

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -148,7 +148,9 @@ pub trait PeerGate: Send + Sync {
 }
 
 /// Default clamp on the pull hop budget we'll honour, so a peer can't turn us
-/// into an unbounded query amplifier (mirrors `MAX_EVENT_TTL` on the push plane).
+/// into an unbounded query amplifier. Lower than the push plane's
+/// [`EVENT_TTL`](crate::mesh_wire::EVENT_TTL) on purpose: a flooded read costs
+/// more, because every hop answers as well as forwards.
 /// A gate may lower it per peer — see [`PeerGate::max_req_ttl`].
 pub(crate) const MAX_REQ_TTL: u8 = 2;
 

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -31,7 +31,9 @@ use nostr::Filter;
 use nsite_deck::seams::RelayBackend;
 use tokio::sync::broadcast;
 
-use myco_relay::{matches_filter, RelayStore};
+use myco_relay::matches_filter;
+#[cfg(test)]
+use myco_relay::RelayStore;
 
 /// Where an event reached this relay from: the local WebView (a loopback socket)
 /// or a mesh peer (a `.fips` socket). Drives the gossiper's push/pull split.
@@ -281,7 +283,9 @@ impl SeenQueries {
 /// live bus, store, and gossiper are shared across them — a peer's event pushed on
 /// the mesh socket reaches a WebView subscription on the loopback socket.
 pub struct RelayHub {
-    store: Arc<RelayStore>,
+    /// Whatever is answering NIP-01 behind us: the embedded store by default,
+    /// or a relay the user pointed us at. The proxy never needs to know which.
+    store: Arc<dyn RelayBackend>,
     live: broadcast::Sender<Event>,
     gossip: Option<Arc<dyn Gossiper>>,
     /// Mesh access policy. `None` = open (local/test default); `Some` restricts
@@ -298,14 +302,14 @@ pub struct RelayHub {
 impl RelayHub {
     /// Build a shared hub. Pass `None` for `gossip` to disable mesh fan-out. No
     /// access gate — every connection is served (the local/test default).
-    pub fn new(store: Arc<RelayStore>, gossip: Option<Arc<dyn Gossiper>>) -> Arc<Self> {
+    pub fn new(store: Arc<dyn RelayBackend>, gossip: Option<Arc<dyn Gossiper>>) -> Arc<Self> {
         Self::with_gate(store, gossip, None)
     }
 
     /// Build a hub that restricts **mesh** access to paired peers via `gate`
     /// (loopback is always allowed). Pass `None` for `gate` to stay open.
     pub fn with_gate(
-        store: Arc<RelayStore>,
+        store: Arc<dyn RelayBackend>,
         gossip: Option<Arc<dyn Gossiper>>,
         gate: Option<Arc<dyn PeerGate>>,
     ) -> Arc<Self> {
@@ -324,7 +328,7 @@ impl RelayHub {
 }
 
 /// Serve the relay on `addr` until the future is dropped/aborted (no gossiper).
-pub async fn serve(store: Arc<RelayStore>, addr: SocketAddr) -> anyhow::Result<()> {
+pub async fn serve(store: Arc<dyn RelayBackend>, addr: SocketAddr) -> anyhow::Result<()> {
     serve_on(store, bind(addr)?).await
 }
 
@@ -352,7 +356,7 @@ pub fn bind(addr: SocketAddr) -> anyhow::Result<tokio::net::TcpListener> {
 
 /// Serve on an already-bound listener with no mesh gossiper (the local/test path).
 pub async fn serve_on(
-    store: Arc<RelayStore>,
+    store: Arc<dyn RelayBackend>,
     listener: tokio::net::TcpListener,
 ) -> anyhow::Result<()> {
     serve_on_with(store, listener, None).await
@@ -361,7 +365,7 @@ pub async fn serve_on(
 /// Serve on an already-bound listener, fanning newly-accepted events to `gossip`
 /// (the mesh propagator). The runtime uses this so chat events reach peers.
 pub async fn serve_on_with(
-    store: Arc<RelayStore>,
+    store: Arc<dyn RelayBackend>,
     listener: tokio::net::TcpListener,
     gossip: Option<Arc<dyn Gossiper>>,
 ) -> anyhow::Result<()> {

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -57,9 +57,10 @@ pub struct Inbound {
     pub sender: Option<IpAddr>,
 }
 
-/// The mesh fan-out hook. The relay calls this for every **newly-accepted** event
-/// (the store's id-dedup is the loop guard: a duplicate is never re-delivered
-/// here). The implementor (`myco-core`) decides whether and how far to push it to
+/// The mesh fan-out hook. The proxy calls this for every event it sees for the
+/// **first time** — its own seen-set is the loop guard, not the store's dedup, so
+/// an id the store has since forgotten is still not re-flooded (D2). The
+/// implementor (`myco-core`) decides whether and how far to push it to
 /// circle peers using the [`Inbound`] context (see `docs/design/event-gossip.md`).
 /// The default does nothing — the relay never fans out on its own.
 #[async_trait]
@@ -678,9 +679,10 @@ async fn handle_client_frame(
                 return Vec::new();
             };
             let id = event.id.to_hex();
-            // Mesh access gate: an unpaired peer may publish only the pairing
-            // handshake (so pairing can bootstrap); everything else is rejected
-            // until they're in our Circle.
+            // Only a paired peer reaches this at all (admission refused the rest
+            // before the upgrade), so this is the peer's write grant — plus the
+            // pairing kinds, which belong to the auth plane and are refused from
+            // every source.
             if origin == Origin::Mesh {
                 if let Some(gate) = &hub.gate {
                     if !gate.may_publish(peer_ip, event.kind.as_u16()) {

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -66,12 +66,17 @@ pub struct Inbound {
 pub trait Gossiper: Send + Sync {
     async fn on_event(&self, event: Event, inbound: Inbound);
 
-    /// The **pull plane**: forward a `REQ`'s filters to circle peers carrying a
-    /// decremented `req-ttl`, returning their matching (signature-verified) events
-    /// to fold into the backlog before `EOSE`. `exclude` is the requester's mesh
-    /// address (split-horizon — never forward straight back to it). The default
-    /// does nothing, so a relay with no gossiper stays single-hop. See
-    /// `docs/design/event-gossip.md` (req-ttl).
+    /// The **pull plane**, forwarding half: a mesh peer asked us with hops left,
+    /// so pass its filters to our own circle peers carrying a decremented
+    /// `req-ttl` and return their matching events to fold into the backlog before
+    /// `EOSE`. `exclude` is the requester's mesh address (split-horizon — never
+    /// forward straight back to it).
+    ///
+    /// Only ever called for a **mesh-origin** `REQ`. A loopback client cannot
+    /// reach this, so its `EOSE` never waits on a peer; the core drives multi-hop
+    /// pull itself, through the peer pool. The default does nothing, so a relay
+    /// with no gossiper stays single-hop. See `docs/design/event-gossip.md`
+    /// (req-ttl) and `reference/thinning-custom-relay.md` (D8).
     async fn on_req(
         &self,
         _filters: Vec<serde_json::Value>,
@@ -455,15 +460,26 @@ async fn handle_client_frame(
                 }
             }
             let raw_filters: Vec<serde_json::Value> = array.iter().skip(2).cloned().collect();
-            // `req-ttl` rides *inside* a filter object (a transient extension key,
-            // like `event-ttl` rides the EVENT) — the remaining mesh forward hops.
-            // parse_filter ignores the key, so it never affects local matching.
-            let req_ttl = raw_filters
-                .iter()
-                .filter_map(|f| f.get("req-ttl").and_then(|v| v.as_u64()))
-                .max()
-                .map(|n| n.min(MAX_REQ_TTL as u64) as u8)
-                .unwrap_or(0);
+            // `req-ttl` is a **mesh-only** forward budget, honoured for a peer's
+            // REQ and ignored on the loopback socket. An nsite must not be able to
+            // turn one filter key into a circle-wide flood — a single key must not
+            // change a query's cost by orders of magnitude — so multi-hop pull is a
+            // core-driven operation (discovery, update checks) that goes through
+            // the peer pool directly, never through a client's filter. See
+            // `reference/thinning-custom-relay.md` (D8).
+            //
+            // It rides inside a filter object today; the `MESH` envelope moves it
+            // out in P5. `parse_filter` ignores the key either way, so it never
+            // affects local matching.
+            let req_ttl = match origin {
+                Origin::Local => 0,
+                Origin::Mesh => raw_filters
+                    .iter()
+                    .filter_map(|f| f.get("req-ttl").and_then(|v| v.as_u64()))
+                    .max()
+                    .map(|n| n.min(MAX_REQ_TTL as u64) as u8)
+                    .unwrap_or(0),
+            };
             let filters: Vec<ManifestFilter> =
                 raw_filters.iter().filter_map(parse_filter).collect();
 
@@ -475,15 +491,16 @@ async fn handle_client_frame(
                 }
             }
 
-            // Pull plane: fold in peers' matching events up to `req-ttl` more hops.
-            // Bounded by the gossiper's own per-peer timeouts. Only paid when a
-            // client opts in by setting req-ttl (e.g. discovery), so plain chat
-            // REQs stay single-hop and cheap.
+            // Forwarding half of the pull plane: a peer asked with hops left, so
+            // fold in our own peers' matching events before answering. Only a mesh
+            // REQ reaches here, so a local client's `EOSE` is never held up by a
+            // slow or unreachable peer — it arrives at local-store speed, and
+            // anything a peer delivers later reaches the client through the live
+            // subscription instead.
             if req_ttl > 0 {
                 if let Some(gossip) = hub.gossip.clone() {
-                    let exclude = (origin == Origin::Mesh).then_some(peer_ip);
                     let remote = gossip
-                        .on_req(raw_filters.clone(), req_ttl - 1, exclude)
+                        .on_req(raw_filters.clone(), req_ttl - 1, Some(peer_ip))
                         .await;
                     events.extend(remote);
                 }
@@ -863,6 +880,71 @@ mod tests {
             store.count(),
             1,
             "still stored again — publishing is idempotent, only the fan-out is suppressed"
+        );
+    }
+
+    /// An nsite cannot start a circle-wide pull, and its `EOSE` never waits on a
+    /// peer.
+    ///
+    /// `req-ttl` is a mesh-only forward budget. If a loopback client could set it,
+    /// one filter key would turn a plain chat query into a flood across the whole
+    /// circle, and the client would block until every peer answered or timed out.
+    /// The gossiper here would hang for a minute if it were ever consulted, so a
+    /// prompt `EOSE` is the assertion. See `reference/thinning-custom-relay.md`
+    /// (D8).
+    #[tokio::test]
+    async fn client_req_ttl_is_ignored_and_never_blocks_eose() {
+        use std::sync::Mutex;
+
+        struct Hang(Mutex<usize>);
+        #[async_trait]
+        impl Gossiper for Hang {
+            async fn on_event(&self, _event: Event, _inbound: Inbound) {}
+            async fn on_req(
+                &self,
+                _filters: Vec<serde_json::Value>,
+                _req_ttl: u8,
+                _exclude: Option<IpAddr>,
+            ) -> Vec<Event> {
+                *self.0.lock().unwrap() += 1;
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                Vec::new()
+            }
+        }
+
+        let store = Arc::new(RelayStore::in_memory());
+        let hang = Arc::new(Hang(Mutex::new(0)));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_on_with(store, listener, Some(hang.clone())));
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+            .await
+            .unwrap();
+        // A client asking for two hops of reach — exactly what must not be honoured.
+        let req = serde_json::json!(["REQ", "s1", { "kinds": [9], "req-ttl": 2 }]);
+        ws.send(WsMessage::Text(req.to_string())).await.unwrap();
+
+        let eose = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while let Some(Ok(WsMessage::Text(txt))) = ws.next().await {
+                let v: serde_json::Value = serde_json::from_str(&txt).unwrap();
+                if v.get(0).and_then(|x| x.as_str()) == Some("EOSE") {
+                    return true;
+                }
+            }
+            false
+        })
+        .await;
+
+        assert_eq!(
+            eose,
+            Ok(true),
+            "EOSE must arrive at local-store speed, not after a peer round trip"
+        );
+        assert_eq!(
+            *hang.0.lock().unwrap(),
+            0,
+            "a client filter must not reach the peer fan-out at all"
         );
     }
 

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -1,13 +1,19 @@
-//! A NIP-01 WebSocket relay over [`RelayStore`]. Serves the node's events to the
-//! in-app WebView at `ws://localhost:4870` and to mesh peers at
-//! `ws://[fd00::self]:4870`.
+//! The **mesh relay proxy**: the NIP-01 WebSocket front door serving the in-app
+//! WebView at `ws://localhost:4870` and mesh peers at `ws://[fd00::self]:4870`,
+//! with a relay store behind it.
 //!
-//! Unlike the original manifest-only socket, this one keeps **live subscriptions**
-//! (a `REQ` stays open; newly-stored events that match are pushed as they arrive),
-//! which is what makes nearby chat feel live. New events also drive an optional
-//! [`Gossiper`] — the mesh fan-out hook (`docs/design/event-gossip.md`) — with the
-//! connection's [`Origin`] (loopback = the local WebView, else a mesh peer) so the
-//! gossiper can apply the push/pull and `event-ttl` rules.
+//! This is the only Myco-specific code on the content path. It keeps **live
+//! subscriptions** (a `REQ` stays open; newly-stored events that match are pushed
+//! as they arrive), which is what makes nearby chat feel live, and it drives both
+//! mesh planes: a [`Gossiper`] for fan-out (`docs/design/event-gossip.md`) and a
+//! [`PeerGate`] for access, each keyed off the connection's [`Origin`] (loopback =
+//! the local WebView, else a mesh peer).
+//!
+//! It lives here rather than in `myco-relay` so the store behind it stays a plain
+//! NIP-01 relay with no Myco concepts in it, and can be swapped for any other
+//! relay later. This is step P1 of `reference/thinning-custom-relay.md`. A proxy
+//! built with no gossiper and no gate behaves as an ordinary NIP-01 relay, which
+//! is what the tests use.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
@@ -24,7 +30,7 @@ use nostr::{Event, PublicKey};
 use nsite_deck::seams::{ManifestFilter, RelayBackend};
 use tokio::sync::broadcast;
 
-use crate::{matches_filter, RelayStore};
+use myco_relay::{matches_filter, RelayStore};
 
 /// Where an event reached this relay from: the local WebView (a loopback socket)
 /// or a mesh peer (a `.fips` socket). Drives the gossiper's push/pull split.

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -26,8 +26,9 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use futures_util::{SinkExt, StreamExt};
-use nostr::{Event, PublicKey};
-use nsite_deck::seams::{ManifestFilter, RelayBackend};
+use nostr::Event;
+use nostr::Filter;
+use nsite_deck::seams::RelayBackend;
 use tokio::sync::broadcast;
 
 use myco_relay::{matches_filter, RelayStore};
@@ -450,7 +451,7 @@ async fn handle_ws(socket: WebSocket, hub: Arc<RelayHub>, peer_ip: IpAddr) {
     let (mut ws_tx, mut ws_rx) = socket.split();
     let mut live = hub.live.subscribe();
     // Active subscriptions on this connection: sub_id -> its filters.
-    let mut subs: HashMap<String, Vec<ManifestFilter>> = HashMap::new();
+    let mut subs: HashMap<String, Vec<Filter>> = HashMap::new();
 
     'conn: loop {
         tokio::select! {
@@ -517,7 +518,7 @@ fn finish_conn(
     hub: &Arc<RelayHub>,
     origin: Origin,
     conn_id: u64,
-    subs: &HashMap<String, Vec<ManifestFilter>>,
+    subs: &HashMap<String, Vec<Filter>>,
 ) {
     if origin != Origin::Local {
         return;
@@ -544,7 +545,7 @@ async fn handle_client_frame(
     origin: Origin,
     peer_ip: IpAddr,
     conn_id: u64,
-    subs: &mut HashMap<String, Vec<ManifestFilter>>,
+    subs: &mut HashMap<String, Vec<Filter>>,
 ) -> Vec<String> {
     let Ok(frame) = serde_json::from_str::<serde_json::Value>(text) else {
         return Vec::new();
@@ -613,16 +614,15 @@ async fn handle_client_frame(
                 .qid
                 .as_deref()
                 .is_some_and(|qid| !hub.seen_queries.insert_query(qid));
-            let filters: Vec<ManifestFilter> =
-                raw_filters.iter().filter_map(parse_filter).collect();
+            // Parsed by the `nostr` crate, so the whole NIP-01 filter surface
+            // works rather than a hand-rolled subset of it.
+            let filters: Vec<Filter> = raw_filters
+                .iter()
+                .filter_map(|f| serde_json::from_value::<Filter>(f.clone()).ok())
+                .collect();
 
             // Stored backlog: any-match across the REQ's filters, newest first.
-            let mut events: Vec<Event> = Vec::new();
-            for filter in &filters {
-                if let Ok(mut matched) = hub.store.query(filter).await {
-                    events.append(&mut matched);
-                }
-            }
+            let mut events: Vec<Event> = hub.store.query(&filters).await.unwrap_or_default();
 
             // Forwarding half of the pull plane: a peer asked with hops left, so
             // fold in our own peers' matching events before answering. Only a mesh
@@ -740,36 +740,6 @@ async fn handle_client_frame(
         }
         _ => Vec::new(),
     }
-}
-
-/// Parse a NIP-01 filter object into the basic [`ManifestFilter`].
-fn parse_filter(value: &serde_json::Value) -> Option<ManifestFilter> {
-    let obj = value.as_object()?;
-    let mut filter = ManifestFilter::default();
-    if let Some(kinds) = obj.get("kinds").and_then(|v| v.as_array()) {
-        filter.kinds = kinds
-            .iter()
-            .filter_map(|k| k.as_u64().map(|k| k as u16))
-            .collect();
-    }
-    if let Some(authors) = obj.get("authors").and_then(|v| v.as_array()) {
-        filter.authors = authors
-            .iter()
-            .filter_map(|a| a.as_str())
-            .filter_map(|hex| PublicKey::parse(hex).ok())
-            .collect();
-    }
-    if let Some(d_tags) = obj.get("#d").and_then(|v| v.as_array()) {
-        filter.d_tags = d_tags
-            .iter()
-            .filter_map(|d| d.as_str().map(str::to_string))
-            .collect();
-    }
-    filter.limit = obj
-        .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|n| n as usize);
-    Some(filter)
 }
 
 #[cfg(test)]
@@ -1000,7 +970,9 @@ mod tests {
         assert_eq!(*count.0.lock().unwrap(), 1, "first sighting fans out");
 
         // Empty the store, standing in for expiry GC or a backend that forgot.
-        store.wipe().await.unwrap();
+        nsite_deck::seams::AdminBackend::wipe(store.as_ref())
+            .await
+            .unwrap();
         assert_eq!(store.count(), 0);
 
         publish(frame).await;
@@ -1189,10 +1161,7 @@ mod tests {
         // The backend link: what actually landed in the store is a canonical
         // event, with no mesh state smuggled into it.
         let stored = store
-            .query(&ManifestFilter {
-                kinds: vec![9],
-                ..Default::default()
-            })
+            .query(&[Filter::new().kind(Kind::from(9u16))])
             .await
             .unwrap();
         assert_eq!(stored.len(), 1);

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -23,7 +23,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{ConnectInfo, State};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use futures_util::{SinkExt, StreamExt};
@@ -101,18 +101,35 @@ pub trait Gossiper: Send + Sync {
     fn on_local_unsubscribe(&self, _key: &str) {}
 }
 
-/// Access policy for **mesh** connections: only paired (Circle) peers may read or
-/// publish content. Loopback (the in-app WebView) bypasses this entirely. The one
-/// exception is the pairing handshake — an as-yet-unpaired peer must be able to
-/// publish a pair request to bootstrap, so [`may_publish`](PeerGate::may_publish)
-/// is consulted per event kind. The implementor (`myco-core`) backs this with the
-/// Circle; a hub with no gate is open (the local/test default).
+/// Access policy for **mesh** connections: only paired (Circle) peers reach the
+/// content plane at all, and what an admitted peer may do comes from its own
+/// permission record. Loopback (the in-app WebView) bypasses this entirely.
+///
+/// There are no exceptions. Pairing used to need one, but the handshake now has
+/// its own service (`crate::auth_service`), so nothing unpaired gets a socket.
+/// The implementor (`myco-core`) backs this with the Circle; a hub with no gate
+/// is open (the local/test default).
 pub trait PeerGate: Send + Sync {
+    /// May the mesh peer at `ip` open a connection at all?
+    ///
+    /// Checked **before the WebSocket upgrade**, so an unpaired peer is refused
+    /// at the door rather than handed a socket and then told "no" per frame. That
+    /// is cheaper over BLE — a stranger no longer costs an upgrade and a round of
+    /// frames — and it means the content plane has one admission rule with no
+    /// exceptions (`reference/thinning-custom-relay.md`, D6).
+    ///
+    /// Membership only. What an admitted peer may then do is [`may_read`] and
+    /// [`may_publish`], from its own permission record.
+    ///
+    /// [`may_read`]: Self::may_read
+    /// [`may_publish`]: Self::may_publish
+    fn may_connect(&self, ip: IpAddr) -> bool;
+
     /// May the mesh peer at `ip` open a `REQ` (read events from us)?
     fn may_read(&self, ip: IpAddr) -> bool;
-    /// May the mesh peer at `ip` publish an `EVENT` of `kind`? Implementors allow
-    /// the pairing kinds from anyone (bootstrap) and everything else only when
-    /// `ip` is a paired peer.
+    /// May the mesh peer at `ip` publish an `EVENT` of `kind`? Implementors
+    /// refuse the pairing kinds outright — those belong to the auth plane — and
+    /// allow the rest per the peer's write grant.
     fn may_publish(&self, ip: IpAddr, kind: u16) -> bool;
 
     /// How far a `REQ` from `ip` may be forwarded on. `0` means answer from our
@@ -321,7 +338,10 @@ pub async fn serve_on_hub(
     hub: Arc<RelayHub>,
     listener: tokio::net::TcpListener,
 ) -> anyhow::Result<()> {
-    let app = Router::new().route("/", get(root)).with_state(hub);
+    let app = Router::new()
+        .route("/", get(root))
+        .layer(axum::middleware::from_fn_with_state(hub.clone(), admit))
+        .with_state(hub);
     // Connect-info gives each socket's peer address, so the handler can tell a
     // loopback (WebView) connection from a mesh peer.
     axum::serve(
@@ -341,6 +361,34 @@ async fn root(
 ) -> Response {
     let peer = addr.ip();
     ws.on_upgrade(move |socket| handle_ws(socket, hub, peer))
+}
+
+/// Admission, applied as a layer so it runs **before** the WebSocket upgrade is
+/// even parsed: an unpaired mesh peer gets a plain 403 and no socket.
+///
+/// A stranger costs us a TCP accept and one small response, rather than an
+/// upgrade plus a round of frames it was never allowed to send — which matters
+/// on a BLE link. Loopback (the in-app WebView) always bypasses.
+async fn admit(
+    State(hub): State<Arc<RelayHub>>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let peer = addr.ip();
+    if !peer.is_loopback() {
+        if let Some(gate) = &hub.gate {
+            if !gate.may_connect(peer) {
+                tracing::debug!(peer = %peer, "relay: refused an unpaired connection");
+                return (
+                    axum::http::StatusCode::FORBIDDEN,
+                    "restricted: pair to access",
+                )
+                    .into_response();
+            }
+        }
+    }
+    next.run(req).await
 }
 
 /// One client connection: serve `REQ` backlog + keep the subscription live, accept
@@ -900,6 +948,58 @@ mod tests {
             store.count(),
             1,
             "still stored again — publishing is idempotent, only the fan-out is suppressed"
+        );
+    }
+
+    /// An unpaired peer never gets a socket at all.
+    ///
+    /// Refusing per frame would still hand a stranger a WebSocket upgrade and a
+    /// round of frames, which over BLE is real cost for a connection that can
+    /// never do anything. Admission is a membership check before the upgrade, so
+    /// the handshake itself fails (`reference/thinning-custom-relay.md`, D6).
+    #[tokio::test]
+    async fn an_unpaired_peer_is_refused_before_the_upgrade() {
+        struct NoOne;
+        impl PeerGate for NoOne {
+            fn may_connect(&self, _ip: IpAddr) -> bool {
+                false
+            }
+            fn may_read(&self, _ip: IpAddr) -> bool {
+                false
+            }
+            fn may_publish(&self, _ip: IpAddr, _kind: u16) -> bool {
+                false
+            }
+        }
+
+        use tower::ServiceExt;
+
+        let store = Arc::new(RelayStore::in_memory());
+        let hub = RelayHub::with_gate(store, None, Some(Arc::new(NoOne)));
+        let app = Router::new()
+            .route("/", get(root))
+            .layer(axum::middleware::from_fn_with_state(hub.clone(), admit))
+            .with_state(hub);
+
+        // A real socket here could only ever be loopback, which bypasses the gate
+        // by design, so drive the route with a synthetic mesh address instead.
+        let mesh_peer: SocketAddr = "[fd00::1]:9999".parse().unwrap();
+        let mut req = axum::http::Request::builder()
+            .uri("/")
+            .header("connection", "upgrade")
+            .header("upgrade", "websocket")
+            .header("sec-websocket-version", "13")
+            .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(mesh_peer));
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            axum::http::StatusCode::FORBIDDEN,
+            "an unpaired peer must be refused at the door, not upgraded and then \
+             told no per frame"
         );
     }
 

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -391,6 +391,17 @@ async fn admit(
     next.run(req).await
 }
 
+/// Has this connection's peer lost access since it was admitted?
+///
+/// Admission is checked once, at the upgrade, so without re-checking here a
+/// subscription opened while paired would keep streaming after the peer was
+/// removed from the circle. Revocation has to reach connections that already
+/// exist, not just the next one (`reference/thinning-custom-relay.md`, D6).
+/// Loopback is the in-app WebView and is never gated.
+fn revoked(hub: &RelayHub, origin: Origin, peer_ip: IpAddr) -> bool {
+    origin == Origin::Mesh && hub.gate.as_ref().is_some_and(|g| !g.may_connect(peer_ip))
+}
+
 /// One client connection: serve `REQ` backlog + keep the subscription live, accept
 /// `EVENT`s (store → fan to local subs → drive the gossiper), honour `CLOSE`.
 async fn handle_ws(socket: WebSocket, hub: Arc<RelayHub>, peer_ip: IpAddr) {
@@ -437,6 +448,15 @@ async fn handle_ws(socket: WebSocket, hub: Arc<RelayHub>, peer_ip: IpAddr) {
             event = live.recv() => {
                 match event {
                     Ok(ev) => {
+                        // Re-check membership before feeding an open subscription.
+                        // Admission happens once, at the upgrade, so without this a
+                        // subscription opened while paired would keep streaming
+                        // after the peer was removed — revocation has to reach
+                        // connections that already exist, not just the next one.
+                        if revoked(&hub, origin, peer_ip) {
+                            tracing::info!(peer = %peer_ip, "relay: dropping a revoked peer's connection");
+                            break 'conn;
+                        }
                         for (sub_id, filters) in subs.iter() {
                             if filters.iter().any(|f| matches_filter(&ev, f)) {
                                 let frame = serde_json::json!(["EVENT", sub_id, ev]).to_string();
@@ -1001,6 +1021,61 @@ mod tests {
             "an unpaired peer must be refused at the door, not upgraded and then \
              told no per frame"
         );
+    }
+
+    /// Revocation reaches a connection that is already open.
+    ///
+    /// Admission is checked once, at the upgrade, so a peer removed from the
+    /// circle mid-session would otherwise keep receiving events on a `REQ` it
+    /// opened while still paired. `axum`'s `WebSocket` cannot be built from a raw
+    /// socket, and a real socket here could only be loopback (which is exempt by
+    /// design), so this covers the decision the live-event branch makes rather
+    /// than the socket teardown around it
+    /// (`reference/thinning-custom-relay.md`, D6).
+    #[test]
+    fn a_revoked_peer_stops_being_fed() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct Revocable(Arc<AtomicBool>);
+        impl PeerGate for Revocable {
+            fn may_connect(&self, _ip: IpAddr) -> bool {
+                self.0.load(Ordering::Relaxed)
+            }
+            fn may_read(&self, _ip: IpAddr) -> bool {
+                true
+            }
+            fn may_publish(&self, _ip: IpAddr, _kind: u16) -> bool {
+                true
+            }
+        }
+
+        let paired = Arc::new(AtomicBool::new(true));
+        let hub = RelayHub::with_gate(
+            Arc::new(RelayStore::in_memory()),
+            None,
+            Some(Arc::new(Revocable(paired.clone()))),
+        );
+        let mesh_peer: IpAddr = "fd00::1".parse().unwrap();
+        let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+
+        assert!(
+            !revoked(&hub, Origin::Mesh, mesh_peer),
+            "paired peer is fed"
+        );
+
+        paired.store(false, Ordering::Relaxed);
+        assert!(
+            revoked(&hub, Origin::Mesh, mesh_peer),
+            "unpairing must close a connection that is already open"
+        );
+        assert!(
+            !revoked(&hub, Origin::Local, loopback),
+            "the in-app WebView is never gated"
+        );
+
+        // A hub with no gate is open, which is what the tests and local runs use.
+        let open = RelayHub::new(Arc::new(RelayStore::in_memory()), None);
+        assert!(!revoked(&open, Origin::Mesh, mesh_peer));
     }
 
     /// An nsite cannot start a circle-wide pull, and its `EOSE` never waits on a

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -114,11 +114,23 @@ pub trait PeerGate: Send + Sync {
     /// the pairing kinds from anyone (bootstrap) and everything else only when
     /// `ip` is a paired peer.
     fn may_publish(&self, ip: IpAddr, kind: u16) -> bool;
+
+    /// How far a `REQ` from `ip` may be forwarded on. `0` means answer from our
+    /// own store only. Per-peer, so revoking multihop reads is a clamp on the
+    /// budget the pull plane already carries rather than a separate branch
+    /// (`reference/thinning-custom-relay.md`, D10).
+    ///
+    /// The push-side counterpart lives in the gossiper, which holds the same
+    /// permission record and applies it where the hop budget is computed.
+    fn max_req_ttl(&self, _ip: IpAddr) -> u8 {
+        MAX_REQ_TTL
+    }
 }
 
-/// Clamp on the `req-ttl` we'll honour, so a peer can't turn us into an
-/// unbounded query amplifier (mirrors `MAX_EVENT_TTL` on the push plane).
-const MAX_REQ_TTL: u8 = 2;
+/// Default clamp on the `req-ttl` we'll honour, so a peer can't turn us into an
+/// unbounded query amplifier (mirrors `MAX_EVENT_TTL` on the push plane). A gate
+/// may lower it per peer — see [`PeerGate::max_req_ttl`].
+pub(crate) const MAX_REQ_TTL: u8 = 2;
 
 /// How long a non-expiring event's id is remembered as seen. A push wave lives
 /// for seconds, so this only has to outlast retries and a slow multi-hop path.
@@ -473,12 +485,20 @@ async fn handle_client_frame(
             // affects local matching.
             let req_ttl = match origin {
                 Origin::Local => 0,
-                Origin::Mesh => raw_filters
-                    .iter()
-                    .filter_map(|f| f.get("req-ttl").and_then(|v| v.as_u64()))
-                    .max()
-                    .map(|n| n.min(MAX_REQ_TTL as u64) as u8)
-                    .unwrap_or(0),
+                Origin::Mesh => {
+                    // The clamp is this peer's own, so a peer without the
+                    // multihop grant is answered from our store alone.
+                    let cap = hub
+                        .gate
+                        .as_ref()
+                        .map_or(MAX_REQ_TTL, |g| g.max_req_ttl(peer_ip));
+                    raw_filters
+                        .iter()
+                        .filter_map(|f| f.get("req-ttl").and_then(|v| v.as_u64()))
+                        .max()
+                        .map(|n| n.min(cap as u64) as u8)
+                        .unwrap_or(0)
+                }
             };
             let filters: Vec<ManifestFilter> =
                 raw_filters.iter().filter_map(parse_filter).collect();

--- a/myco-core/src/mesh_relay.rs
+++ b/myco-core/src/mesh_relay.rs
@@ -557,9 +557,7 @@ mod tests {
             "REQ", "s1",
             { "kinds": [KIND_ROOT], "authors": [hex::encode(keys.public_key().to_bytes())] }
         ]);
-        ws.send(WsMessage::Text(req.to_string().into()))
-            .await
-            .unwrap();
+        ws.send(WsMessage::Text(req.to_string())).await.unwrap();
 
         let mut got_event = false;
         let mut got_eose = false;
@@ -596,9 +594,7 @@ mod tests {
             .await
             .unwrap();
         ws.send(WsMessage::Text(
-            serde_json::json!(["EVENT", site.manifest])
-                .to_string()
-                .into(),
+            serde_json::json!(["EVENT", site.manifest]).to_string(),
         ))
         .await
         .unwrap();
@@ -625,9 +621,7 @@ mod tests {
             .await
             .unwrap();
         let req = serde_json::json!(["REQ", "s1", { "kinds": [9], "#d": ["mesh"] }]);
-        sub.send(WsMessage::Text(req.to_string().into()))
-            .await
-            .unwrap();
+        sub.send(WsMessage::Text(req.to_string())).await.unwrap();
         // Drain until EOSE so we know the live subscription is registered.
         loop {
             if let Some(Ok(WsMessage::Text(txt))) = sub.next().await {
@@ -644,7 +638,7 @@ mod tests {
             .unwrap();
         let msg = chat_event(&keys, "mesh", "live hello");
         pubr.send(WsMessage::Text(
-            serde_json::json!(["EVENT", msg]).to_string().into(),
+            serde_json::json!(["EVENT", msg]).to_string(),
         ))
         .await
         .unwrap();
@@ -693,7 +687,7 @@ mod tests {
             .await
             .unwrap();
         ws.send(WsMessage::Text(
-            serde_json::json!(["EVENT", msg]).to_string().into(),
+            serde_json::json!(["EVENT", msg]).to_string(),
         ))
         .await
         .unwrap();
@@ -746,7 +740,7 @@ mod tests {
             .unwrap();
         let filter = serde_json::json!({ "kinds": [9], "#d": ["mesh"] });
         ws.send(WsMessage::Text(
-            serde_json::json!(["REQ", "s1", filter]).to_string().into(),
+            serde_json::json!(["REQ", "s1", filter]).to_string(),
         ))
         .await
         .unwrap();
@@ -771,7 +765,7 @@ mod tests {
         );
 
         ws.send(WsMessage::Text(
-            serde_json::json!(["CLOSE", "s1"]).to_string().into(),
+            serde_json::json!(["CLOSE", "s1"]).to_string(),
         ))
         .await
         .unwrap();

--- a/myco-core/src/mesh_wire.rs
+++ b/myco-core/src/mesh_wire.rs
@@ -69,6 +69,16 @@ fn is_zero(n: &u8) -> bool {
     *n == 0
 }
 
+/// How far a pushed event travels: the budget a node stamps on its own events,
+/// and the most it will honour from a peer. One constant, because they are the
+/// same number for the same reason — the reach a wave is allowed — and having
+/// chat, manifests, and the clamp each name it separately let them drift.
+///
+/// The pull plane's counterpart is [`MAX_REQ_TTL`](crate::mesh_relay::MAX_REQ_TTL),
+/// deliberately lower: a flooded read costs more than a flooded write, since
+/// every hop answers as well as forwards.
+pub const EVENT_TTL: u8 = 3;
+
 /// Share of the remaining budget a hop may spend downstream, keeping the rest to
 /// receive and relay. Deadlines are not composed — see [`MeshMeta::budget_ms`].
 const BUDGET_SHARE: f64 = 0.6;

--- a/myco-core/src/mesh_wire.rs
+++ b/myco-core/src/mesh_wire.rs
@@ -27,6 +27,8 @@
 //! behind it. Only proxy-to-proxy traffic over `.fips` is ours to shape. See
 //! `reference/thinning-custom-relay.md` (D1, D8).
 
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 
 /// The verb. Anything that does not know it replies `NOTICE` and ignores the
@@ -111,7 +113,31 @@ impl MeshMeta {
         self.ttl = self.ttl.min(max_ttl);
         self
     }
+
+    /// How long this hop may wait on the peers it forwards to.
+    ///
+    /// This is what stops deadlines nesting. Without it every hop starts a fresh
+    /// full-length timer inside its parent's, so a peer two hops out that
+    /// honestly takes most of its window returns after the hop above has already
+    /// given up — depth 2 then looks implemented while reliably yielding nothing.
+    /// Taking the budget that arrived means the whole wave collapses inside the
+    /// originator's window.
+    ///
+    /// `fallback` is used when no budget rode in — an older peer, or a plain
+    /// pull that never carried one. Both ends are bounded: never longer than the
+    /// budget allows, and never so short that a slow BLE link cannot answer.
+    pub fn hop_timeout(&self, fallback: Duration) -> Duration {
+        match self.budget_ms {
+            Some(ms) => Duration::from_millis(ms as u64).clamp(MIN_HOP_TIMEOUT, fallback),
+            None => fallback,
+        }
+    }
 }
+
+/// Floor on a forwarded hop's timeout. A budget worn down by several hops can get
+/// small; below this there is no point dialling at all over BLE, where a connect
+/// alone can take a second.
+const MIN_HOP_TIMEOUT: Duration = Duration::from_millis(1500);
 
 /// A fresh query id for a pull this node originates.
 ///
@@ -201,6 +227,69 @@ mod tests {
         assert_eq!(hop2.budget_ms, Some(3_600));
 
         assert!(hop2.next_hop().is_none(), "the wave terminates");
+    }
+
+    /// A forwarded hop waits no longer than the budget that arrived.
+    ///
+    /// This is the whole point of carrying one. With a fresh full-length timer
+    /// per hop, each hop's window sits inside its parent's, so a peer two hops
+    /// out that honestly uses most of its time returns after the hop above has
+    /// given up — depth 2 looks implemented and reliably yields nothing.
+    #[test]
+    fn a_hop_waits_within_the_budget_it_was_given() {
+        let fallback = Duration::from_secs(8);
+
+        // A budget shorter than the fallback wins.
+        let tight = MeshMeta::pull(1, "q", 3_000);
+        assert_eq!(tight.hop_timeout(fallback), Duration::from_millis(3_000));
+
+        // A budget longer than the fallback does not extend us: a peer cannot
+        // ask us to hold a connection open for a minute.
+        let greedy = MeshMeta::pull(1, "q", 600_000);
+        assert_eq!(greedy.hop_timeout(fallback), fallback);
+
+        // No budget at all (an older peer) falls back to the fixed timeout.
+        assert_eq!(MeshMeta::push(1).hop_timeout(fallback), fallback);
+
+        // A budget worn down to nearly nothing still leaves time to dial, since
+        // a BLE connect alone can take about a second.
+        let spent = MeshMeta::pull(1, "q", 10);
+        assert_eq!(spent.hop_timeout(fallback), MIN_HOP_TIMEOUT);
+    }
+
+    /// Each hop's window fits strictly inside its parent's.
+    ///
+    /// Hop windows nest rather than add up: hop 2 does its waiting *inside* hop
+    /// 1's window. So the property that makes a wave terminate is that every hop
+    /// allows less time than the hop above it, and the first allows no more than
+    /// the originator's budget. A fixed timeout per hop fails at the first step —
+    /// every hop would allow exactly as long as its parent, so the deepest one is
+    /// still running when the originator has already given up.
+    #[test]
+    fn each_hop_waits_less_than_the_one_above_it() {
+        let fallback = Duration::from_secs(8);
+        let originator_budget = Duration::from_millis(10_000);
+
+        let mut meta = MeshMeta::pull(3, "q", 10_000);
+        let mut windows = Vec::new();
+        while let Some(next) = meta.next_hop() {
+            windows.push(next.hop_timeout(fallback));
+            meta = next;
+        }
+
+        assert_eq!(windows.len(), 3, "three hops of budget");
+        assert!(
+            windows[0] <= originator_budget,
+            "the first hop stays inside the originator's budget"
+        );
+        for pair in windows.windows(2) {
+            assert!(
+                pair[1] < pair[0],
+                "each hop must allow less than its parent, got {:?} then {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
     }
 
     /// A peer cannot set a large hop count and make us amplify for it.

--- a/myco-core/src/mesh_wire.rs
+++ b/myco-core/src/mesh_wire.rs
@@ -1,0 +1,226 @@
+//! The `MESH` envelope: Myco's own framing on the peer-to-peer link.
+//!
+//! Mesh state used to ride *inside* the objects a relay stores and matches on —
+//! an `event-ttl` key added to the event, a `req-ttl` key added to a filter. That
+//! made every relay in the mesh implement Myco's protocol, made correctness
+//! depend on a backend not round-tripping unknown keys, and pushed routing state
+//! through the query language.
+//!
+//! Now it rides beside them instead:
+//!
+//! ```text
+//! ["MESH", {"ttl": 2}, ["EVENT", <event>]]
+//! ["MESH", {"ttl": 1, "qid": "…", "budgetMs": 5000}, ["REQ", <sub_id>, <filter>, …]]
+//! ```
+//!
+//! The inner element is **exactly** what would go on the wire to any relay: the
+//! event object and every filter object are canonical NIP-01, byte for byte. The
+//! proxy reads `meta`, decides, and passes the inner element through unchanged,
+//! so nothing is re-encoded anywhere in the path.
+//!
+//! The wrapper is verb-agnostic on purpose. `["MESH", meta, <anything NIP-01>]`
+//! carries `COUNT`, a future `NEG-OPEN`, or anything else without this module
+//! learning what they are — and it is one grep to find every mesh frame in a log.
+//!
+//! **This framing appears on exactly one link.** The nsite talks plain NIP-01 to
+//! `localhost:4870`, and the proxy talks plain NIP-01 to whatever relay sits
+//! behind it. Only proxy-to-proxy traffic over `.fips` is ours to shape. See
+//! `reference/thinning-custom-relay.md` (D1, D8).
+
+use serde::{Deserialize, Serialize};
+
+/// The verb. Anything that does not know it replies `NOTICE` and ignores the
+/// frame, which is the correct failure: a relay that is not part of this mesh
+/// must not join a flood.
+pub const MESH: &str = "MESH";
+
+/// Mesh state travelling alongside a NIP-01 message.
+///
+/// Future fields (a path vector, an origin hint, a rate class) extend this, never
+/// the inner message.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MeshMeta {
+    /// Remaining forward hops. `0` means store it, do not pass it on.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub ttl: u8,
+
+    /// Query id, stamped by the originating proxy so every node can serve a given
+    /// query once. A circle is a graph rather than a tree, so the same query
+    /// arrives by several paths; without this each arrival re-fans it and the
+    /// cost multiplies. Also the amplification bound — one peer's `REQ` would
+    /// otherwise make us issue one per circle member.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qid: Option<String>,
+
+    /// Remaining time budget in milliseconds, **relative** — never a wall-clock
+    /// deadline, because mesh clocks are not synchronised.
+    ///
+    /// Its only job is bounding how long a node holds query state. Results that
+    /// arrive late are not an error; they stream to whoever is still listening,
+    /// and a node whose budget has run out simply drops them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_ms: Option<u32>,
+}
+
+fn is_zero(n: &u8) -> bool {
+    *n == 0
+}
+
+/// Share of the remaining budget a hop may spend downstream, keeping the rest to
+/// receive and relay. Deadlines are not composed — see [`MeshMeta::budget_ms`].
+const BUDGET_SHARE: f64 = 0.6;
+
+impl MeshMeta {
+    /// Metadata for a push carrying `ttl` more hops.
+    pub fn push(ttl: u8) -> Self {
+        Self {
+            ttl,
+            ..Default::default()
+        }
+    }
+
+    /// Metadata for a pull: `ttl` more hops under query id `qid`, with `budget_ms`
+    /// left to answer in.
+    pub fn pull(ttl: u8, qid: impl Into<String>, budget_ms: u32) -> Self {
+        Self {
+            ttl,
+            qid: Some(qid.into()),
+            budget_ms: Some(budget_ms),
+        }
+    }
+
+    /// What to send to the next hop: one fewer hop, and a share of what is left of
+    /// the budget. Returns `None` once the hop count is spent.
+    pub fn next_hop(&self) -> Option<Self> {
+        if self.ttl == 0 {
+            return None;
+        }
+        Some(Self {
+            ttl: self.ttl - 1,
+            qid: self.qid.clone(),
+            budget_ms: self
+                .budget_ms
+                .map(|ms| (ms as f64 * BUDGET_SHARE).round() as u32),
+        })
+    }
+
+    /// Clamp the hop count to what this node is willing to honour, so a peer
+    /// cannot set a large value and turn us into an amplifier.
+    pub fn clamped(mut self, max_ttl: u8) -> Self {
+        self.ttl = self.ttl.min(max_ttl);
+        self
+    }
+}
+
+/// A fresh query id for a pull this node originates.
+///
+/// Only has to be unique among queries in flight nearby, so 8 random bytes is
+/// ample. A **forwarded** pull must carry the id it arrived with instead — that
+/// is what lets every node downstream serve it once.
+pub fn new_query_id() -> String {
+    hex::encode(crate::ip_source::random_bytes(8))
+}
+
+/// Wrap a NIP-01 message in a `MESH` envelope, ready to write to a peer.
+pub fn wrap(meta: &MeshMeta, inner: serde_json::Value) -> String {
+    serde_json::json!([MESH, meta, inner]).to_string()
+}
+
+/// Split a `MESH` envelope into its metadata and the untouched NIP-01 message
+/// inside. `None` for anything that is not one — including a plain NIP-01 frame,
+/// which stays valid on this link and means "no mesh metadata": store it, do not
+/// forward it.
+pub fn unwrap(frame: &serde_json::Value) -> Option<(MeshMeta, serde_json::Value)> {
+    let array = frame.as_array()?;
+    if array.first()?.as_str()? != MESH {
+        return None;
+    }
+    // A malformed meta is treated as absent rather than fatal: the inner message
+    // is still a valid NIP-01 message and is worth handling, just not forwarding.
+    let meta = array
+        .get(1)
+        .and_then(|m| serde_json::from_value::<MeshMeta>(m.clone()).ok())
+        .unwrap_or_default();
+    let inner = array.get(2)?.clone();
+    // Only an array can be a NIP-01 message; anything else is a malformed frame.
+    inner.as_array()?;
+    Some((meta, inner))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The inner message must survive the round trip untouched — that is the
+    /// whole point of wrapping rather than modifying.
+    #[test]
+    fn the_inner_message_is_carried_verbatim() {
+        let event = serde_json::json!({
+            "id": "abc", "pubkey": "def", "created_at": 1, "kind": 9,
+            "tags": [["d", "mesh"]], "content": "hi", "sig": "beef"
+        });
+        let inner = serde_json::json!(["EVENT", event]);
+
+        let frame = wrap(&MeshMeta::push(2), inner.clone());
+        let parsed: serde_json::Value = serde_json::from_str(&frame).unwrap();
+        let (meta, got) = unwrap(&parsed).expect("a MESH frame");
+
+        assert_eq!(meta.ttl, 2);
+        assert_eq!(got, inner, "the NIP-01 message is byte-for-byte unchanged");
+        assert!(
+            !frame.contains("event-ttl") && !frame.contains("req-ttl"),
+            "no mesh state inside the event or filters"
+        );
+    }
+
+    /// A plain NIP-01 frame stays valid on this link and carries no metadata, so
+    /// it is stored and never forwarded.
+    #[test]
+    fn plain_nip01_is_not_a_mesh_frame() {
+        let plain = serde_json::json!(["EVENT", { "id": "abc" }]);
+        assert!(unwrap(&plain).is_none());
+
+        let req = serde_json::json!(["REQ", "s1", { "kinds": [9] }]);
+        assert!(unwrap(&req).is_none());
+    }
+
+    /// Hops decrement and the budget shrinks with depth, rather than each hop
+    /// nesting a fresh full-length deadline inside its parent's.
+    #[test]
+    fn hops_decrement_and_the_budget_shrinks() {
+        let start = MeshMeta::pull(2, "q1", 10_000);
+
+        let hop1 = start.next_hop().expect("hops left");
+        assert_eq!(hop1.ttl, 1);
+        assert_eq!(hop1.qid.as_deref(), Some("q1"), "the query id is carried");
+        assert_eq!(hop1.budget_ms, Some(6_000));
+
+        let hop2 = hop1.next_hop().expect("one more hop");
+        assert_eq!(hop2.ttl, 0);
+        assert_eq!(hop2.budget_ms, Some(3_600));
+
+        assert!(hop2.next_hop().is_none(), "the wave terminates");
+    }
+
+    /// A peer cannot set a large hop count and make us amplify for it.
+    #[test]
+    fn a_hostile_ttl_is_clamped() {
+        let meta = MeshMeta::push(255).clamped(3);
+        assert_eq!(meta.ttl, 3);
+    }
+
+    /// A malformed envelope must not take the connection down with it.
+    #[test]
+    fn a_malformed_envelope_is_rejected_not_fatal() {
+        // No inner message.
+        assert!(unwrap(&serde_json::json!(["MESH", {"ttl": 1}])).is_none());
+        // Inner is not a NIP-01 message.
+        assert!(unwrap(&serde_json::json!(["MESH", {"ttl": 1}, "nope"])).is_none());
+        // Unreadable meta still yields the inner message, with no hops.
+        let (meta, inner) =
+            unwrap(&serde_json::json!(["MESH", "junk", ["EVENT", {}]])).expect("inner is usable");
+        assert_eq!(meta, MeshMeta::default());
+        assert_eq!(inner, serde_json::json!(["EVENT", {}]));
+    }
+}

--- a/myco-core/src/peer_diagnostics.rs
+++ b/myco-core/src/peer_diagnostics.rs
@@ -446,6 +446,7 @@ mod tests {
 
     fn circle(npub: &str, name: &str) -> CircleContact {
         CircleContact {
+            perms: Default::default(),
             npub: npub.to_string(),
             name: name.to_string(),
             added_at: 0,

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -127,6 +127,9 @@ enum Command {
     /// then reply once with the batch and close the subscription (the pull plane).
     Request {
         filters: Vec<serde_json::Value>,
+        /// Mesh state for this pull, carried in the envelope around the `REQ`.
+        /// `None` sends a plain NIP-01 `REQ`: single hop, no query id.
+        meta: Option<crate::mesh_wire::MeshMeta>,
         reply: oneshot::Sender<Vec<Event>>,
     },
 }
@@ -245,6 +248,20 @@ impl PeerRelayPool {
         filters: Vec<serde_json::Value>,
         timeout: Duration,
     ) -> Vec<Event> {
+        self.request_with(npub, url, filters, None, timeout).await
+    }
+
+    /// As [`request`](Self::request), but carrying mesh state — a hop budget,
+    /// query id, and time budget — in the envelope around the `REQ`. Used by the
+    /// core-driven multi-hop pulls (discovery, update checks).
+    pub async fn request_with(
+        &self,
+        npub: &str,
+        url: &str,
+        filters: Vec<serde_json::Value>,
+        meta: Option<crate::mesh_wire::MeshMeta>,
+        timeout: Duration,
+    ) -> Vec<Event> {
         let (reply_tx, reply_rx) = oneshot::channel();
         {
             let mut peers = self.peers.lock().unwrap();
@@ -255,6 +272,7 @@ impl PeerRelayPool {
             if tx
                 .send(Command::Request {
                     filters,
+                    meta,
                     reply: reply_tx,
                 })
                 .is_err()
@@ -368,14 +386,20 @@ async fn run(
                         break;
                     }
                 }
-                Some(Command::Request { filters, reply }) => {
+                Some(Command::Request { filters, meta, reply }) => {
                     let sub_id = format!("r{next_sub}");
                     next_sub += 1;
                     let mut req: Vec<serde_json::Value> = Vec::with_capacity(filters.len() + 2);
                     req.push(serde_json::Value::from("REQ"));
                     req.push(serde_json::Value::from(sub_id.clone()));
                     req.extend(filters);
-                    let frame = serde_json::Value::Array(req).to_string();
+                    let req = serde_json::Value::Array(req);
+                    // The filters stay canonical NIP-01; anything mesh-specific
+                    // rides the envelope around them.
+                    let frame = match &meta {
+                        Some(meta) => crate::mesh_wire::wrap(meta, req),
+                        None => req.to_string(),
+                    };
                     if sink.send(Message::Text(frame)).await.is_err() {
                         let _ = reply.send(Vec::new());
                         reason = "write failed (request)";

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -474,7 +474,7 @@ mod tests {
         ));
     }
 
-    use myco_relay::server::serve_on;
+    use crate::mesh_relay::serve_on;
     use myco_relay::RelayStore;
     use nostr::{EventBuilder, Keys, Kind, Tag};
     use std::sync::Arc;

--- a/myco-core/src/peer_relay.rs
+++ b/myco-core/src/peer_relay.rs
@@ -42,6 +42,16 @@ use tokio_tungstenite::tungstenite::Message;
 /// over BLE. The runtime's keepwarm loop respawns the dropped task promptly.
 const PING_INTERVAL: Duration = Duration::from_secs(10);
 
+/// Drop any event whose signature does not check out.
+///
+/// One place, at the point remote events enter the process, rather than a check
+/// each call site has to remember — a missed one is a silent forgery hole. A
+/// forged manifest is the sharp case: the gateway would stage and serve it as
+/// the named publisher's site. See `reference/thinning-custom-relay.md` (D7).
+pub(crate) fn verified(events: Vec<Event>) -> Vec<Event> {
+    events.into_iter().filter(|e| e.verify().is_ok()).collect()
+}
+
 /// Cap on the WS connect itself. Without this, a TCP connect into a wedged FSP
 /// session hangs on SYN retransmits for the OS horizon (~2min) — and every
 /// retransmit rides the session, refreshing its activity clock so the node's
@@ -254,7 +264,13 @@ impl PeerRelayPool {
             }
         } // release the lock before awaiting the reply
         match tokio::time::timeout(timeout, reply_rx).await {
-            Ok(Ok(events)) => events,
+            // Signature check at the boundary: this is where a peer's events cross
+            // into the process, so callers downstream can treat what they get as
+            // authentic. Transport authenticity is not authorship — a peer relays
+            // events signed by third parties it has never met, so an honest peer
+            // still cannot vouch for them. See `reference/thinning-custom-relay.md`
+            // (D7).
+            Ok(Ok(events)) => verified(events),
             // Timed out, or the actor died before EOSE (connection dropped).
             _ => Vec::new(),
         }
@@ -450,6 +466,29 @@ fn handle_inbound(txt: &str, pending: &mut HashMap<String, Pending>) -> Option<S
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Ingress verification is the only signature check on the pull path — the
+    /// call sites downstream were removed in favour of this one, so a regression
+    /// here would let a peer hand us a forged event (a forged manifest is served
+    /// by the gateway as the named publisher's site). Pin it.
+    #[test]
+    fn ingress_drops_forged_signatures() {
+        let keys = nostr::Keys::generate();
+        let good = nostr::EventBuilder::new(nostr::Kind::from(9u16), "real")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        // Tamper with the content after signing: id and sig no longer match, but
+        // it still deserializes as an Event, which is exactly what a hostile peer
+        // would send.
+        let mut raw = serde_json::to_value(&good).unwrap();
+        raw["content"] = serde_json::json!("forged");
+        let forged: Event = serde_json::from_value(raw).unwrap();
+
+        let out = verified(vec![good.clone(), forged]);
+        assert_eq!(out.len(), 1, "only the untampered event survives");
+        assert_eq!(out[0].id, good.id);
+    }
 
     /// The classifier reads OS error text, so pin the three cases: mistaking a
     /// startup race for a peer failure holds a good peer off for minutes.

--- a/myco-core/src/remote_backend.rs
+++ b/myco-core/src/remote_backend.rs
@@ -25,7 +25,7 @@
 //! (`reference/thinning-custom-relay.md`, D7).
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -73,6 +73,23 @@ struct Pending {
 pub struct RemoteBackend {
     url: String,
     tx: Mutex<Option<mpsc::UnboundedSender<Command>>>,
+    /// Why the last attempt to reach it failed, or `None` while it is working.
+    /// Shared with the connection actor, which is what actually learns.
+    ///
+    /// Worth surfacing rather than only logging: a relay that has moved, or a
+    /// laptop that went to sleep, otherwise looks like an app with no content —
+    /// every site missing, no explanation. The settings screen warns instead.
+    last_error: Arc<Mutex<Option<String>>>,
+}
+
+/// What the settings screen shows about a configured backend.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackendHealth {
+    /// The configured URL, empty when the built-in store is in use.
+    pub url: String,
+    /// Why it is unreachable, empty when it is fine or not configured.
+    pub error: String,
 }
 
 impl RemoteBackend {
@@ -80,6 +97,15 @@ impl RemoteBackend {
         Self {
             url: url.into(),
             tx: Mutex::new(None),
+            last_error: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// What to tell the user about this backend right now.
+    pub fn health(&self) -> BackendHealth {
+        BackendHealth {
+            url: self.url.clone(),
+            error: self.last_error.lock().unwrap().clone().unwrap_or_default(),
         }
     }
 
@@ -100,7 +126,8 @@ impl RemoteBackend {
         }
         let (tx, rx) = mpsc::unbounded_channel();
         let url = self.url.clone();
-        tokio::spawn(async move { run(url, rx).await });
+        let health = self.last_error.clone();
+        tokio::spawn(async move { run(url, rx, health).await });
         *slot = Some(tx.clone());
         tx
     }
@@ -151,20 +178,28 @@ impl RelayBackend for RemoteBackend {
 /// to start a fresh actor on the next call.
 ///
 /// [`sender`]: RemoteBackend::sender
-async fn run(url: String, mut rx: mpsc::UnboundedReceiver<Command>) {
+async fn run(
+    url: String,
+    mut rx: mpsc::UnboundedReceiver<Command>,
+    health: Arc<Mutex<Option<String>>>,
+) {
     let connect = tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(&url));
     let ws = match connect.await {
         Ok(Ok((ws, _))) => ws,
         Ok(Err(e)) => {
             tracing::warn!(url, error = %e, "relay backend: connect failed");
+            *health.lock().unwrap() = Some(format!("Could not reach {url}: {e}"));
             return;
         }
         Err(_) => {
             tracing::warn!(url, "relay backend: connect timed out");
+            *health.lock().unwrap() = Some(format!("{url} did not respond"));
             return;
         }
     };
     tracing::info!(url, "relay backend: connected");
+    // Reaching it clears whatever the last failure was.
+    *health.lock().unwrap() = None;
 
     let (mut sink, mut stream) = ws.split();
     let mut pending: HashMap<String, Pending> = HashMap::new();
@@ -240,6 +275,10 @@ async fn run(url: String, mut rx: mpsc::UnboundedReceiver<Command>) {
     for (_, reply) in publishes.drain() {
         let _ = reply.send(false);
     }
+    // A closed connection is not itself a fault — the next call reopens it — but
+    // record why, so a relay that keeps dropping us is visible rather than just
+    // slow.
+    *health.lock().unwrap() = Some(format!("Lost the connection to {url}: {reason}"));
     tracing::info!(url, reason, "relay backend: connection closed");
 }
 
@@ -283,7 +322,6 @@ fn handle_inbound(
 mod tests {
     use super::*;
     use nsite_deck::seams::AdminBackend;
-    use std::sync::Arc;
 
     /// Stand up the embedded relay and drive it through `RemoteBackend`, which is
     /// the arrangement P6 is for: Myco talking to a relay it does not own, over

--- a/myco-core/src/remote_backend.rs
+++ b/myco-core/src/remote_backend.rs
@@ -1,0 +1,397 @@
+//! [`RemoteBackend`] — a [`RelayBackend`] backed by **someone else's** NIP-01
+//! relay, reached over a WebSocket.
+//!
+//! This is what makes the seam's promise real: with the store behind an ordinary
+//! NIP-01 surface, the thing answering can be Citrine on the same phone, a strfry
+//! on the LAN, or anything else that speaks the protocol. Myco keeps its mesh
+//! behaviour in the proxy in front and asks the backend only for `EVENT` and
+//! `REQ`.
+//!
+//! **Nothing Myco-specific goes over this link.** No `MESH` envelope, no ttl, no
+//! circle. That is boundary 2 (`reference/thinning-custom-relay.md`), and it is
+//! the reason an unmodified relay can serve here at all.
+//!
+//! One connection, held open and reopened on demand. The gateway hits the backend
+//! on every page load, so a socket per request would be wasteful even against
+//! localhost — and against a relay on the LAN it would be a round trip per blob
+//! lookup. A single actor task owns the socket and multiplexes publishes and
+//! queries over it by subscription id, the same shape
+//! [`crate::peer_relay`] uses for peers.
+//!
+//! Reads are **not** re-verified. NIP-01 makes signature checking mandatory for a
+//! relay accepting an `EVENT`, so a conforming relay has already done it, and
+//! paying Schnorr again per event on a phone buys nothing. Pointing Myco at a
+//! relay is therefore an act of trust, which is why configuring one warns
+//! (`reference/thinning-custom-relay.md`, D7).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use nostr::{Event, Filter};
+use nsite_deck::seams::RelayBackend;
+use tokio::sync::{mpsc, oneshot};
+use tokio_tungstenite::tungstenite::Message;
+
+/// Cap on a single connect. A misconfigured URL must fail fast rather than
+/// hanging the gateway on SYN retransmits.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cap on one query. A relay that accepts the `REQ` and never sends `EOSE` would
+/// otherwise stall a page load indefinitely.
+const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Cap on waiting for an `OK` after publishing. Storing is idempotent and the
+/// seam reports nothing back, so this only bounds how long we hold the caller.
+const PUBLISH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Keepalive, so a silently half-open socket is noticed rather than swallowing
+/// writes. Same hazard the peer pool documents: a write to a dead-but-unreset
+/// socket buffers and looks like success for as long as the OS retransmits.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+enum Command {
+    Publish {
+        event: Box<Event>,
+        reply: oneshot::Sender<bool>,
+    },
+    Query {
+        filters: Vec<Filter>,
+        reply: oneshot::Sender<Vec<Event>>,
+    },
+}
+
+/// An in-flight `REQ`: events so far, and where to deliver them on `EOSE`.
+struct Pending {
+    events: Vec<Event>,
+    reply: oneshot::Sender<Vec<Event>>,
+}
+
+/// A relay we do not own, used as the event store.
+pub struct RemoteBackend {
+    url: String,
+    tx: Mutex<Option<mpsc::UnboundedSender<Command>>>,
+}
+
+impl RemoteBackend {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            tx: Mutex::new(None),
+        }
+    }
+
+    /// The URL this backend talks to, for diagnostics and the settings screen.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// A live command channel, starting the connection actor if the last one
+    /// exited. Lazy on purpose: a backend configured but unreachable should cost
+    /// nothing until something actually reads or writes.
+    fn sender(&self) -> mpsc::UnboundedSender<Command> {
+        let mut slot = self.tx.lock().unwrap();
+        if let Some(tx) = slot.as_ref() {
+            if !tx.is_closed() {
+                return tx.clone();
+            }
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        let url = self.url.clone();
+        tokio::spawn(async move { run(url, rx).await });
+        *slot = Some(tx.clone());
+        tx
+    }
+}
+
+#[async_trait]
+impl RelayBackend for RemoteBackend {
+    async fn publish(&self, event: Event) -> anyhow::Result<()> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let cmd = Command::Publish {
+            event: Box::new(event),
+            reply: reply_tx,
+        };
+        if self.sender().send(cmd).is_err() {
+            anyhow::bail!("relay backend unavailable: {}", self.url);
+        }
+        match tokio::time::timeout(PUBLISH_TIMEOUT, reply_rx).await {
+            Ok(Ok(true)) => Ok(()),
+            // The relay answered `OK false`, or the socket died mid-write. Either
+            // way the event is not stored, and the caller should know: unlike the
+            // embedded store, this can fail for reasons outside our control.
+            Ok(Ok(false)) => anyhow::bail!("relay backend rejected the event"),
+            Ok(Err(_)) | Err(_) => anyhow::bail!("relay backend did not acknowledge in time"),
+        }
+    }
+
+    async fn query(&self, filters: &[Filter]) -> anyhow::Result<Vec<Event>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let cmd = Command::Query {
+            filters: filters.to_vec(),
+            reply: reply_tx,
+        };
+        if self.sender().send(cmd).is_err() {
+            anyhow::bail!("relay backend unavailable: {}", self.url);
+        }
+        match tokio::time::timeout(QUERY_TIMEOUT, reply_rx).await {
+            Ok(Ok(events)) => Ok(events),
+            // A read failure is an error rather than an empty result: an empty
+            // set means "the relay has nothing", and the gateway would render
+            // that as a missing site.
+            Ok(Err(_)) | Err(_) => anyhow::bail!("relay backend did not answer in time"),
+        }
+    }
+}
+
+/// One connection's lifetime: connect, then multiplex commands over it until the
+/// socket dies. Exiting drops the command channel, which is how [`sender`] knows
+/// to start a fresh actor on the next call.
+///
+/// [`sender`]: RemoteBackend::sender
+async fn run(url: String, mut rx: mpsc::UnboundedReceiver<Command>) {
+    let connect = tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(&url));
+    let ws = match connect.await {
+        Ok(Ok((ws, _))) => ws,
+        Ok(Err(e)) => {
+            tracing::warn!(url, error = %e, "relay backend: connect failed");
+            return;
+        }
+        Err(_) => {
+            tracing::warn!(url, "relay backend: connect timed out");
+            return;
+        }
+    };
+    tracing::info!(url, "relay backend: connected");
+
+    let (mut sink, mut stream) = ws.split();
+    let mut pending: HashMap<String, Pending> = HashMap::new();
+    // Publishes awaiting an `OK`, keyed by event id.
+    let mut publishes: HashMap<String, oneshot::Sender<bool>> = HashMap::new();
+    let mut next_sub: u64 = 0;
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    ping.tick().await; // the first tick is immediate
+
+    let reason = loop {
+        tokio::select! {
+            cmd = rx.recv() => match cmd {
+                None => break "pool dropped",
+                Some(Command::Publish { event, reply }) => {
+                    let id = event.id.to_hex();
+                    let frame = serde_json::json!(["EVENT", *event]).to_string();
+                    if sink.send(Message::Text(frame.into())).await.is_err() {
+                        let _ = reply.send(false);
+                        break "write failed (publish)";
+                    }
+                    publishes.insert(id, reply);
+                }
+                Some(Command::Query { filters, reply }) => {
+                    let sub_id = format!("q{next_sub}");
+                    next_sub += 1;
+                    let mut req: Vec<serde_json::Value> =
+                        vec![serde_json::Value::from("REQ"), sub_id.clone().into()];
+                    req.extend(filters.iter().filter_map(|f| serde_json::to_value(f).ok()));
+                    let frame = serde_json::Value::Array(req).to_string();
+                    if sink.send(Message::Text(frame.into())).await.is_err() {
+                        let _ = reply.send(Vec::new());
+                        break "write failed (query)";
+                    }
+                    pending.insert(sub_id, Pending { events: Vec::new(), reply });
+                }
+            },
+            msg = stream.next() => match msg {
+                Some(Ok(Message::Text(txt))) => {
+                    if let Some(done) = handle_inbound(&txt, &mut pending, &mut publishes) {
+                        // Close the satisfied subscription so it does not linger
+                        // on the relay's side.
+                        let close = serde_json::json!(["CLOSE", done]).to_string();
+                        if sink.send(Message::Text(close.into())).await.is_err() {
+                            break "write failed (close)";
+                        }
+                    }
+                }
+                Some(Ok(Message::Ping(p))) => {
+                    if sink.send(Message::Pong(p)).await.is_err() {
+                        break "write failed (pong)";
+                    }
+                }
+                Some(Ok(_)) => {}
+                Some(Err(e)) => {
+                    tracing::debug!(url, error = %e, "relay backend: read error");
+                    break "read error";
+                }
+                None => break "closed by relay",
+            },
+            _ = ping.tick() => {
+                if sink.send(Message::Ping(Vec::new().into())).await.is_err() {
+                    break "write failed (ping)";
+                }
+            }
+        }
+    };
+
+    // Release anything still waiting, so a caller gets its error rather than
+    // sitting until its own timeout.
+    for (_, p) in pending.drain() {
+        let _ = p.reply.send(Vec::new());
+    }
+    for (_, reply) in publishes.drain() {
+        let _ = reply.send(false);
+    }
+    tracing::info!(url, reason, "relay backend: connection closed");
+}
+
+/// Route one inbound frame. Returns a subscription id that has just been
+/// satisfied, so the caller can `CLOSE` it.
+fn handle_inbound(
+    txt: &str,
+    pending: &mut HashMap<String, Pending>,
+    publishes: &mut HashMap<String, oneshot::Sender<bool>>,
+) -> Option<String> {
+    let val: serde_json::Value = serde_json::from_str(txt).ok()?;
+    let arr = val.as_array()?;
+    match arr.first().and_then(|v| v.as_str())? {
+        "EVENT" => {
+            let sub_id = arr.get(1)?.as_str()?;
+            let p = pending.get_mut(sub_id)?;
+            let event = serde_json::from_value::<Event>(arr.get(2)?.clone()).ok()?;
+            p.events.push(event);
+            None
+        }
+        "EOSE" | "CLOSED" => {
+            let sub_id = arr.get(1)?.as_str()?.to_string();
+            let p = pending.remove(&sub_id)?;
+            let _ = p.reply.send(p.events);
+            Some(sub_id)
+        }
+        "OK" => {
+            // ["OK", <event_id>, <accepted>, <message>]
+            let id = arr.get(1)?.as_str()?;
+            let accepted = arr.get(2)?.as_bool().unwrap_or(false);
+            if let Some(reply) = publishes.remove(id) {
+                let _ = reply.send(accepted);
+            }
+            None
+        }
+        _ => None, // NOTICE, AUTH, … — nothing to route
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nsite_deck::seams::AdminBackend;
+    use std::sync::Arc;
+
+    /// Stand up the embedded relay and drive it through `RemoteBackend`, which is
+    /// the arrangement P6 is for: Myco talking to a relay it does not own, over
+    /// nothing but NIP-01.
+    async fn spawn_relay() -> (Arc<myco_relay::RelayStore>, String) {
+        let store = Arc::new(myco_relay::RelayStore::in_memory());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(crate::mesh_relay::serve_on(store.clone(), listener));
+        (store, format!("ws://{addr}"))
+    }
+
+    fn chat(keys: &nostr::Keys, content: &str) -> Event {
+        nostr::EventBuilder::new(nostr::Kind::from(9u16), content)
+            .tags([nostr::Tag::identifier("mesh".to_string())])
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    /// Publish and read back over a socket, with the same connection reused —
+    /// the round trip the gateway depends on.
+    #[tokio::test]
+    async fn publishes_and_queries_over_one_connection() {
+        let (store, url) = spawn_relay().await;
+        let backend = RemoteBackend::new(&url);
+        let keys = nostr::Keys::generate();
+
+        let first = chat(&keys, "one");
+        let second = chat(&keys, "two");
+        backend.publish(first.clone()).await.unwrap();
+        backend.publish(second.clone()).await.unwrap();
+        assert_eq!(store.count(), 2, "both reached the relay");
+
+        let got = backend
+            .query(&[Filter::new().kind(nostr::Kind::from(9u16))])
+            .await
+            .unwrap();
+        assert_eq!(got.len(), 2);
+
+        // Re-publishing is idempotent, exactly as the seam promises.
+        backend.publish(first).await.unwrap();
+        assert_eq!(store.count(), 2);
+    }
+
+    /// The full filter surface has to survive the trip, or the embedded and
+    /// remote backends would disagree about what a query means.
+    #[tokio::test]
+    async fn filters_are_honoured_by_the_remote_relay() {
+        let (_store, url) = spawn_relay().await;
+        let backend = RemoteBackend::new(&url);
+        let keys = nostr::Keys::generate();
+
+        let old = nostr::EventBuilder::new(nostr::Kind::from(9u16), "old")
+            .custom_created_at(nostr::Timestamp::from(1_000))
+            .sign_with_keys(&keys)
+            .unwrap();
+        let recent = nostr::EventBuilder::new(nostr::Kind::from(9u16), "recent")
+            .custom_created_at(nostr::Timestamp::from(9_000))
+            .sign_with_keys(&keys)
+            .unwrap();
+        backend.publish(old.clone()).await.unwrap();
+        backend.publish(recent.clone()).await.unwrap();
+
+        let windowed = backend
+            .query(&[Filter::new().since(nostr::Timestamp::from(5_000))])
+            .await
+            .unwrap();
+        assert_eq!(windowed.len(), 1, "since must reach the relay");
+        assert_eq!(windowed[0].id, recent.id);
+    }
+
+    /// A relay that is not there must fail, not hang and not look empty.
+    ///
+    /// An empty result would read as "the site does not exist" and the gateway
+    /// would render a 404 for content that is merely unreachable.
+    #[tokio::test]
+    async fn an_unreachable_relay_is_an_error_not_an_empty_answer() {
+        // Port 1 is reserved and nothing listens there.
+        let backend = RemoteBackend::new("ws://127.0.0.1:1");
+        let err = backend
+            .query(&[Filter::new().kind(nostr::Kind::from(9u16))])
+            .await;
+        assert!(err.is_err(), "an unreachable relay is an error");
+
+        let keys = nostr::Keys::generate();
+        assert!(backend.publish(chat(&keys, "nobody home")).await.is_err());
+    }
+
+    /// The actor reconnects once its socket dies, rather than the backend going
+    /// permanently cold after the first blip.
+    #[tokio::test]
+    async fn a_dropped_connection_is_reopened_on_the_next_call() {
+        let (store, url) = spawn_relay().await;
+        let backend = RemoteBackend::new(&url);
+        let keys = nostr::Keys::generate();
+
+        backend.publish(chat(&keys, "before")).await.unwrap();
+
+        // Drop the actor the way a dead socket would.
+        {
+            let mut slot = backend.tx.lock().unwrap();
+            *slot = None;
+        }
+
+        backend.publish(chat(&keys, "after")).await.unwrap();
+        assert_eq!(store.count(), 2, "the second publish reconnected");
+
+        // The store is ours in this test, so tidy up through the admin seam.
+        AdminBackend::wipe(store.as_ref()).await.unwrap();
+    }
+}

--- a/myco-core/src/remote_blobs.rs
+++ b/myco-core/src/remote_blobs.rs
@@ -1,0 +1,300 @@
+//! [`RemoteBlobStore`] — a [`BlobStore`] backed by **someone else's** Blossom
+//! server.
+//!
+//! The blob half of the same idea as [`crate::remote_backend`]: keep Myco's
+//! behaviour in front and speak nothing but the standard protocol to whatever is
+//! storing the bytes. Here that protocol is BUD-01 — `GET`/`HEAD /<sha256>` to
+//! read, `PUT /upload` to write — so an unmodified Blossom server can serve.
+//!
+//! **Every read is hash-checked.** The embedded store deliberately skips
+//! re-hashing on read, because the only way bytes get in is a verified write.
+//! That assumption dies the moment the store is shared: another writer, or a
+//! server that simply returns the wrong body, would otherwise hand us bytes we
+//! serve as an app's content. Blobs are content-addressed, so the check is exact
+//! and needs no trust — unlike the signature question on the relay side, this
+//! one is a cost decision, and the cost is worth paying.
+//!
+//! Uploads are signed with the device key as a kind-24242 authorization event
+//! (BUD-01). The embedded server does not ask for one, because the circle gate
+//! covers it; a public server will.
+//!
+//! See `reference/thinning-custom-relay.md` (D9).
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use nostr::base64::prelude::{Engine as _, BASE64_STANDARD};
+use nostr::{EventBuilder, Keys, Kind, Tag};
+use nsite_deck::seams::BlobStore;
+use nsite_deck::sha256_hex;
+
+/// Generous: a blob can be megabytes, and the server may be across a slow link.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How long an upload authorization stays valid. Short, because it authorises
+/// one specific blob and is minted immediately before use.
+const AUTH_TTL_SECS: u64 = 300;
+
+/// BUD-01's authorization event kind.
+const KIND_BLOSSOM_AUTH: u16 = 24242;
+
+/// A Blossom server we do not own, used as the blob store.
+pub struct RemoteBlobStore {
+    base: String,
+    http: reqwest::Client,
+    /// The device key, shared with [`crate::content::Content`] because it is set
+    /// after construction — the store is built before the identity is loaded.
+    keys: Arc<Mutex<Option<Keys>>>,
+    /// Why the last attempt failed, or `None` while it is working.
+    last_error: Arc<Mutex<Option<String>>>,
+}
+
+impl RemoteBlobStore {
+    pub fn new(base: impl Into<String>, keys: Arc<Mutex<Option<Keys>>>) -> Self {
+        Self {
+            base: base.into().trim_end_matches('/').to_string(),
+            http: reqwest::Client::builder()
+                .timeout(HTTP_TIMEOUT)
+                .build()
+                .unwrap_or_default(),
+            keys,
+            last_error: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// The key holder this store signs with, so the owner can share it rather
+    /// than keeping a second copy that could fall out of step.
+    pub fn keys(&self) -> Arc<Mutex<Option<Keys>>> {
+        self.keys.clone()
+    }
+
+    /// What to tell the user about this server right now.
+    pub fn health(&self) -> crate::remote_backend::BackendHealth {
+        crate::remote_backend::BackendHealth {
+            url: self.base.clone(),
+            error: self.last_error.lock().unwrap().clone().unwrap_or_default(),
+        }
+    }
+
+    fn note(&self, err: Option<String>) {
+        *self.last_error.lock().unwrap() = err;
+    }
+
+    fn url_for(&self, hash: &str) -> String {
+        format!("{}/{}", self.base, hash)
+    }
+
+    /// A BUD-01 `Authorization: Nostr <base64>` header authorising one upload.
+    ///
+    /// `None` when the device key is not loaded yet, which is a real state
+    /// during early startup rather than an error — the caller sends the request
+    /// unsigned and lets the server decide, since our own embedded server does
+    /// not ask for one.
+    fn upload_auth(&self, hash: &str) -> Option<String> {
+        let keys = self.keys.lock().unwrap().clone()?;
+        let expiration = crate::content::now_secs() + AUTH_TTL_SECS;
+        let event = EventBuilder::new(Kind::from(KIND_BLOSSOM_AUTH), "Upload blob")
+            .tags([
+                Tag::parse(["t", "upload"]).ok()?,
+                Tag::parse(["x", hash]).ok()?,
+                Tag::parse(["expiration", &expiration.to_string()]).ok()?,
+            ])
+            .sign_with_keys(&keys)
+            .ok()?;
+        let json = serde_json::to_string(&event).ok()?;
+        Some(format!("Nostr {}", BASE64_STANDARD.encode(json)))
+    }
+}
+
+#[async_trait]
+impl BlobStore for RemoteBlobStore {
+    async fn has(&self, want_hex: &str) -> bool {
+        match self.http.head(self.url_for(want_hex)).send().await {
+            Ok(r) => {
+                self.note(None);
+                r.status().is_success()
+            }
+            Err(e) => {
+                self.note(Some(format!("Could not reach {}: {e}", self.base)));
+                false
+            }
+        }
+    }
+
+    async fn get(&self, want_hex: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        let want = want_hex.to_ascii_lowercase();
+        let resp = match self.http.get(self.url_for(&want)).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                self.note(Some(format!("Could not reach {}: {e}", self.base)));
+                anyhow::bail!("blob store unreachable: {e}");
+            }
+        };
+        self.note(None);
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            anyhow::bail!("blob store returned {}", resp.status());
+        }
+        let bytes = resp.bytes().await?.to_vec();
+        // The hash is the identity, so bytes that do not match it are not the
+        // blob — whatever the server meant by sending them. Treated as absent
+        // rather than an error, so the sync path falls through to another source
+        // exactly as it would for a missing blob.
+        if sha256_hex(&bytes) != want {
+            tracing::warn!(
+                server = %self.base,
+                want = %want,
+                "blob store returned bytes that do not match the requested hash"
+            );
+            return Ok(None);
+        }
+        Ok(Some(bytes))
+    }
+
+    async fn put(&self, bytes: &[u8]) -> anyhow::Result<String> {
+        let hash = sha256_hex(bytes);
+        let mut req = self
+            .http
+            .put(format!("{}/upload", self.base))
+            .body(bytes.to_vec());
+        if let Some(auth) = self.upload_auth(&hash) {
+            req = req.header("Authorization", auth);
+        }
+        let resp = match req.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                self.note(Some(format!("Could not reach {}: {e}", self.base)));
+                anyhow::bail!("blob store unreachable: {e}");
+            }
+        };
+        self.note(None);
+        if resp.status() == reqwest::StatusCode::UNAUTHORIZED
+            || resp.status() == reqwest::StatusCode::FORBIDDEN
+        {
+            anyhow::bail!(
+                "{} refused the upload — it may not accept this device's key",
+                self.base
+            );
+        }
+        if !resp.status().is_success() {
+            anyhow::bail!("blob store returned {} on upload", resp.status());
+        }
+        Ok(hash)
+    }
+
+    async fn wipe(&self) -> anyhow::Result<()> {
+        // Not ours to clear. BUD-02 can delete blobs we uploaded, one call each,
+        // but a server we do not run holds other people's data too and its
+        // contents are the operator's business — the same call made for a custom
+        // relay (`reference/thinning-custom-relay.md`, D4).
+        tracing::info!(
+            server = %self.base,
+            "blob store: skipping wipe, a custom Blossom's contents are not ours to clear"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stand up the embedded Blossom and drive it through `RemoteBlobStore`:
+    /// Myco talking to a blob server over nothing but BUD-01.
+    async fn spawn_blossom() -> (Arc<myco_blossom::FsBlobStore>, String, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "myco-remote-blobs-{}-{}",
+            std::process::id(),
+            nostr::Keys::generate().public_key().to_hex()
+        ));
+        let store = Arc::new(myco_blossom::FsBlobStore::open(&dir).unwrap());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(myco_blossom::server::serve_on(store.clone(), listener));
+        (store, format!("http://{addr}"), dir)
+    }
+
+    fn keys() -> Arc<Mutex<Option<Keys>>> {
+        Arc::new(Mutex::new(Some(Keys::generate())))
+    }
+
+    #[tokio::test]
+    async fn round_trips_a_blob_over_bud01() {
+        let (local, base, dir) = spawn_blossom().await;
+        let store = RemoteBlobStore::new(&base, keys());
+
+        let hash = store.put(b"hello blossom").await.unwrap();
+        assert_eq!(hash, sha256_hex(b"hello blossom"));
+        assert_eq!(local.count(), 1, "the bytes landed on the server");
+
+        assert!(store.has(&hash).await);
+        assert_eq!(
+            store.get(&hash).await.unwrap().as_deref(),
+            Some(&b"hello blossom"[..]),
+        );
+
+        // A blob nobody stored is absent, not an error.
+        let missing = sha256_hex(b"never uploaded");
+        assert!(!store.has(&missing).await);
+        assert!(store.get(&missing).await.unwrap().is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Bytes that do not hash to the name we asked for are not that blob, so
+    /// they are treated as absent.
+    ///
+    /// The embedded store can skip this check because the only way bytes get in
+    /// is a verified write. A shared server has other writers, so serving what
+    /// it hands back unchecked would mean serving whatever it happened to store
+    /// under that name as an app's content.
+    #[tokio::test]
+    async fn bytes_that_do_not_match_the_hash_are_rejected() {
+        // A server that answers every GET with the same wrong body.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let app = axum::Router::new().route(
+                "/{hash}",
+                axum::routing::get(|| async { "not what you asked for" }),
+            );
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let store = RemoteBlobStore::new(format!("http://{addr}"), keys());
+        let want = sha256_hex(b"the real blob");
+        assert!(
+            store.get(&want).await.unwrap().is_none(),
+            "mismatched bytes must not be served as the blob"
+        );
+    }
+
+    /// An unreachable server is an error on read, not an empty answer — the same
+    /// distinction the relay backend makes, for the same reason.
+    #[tokio::test]
+    async fn an_unreachable_server_is_an_error() {
+        let store = RemoteBlobStore::new("http://127.0.0.1:1", keys());
+        assert!(store.get(&sha256_hex(b"x")).await.is_err());
+        assert!(store.put(b"x").await.is_err());
+        assert!(
+            !store.health().error.is_empty(),
+            "the failure is recorded for the settings screen"
+        );
+    }
+
+    /// Wiping a server we do not run is a no-op, not a mass delete.
+    #[tokio::test]
+    async fn wiping_a_custom_server_leaves_it_alone() {
+        let (local, base, dir) = spawn_blossom().await;
+        let store = RemoteBlobStore::new(&base, keys());
+        store.put(b"keep me").await.unwrap();
+
+        store.wipe().await.unwrap();
+        assert_eq!(local.count(), 1, "a custom server's blobs are not ours");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/myco-core/src/remote_blobs.rs
+++ b/myco-core/src/remote_blobs.rs
@@ -116,6 +116,11 @@ impl BlobStore for RemoteBlobStore {
                 r.status().is_success()
             }
             Err(e) => {
+                // The seam has no way to say "I could not tell" here, so an
+                // unreachable server and a missing blob both read as `false`.
+                // Recording the failure is what keeps them distinguishable: the
+                // settings screen shows the reason, rather than the user seeing
+                // a site stuck at "incomplete" with nothing to explain it.
                 self.note(Some(format!("Could not reach {}: {e}", self.base)));
                 false
             }
@@ -274,6 +279,11 @@ mod tests {
 
     /// An unreachable server is an error on read, not an empty answer — the same
     /// distinction the relay backend makes, for the same reason.
+    ///
+    /// `has` is the exception, because the seam returns a bare `bool` with no
+    /// way to say "could not tell". It records the failure instead, so the
+    /// reason is on the settings screen rather than a site sitting at
+    /// "incomplete" with nothing to explain it.
     #[tokio::test]
     async fn an_unreachable_server_is_an_error() {
         let store = RemoteBlobStore::new("http://127.0.0.1:1", keys());
@@ -282,6 +292,14 @@ mod tests {
         assert!(
             !store.health().error.is_empty(),
             "the failure is recorded for the settings screen"
+        );
+
+        let unreachable = RemoteBlobStore::new("http://127.0.0.1:1", keys());
+        assert!(!unreachable.has(&sha256_hex(b"x")).await);
+        assert!(
+            !unreachable.health().error.is_empty(),
+            "has() cannot report the failure in its return value, so it must \
+             leave it where the user will see it"
         );
     }
 

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -250,14 +250,14 @@ impl AppRuntime {
             // live subscription on localhost (shared store + live bus + gossiper).
             // The gossiper fans this device's own nsite events out to Circle peers
             // (docs/design/event-gossip.md).
-            let gossiper: Arc<dyn myco_relay::server::Gossiper> =
+            let gossiper: Arc<dyn crate::mesh_relay::Gossiper> =
                 Arc::new(crate::gossip::MeshGossiper::new(content.clone()));
             // Restrict mesh access to paired (Circle) peers — only the pairing
             // handshake is open, so strangers can request to pair but can't read or
             // push content. Loopback (the in-app WebView) always bypasses the gate.
-            let gate: Arc<dyn myco_relay::server::PeerGate> =
+            let gate: Arc<dyn crate::mesh_relay::PeerGate> =
                 Arc::new(crate::content::CircleGate::new(content.clone()));
-            let hub = myco_relay::server::RelayHub::with_gate(
+            let hub = crate::mesh_relay::RelayHub::with_gate(
                 content.relay(),
                 Some(gossiper),
                 Some(gate),
@@ -265,11 +265,11 @@ impl AppRuntime {
 
             // Mesh socket: IPV6_V6ONLY `[::]:4870` so it doesn't collide with the
             // loopback bind and is reachable by peers at `ws://<npub>.fips:4870`.
-            match myco_relay::server::bind("[::]:4870".parse::<SocketAddr>().unwrap()) {
+            match crate::mesh_relay::bind("[::]:4870".parse::<SocketAddr>().unwrap()) {
                 Ok(listener) => {
                     let hub = hub.clone();
                     rt.spawn(async move {
-                        if let Err(e) = myco_relay::server::serve_on_hub(hub, listener).await {
+                        if let Err(e) = crate::mesh_relay::serve_on_hub(hub, listener).await {
                             tracing::error!(error = %e, "mesh relay server exited");
                         }
                     });
@@ -282,11 +282,11 @@ impl AppRuntime {
             // Loopback socket: the in-app nsite WebView talks to `ws://localhost:4870`
             // / `ws://127.0.0.1:4870`; the mesh socket is v6only, so serve loopback
             // explicitly. Connections here are classified as `Origin::Local`.
-            match myco_relay::server::bind("127.0.0.1:4870".parse::<SocketAddr>().unwrap()) {
+            match crate::mesh_relay::bind("127.0.0.1:4870".parse::<SocketAddr>().unwrap()) {
                 Ok(listener) => {
                     let hub = hub.clone();
                     rt.spawn(async move {
-                        if let Err(e) = myco_relay::server::serve_on_hub(hub, listener).await {
+                        if let Err(e) = crate::mesh_relay::serve_on_hub(hub, listener).await {
                             tracing::error!(error = %e, "loopback relay server exited");
                         }
                     });

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -119,6 +119,10 @@ pub struct AppRuntime {
     data_dir: String,
     rev: u64,
     error: String,
+    /// The custom relay URL as last saved — which is what the settings screen
+    /// should show, even though the running store is still the previous one
+    /// until the app is restarted.
+    pending_relay_url: String,
     identity: IdentityView,
     ble_enabled: bool,
     wifi_aware_enabled: bool,
@@ -200,7 +204,15 @@ impl AppRuntime {
 
         // The content layer (relay + Blossom + gateway + Library) lives for the
         // whole process; it is independent of the node's start/stop lifecycle.
-        let content = Arc::new(Content::open(Path::new(data_dir))?);
+        // The backend is chosen before anything else opens, so the setting has to
+        // come off disk first. A custom relay means the embedded store stays on
+        // disk but stops serving (`reference/thinning-custom-relay.md`, D3).
+        let settings = crate::settings_store::load(Path::new(data_dir));
+        let custom_relay = settings.relay_url().map(|url| {
+            tracing::info!(url, "content: using a custom relay");
+            Arc::new(crate::remote_backend::RemoteBackend::new(url))
+        });
+        let content = Arc::new(Content::open_with_relay(Path::new(data_dir), custom_relay)?);
 
         // The device keypair (same nsec the node uses) is the pairing identity —
         // pair request/accept events are signed with it.
@@ -452,6 +464,7 @@ impl AppRuntime {
         Ok(Self {
             app_version: app_version.to_string(),
             data_dir: data_dir.to_string(),
+            pending_relay_url: settings.relay_url().unwrap_or_default(),
             rev: 0,
             error: mesh_warning,
             identity,
@@ -600,6 +613,7 @@ impl AppRuntime {
             data_dir: String::new(),
             rev: 0,
             error: msg.to_string(),
+            pending_relay_url: String::new(),
             identity: IdentityView::default(),
             ble_enabled: false,
             wifi_aware_enabled: false,
@@ -752,6 +766,24 @@ impl AppRuntime {
             NativeAppAction::SetOfflineOnly { enabled } => {
                 if let Some(content) = &self.content {
                     content.set_offline_only(enabled);
+                }
+                self.rev += 1;
+            }
+            NativeAppAction::SetCustomRelay { url } => {
+                let settings = crate::settings_store::Settings {
+                    custom_relay_url: Some(url.clone()),
+                };
+                match crate::settings_store::save(Path::new(&self.data_dir), &settings) {
+                    // Takes effect at the next launch; the store in use right now
+                    // does not change under the running content layer.
+                    Ok(()) => {
+                        self.pending_relay_url = settings.relay_url().unwrap_or_default();
+                        tracing::info!(url, "settings: custom relay saved");
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "settings: could not save the custom relay");
+                        self.error = format!("Could not save the relay setting: {e}");
+                    }
                 }
                 self.rev += 1;
             }
@@ -1345,6 +1377,12 @@ impl AppRuntime {
                 .as_ref()
                 .map(|c| c.is_offline_only())
                 .unwrap_or(false),
+            relay_backend: self
+                .content
+                .as_ref()
+                .map(|c| c.relay_health())
+                .unwrap_or_default(),
+            pending_relay_url: self.pending_relay_url.clone(),
             update_check: self
                 .content
                 .as_ref()

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -257,11 +257,8 @@ impl AppRuntime {
             // push content. Loopback (the in-app WebView) always bypasses the gate.
             let gate: Arc<dyn crate::mesh_relay::PeerGate> =
                 Arc::new(crate::content::CircleGate::new(content.clone()));
-            let hub = crate::mesh_relay::RelayHub::with_gate(
-                content.relay(),
-                Some(gossiper),
-                Some(gate),
-            );
+            let hub =
+                crate::mesh_relay::RelayHub::with_gate(content.relay(), Some(gossiper), Some(gate));
 
             // Mesh socket: IPV6_V6ONLY `[::]:4870` so it doesn't collide with the
             // loopback bind and is reachable by peers at `ws://<npub>.fips:4870`.

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -123,6 +123,8 @@ pub struct AppRuntime {
     /// should show, even though the running store is still the previous one
     /// until the app is restarted.
     pending_relay_url: String,
+    /// The custom Blossom URL as last saved, for the same reason.
+    pending_blossom_url: String,
     identity: IdentityView,
     ble_enabled: bool,
     wifi_aware_enabled: bool,
@@ -212,7 +214,18 @@ impl AppRuntime {
             tracing::info!(url, "content: using a custom relay");
             Arc::new(crate::remote_backend::RemoteBackend::new(url))
         });
-        let content = Arc::new(Content::open_with_relay(Path::new(data_dir), custom_relay)?);
+        let custom_blobs = settings.blossom_url().map(|url| {
+            tracing::info!(url, "content: using a custom blob store");
+            Arc::new(crate::remote_blobs::RemoteBlobStore::new(
+                url,
+                Arc::new(std::sync::Mutex::new(None)),
+            ))
+        });
+        let content = Arc::new(Content::open_with_backends(
+            Path::new(data_dir),
+            custom_relay,
+            custom_blobs,
+        )?);
 
         // The device keypair (same nsec the node uses) is the pairing identity —
         // pair request/accept events are signed with it.
@@ -255,7 +268,11 @@ impl AppRuntime {
         {
             use std::net::SocketAddr;
             let _guard = rt.enter(); // runtime context for TcpListener::from_std
-            let blobs = content.blobs();
+                                     // The mesh Blossom serves *our own* blobs to peers, so it needs the
+                                     // embedded store. With a custom server configured there is nothing
+                                     // local to serve — peers reach that server by its own URL, not
+                                     // through us — so the listener is simply not bound.
+            let blobs = content.blobs_local();
 
             // One shared relay hub backs both the mesh socket and a loopback socket,
             // so a chat event a peer pushes over `.fips` reaches the in-app nsite's
@@ -347,8 +364,14 @@ impl AppRuntime {
                     ));
                 }
             }
-            match myco_blossom::server::bind("[::]:24243".parse::<SocketAddr>().unwrap()) {
-                Ok(listener) => {
+            match (
+                blobs.clone(),
+                myco_blossom::server::bind("[::]:24243".parse::<SocketAddr>().unwrap()),
+            ) {
+                (None, _) => {
+                    tracing::info!("blossom: not serving, a custom blob store is configured");
+                }
+                (Some(blobs), Ok(listener)) => {
                     // Same paired-only gate for blobs: a mesh source must be a
                     // current Circle member (loopback bypasses). Pairing never
                     // touches Blossom, so there's no handshake exception here.
@@ -370,7 +393,7 @@ impl AppRuntime {
                         }
                     });
                 }
-                Err(e) => {
+                (Some(_), Err(e)) => {
                     if !mesh_warning.is_empty() {
                         mesh_warning.push_str("; ");
                     }
@@ -465,6 +488,7 @@ impl AppRuntime {
             app_version: app_version.to_string(),
             data_dir: data_dir.to_string(),
             pending_relay_url: settings.relay_url().unwrap_or_default(),
+            pending_blossom_url: settings.blossom_url().unwrap_or_default(),
             rev: 0,
             error: mesh_warning,
             identity,
@@ -614,6 +638,7 @@ impl AppRuntime {
             rev: 0,
             error: msg.to_string(),
             pending_relay_url: String::new(),
+            pending_blossom_url: String::new(),
             identity: IdentityView::default(),
             ble_enabled: false,
             wifi_aware_enabled: false,
@@ -770,9 +795,8 @@ impl AppRuntime {
                 self.rev += 1;
             }
             NativeAppAction::SetCustomRelay { url } => {
-                let settings = crate::settings_store::Settings {
-                    custom_relay_url: Some(url.clone()),
-                };
+                let mut settings = crate::settings_store::load(Path::new(&self.data_dir));
+                settings.custom_relay_url = Some(url.clone());
                 match crate::settings_store::save(Path::new(&self.data_dir), &settings) {
                     // Takes effect at the next launch; the store in use right now
                     // does not change under the running content layer.
@@ -783,6 +807,23 @@ impl AppRuntime {
                     Err(e) => {
                         tracing::warn!(error = %e, "settings: could not save the custom relay");
                         self.error = format!("Could not save the relay setting: {e}");
+                    }
+                }
+                self.rev += 1;
+            }
+            NativeAppAction::SetCustomBlossom { url } => {
+                // Read-modify-write: the two settings share a file, so writing
+                // one from a stale struct would silently clear the other.
+                let mut settings = crate::settings_store::load(Path::new(&self.data_dir));
+                settings.custom_blossom_url = Some(url.clone());
+                match crate::settings_store::save(Path::new(&self.data_dir), &settings) {
+                    Ok(()) => {
+                        self.pending_blossom_url = settings.blossom_url().unwrap_or_default();
+                        tracing::info!(url, "settings: custom blossom saved");
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "settings: could not save the custom blossom");
+                        self.error = format!("Could not save the blob store setting: {e}");
                     }
                 }
                 self.rev += 1;
@@ -1383,6 +1424,12 @@ impl AppRuntime {
                 .map(|c| c.relay_health())
                 .unwrap_or_default(),
             pending_relay_url: self.pending_relay_url.clone(),
+            blob_backend: self
+                .content
+                .as_ref()
+                .map(|c| c.blobs_health())
+                .unwrap_or_default(),
+            pending_blossom_url: self.pending_blossom_url.clone(),
             update_check: self
                 .content
                 .as_ref()
@@ -1562,6 +1609,52 @@ mod tests {
 
     fn temp_dir(tag: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!("myco-test-{}-{}", std::process::id(), tag))
+    }
+
+    /// The action tag the app sends has to be the one the reducer accepts.
+    ///
+    /// It was not: the helper sent `"SetCustomRelay"` while the enum is tagged
+    /// snake_case, so every save was rejected as an unparseable action and the
+    /// setting silently never persisted. Nothing in Rust or Kotlin catches that
+    /// on its own — the two halves only meet at this string.
+    #[test]
+    fn saving_a_custom_relay_persists_it() {
+        let dir = temp_dir("set-custom-relay");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut rt = AppRuntime::new(dir.to_str().unwrap(), "test");
+
+        // Exactly the JSON `NativeActions.setCustomRelay` builds.
+        let state = rt.dispatch_json(r#"{"type":"set_custom_relay","url":"ws://10.0.0.5:4869"}"#);
+        assert!(
+            !state.contains("invalid action JSON"),
+            "the app's tag must deserialize: {state}"
+        );
+        assert_eq!(
+            crate::settings_store::load(&dir).relay_url().as_deref(),
+            Some("ws://10.0.0.5:4869"),
+            "the URL must reach settings.json"
+        );
+
+        // And an empty URL clears it, which is how the dialog goes back to the
+        // built-in store.
+        // The Blossom setting shares the file, so saving one must not clear the
+        // other — a read-modify-write, not a fresh struct.
+        rt.dispatch_json(r#"{"type":"set_custom_blossom","url":"http://10.0.0.5:24242"}"#);
+        let both = crate::settings_store::load(&dir);
+        assert_eq!(both.relay_url().as_deref(), Some("ws://10.0.0.5:4869"));
+        assert_eq!(both.blossom_url().as_deref(), Some("http://10.0.0.5:24242"));
+
+        rt.dispatch_json(r#"{"type":"set_custom_relay","url":""}"#);
+        let after = crate::settings_store::load(&dir);
+        assert!(after.relay_url().is_none());
+        assert_eq!(
+            after.blossom_url().as_deref(),
+            Some("http://10.0.0.5:24242"),
+            "clearing the relay must leave the blob store alone"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -303,6 +303,38 @@ impl AppRuntime {
                     ));
                 }
             }
+            // The auth plane: the one port open to peers we have never met, and
+            // the only way into the Circle. It has to bind before the content
+            // servers matter — without it a stranger cannot pair at all, and the
+            // relay and Blossom gates below have no exceptions to let them in.
+            // See `reference/thinning-custom-relay.md` (D6).
+            match crate::auth_service::bind(
+                format!("[::]:{}", crate::auth_service::AUTH_PORT)
+                    .parse::<SocketAddr>()
+                    .unwrap(),
+            ) {
+                Ok(listener) => {
+                    let content_for_auth = content.clone();
+                    rt.spawn(async move {
+                        if let Err(e) =
+                            crate::auth_service::serve_on(content_for_auth, listener).await
+                        {
+                            tracing::error!(error = %e, "auth service exited");
+                        }
+                    });
+                }
+                Err(e) => {
+                    if !mesh_warning.is_empty() {
+                        mesh_warning.push_str("; ");
+                    }
+                    mesh_warning.push_str(&format!(
+                        "Another app is using port {} — Myco can't accept pairing \
+                         requests, so new peers won't be able to pair with this \
+                         device. ({e})",
+                        crate::auth_service::AUTH_PORT
+                    ));
+                }
+            }
             match myco_blossom::server::bind("[::]:24243".parse::<SocketAddr>().unwrap()) {
                 Ok(listener) => {
                     // Same paired-only gate for blobs: a mesh source must be a

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -668,7 +668,7 @@ impl AppRuntime {
             NativeAppAction::AddToLibrary { link } => {
                 if let (Some(content), Some(addr)) = (&self.content, nsite_deck::parse_link(&link))
                 {
-                    content.add_to_library(&addr, None, now_secs());
+                    content.add_to_library(&addr, None, crate::content::now_secs());
                 }
                 self.rev += 1;
             }
@@ -1493,20 +1493,12 @@ fn seed_default_sites(content: &Arc<Content>, rt: &Runtime, data_dir: &Path) {
             tracing::warn!(link, "default site link did not parse; skipping seed");
             continue;
         };
-        content.add_to_library(&addr, None, now_secs());
+        content.add_to_library(&addr, None, crate::content::now_secs());
         rt.spawn(content.clone().open_site(addr, None));
     }
     if let Err(e) = std::fs::write(&marker, b"1\n") {
         tracing::warn!(error = %e, "could not write default-seed marker");
     }
-}
-
-/// Seconds since the Unix epoch (Library `added_at` timestamps).
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
 }
 
 /// Milliseconds since the Unix epoch, passed to `merge_peers` (reserved for

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -309,8 +309,15 @@ impl AppRuntime {
                     // current Circle member (loopback bypasses). Pairing never
                     // touches Blossom, so there's no handshake exception here.
                     let content_for_blob = content.clone();
-                    let access: myco_blossom::server::AccessFn =
-                        Arc::new(move |ip| content_for_blob.is_paired_ip(ip));
+                    // Reads are granted to every paired peer; uploads are not, so
+                    // the two are answered from different flags on the peer's own
+                    // permission record (D10).
+                    let access: myco_blossom::server::AccessFn = Arc::new(move |ip, op| match op {
+                        myco_blossom::server::BlobOp::Read => content_for_blob.may_read_blobs(ip),
+                        myco_blossom::server::BlobOp::Write => {
+                            content_for_blob.may_upload_blobs(ip)
+                        }
+                    });
                     rt.spawn(async move {
                         if let Err(e) =
                             myco_blossom::server::serve_on_guarded(blobs, listener, access).await

--- a/myco-core/src/settings_store.rs
+++ b/myco-core/src/settings_store.rs
@@ -1,14 +1,13 @@
 //! Settings that have to survive a restart, in `settings.json`.
 //!
-//! Only one lives here so far: the custom relay URL. It has to be persisted
-//! rather than held in memory like `offline_only`, because it decides how the
-//! content layer is *constructed* — the backend is chosen before anything else
-//! opens, so the answer must already be on disk at startup.
+//! Both values here — the custom relay and the custom Blossom — have to be
+//! persisted rather than held in memory like `offline_only`, because they decide
+//! how the content layer is *constructed*. The backends are chosen before
+//! anything else opens, so the answers must already be on disk at startup.
 //!
-//! Deliberately a plain file rather than a settings framework. There is one
-//! value, it is read once per launch, and a missing or corrupt file means "use
-//! the defaults" — which is the behaviour we want anyway, since a broken
-//! settings file must never stop the app opening its own store.
+//! Deliberately a plain file rather than a settings framework. A missing or
+//! corrupt file means "use the defaults", which is the behaviour we want anyway:
+//! a broken settings file must never stop the app opening its own store.
 
 use std::path::{Path, PathBuf};
 
@@ -25,18 +24,32 @@ pub struct Settings {
     /// because NIP-01 makes signature checking the relay's job
     /// (`reference/thinning-custom-relay.md`, D7).
     pub custom_relay_url: Option<String>,
+
+    /// A Blossom server to store blobs on instead of the embedded one.
+    ///
+    /// Sharper trade-off than the relay: blobs are the bulk of an nsite, so
+    /// pointing this at an internet server means a peer pulling an app from us
+    /// needs *our* connection (`reference/thinning-custom-relay.md`, D9).
+    pub custom_blossom_url: Option<String>,
 }
 
 impl Settings {
     /// The configured relay, ignoring an empty value. Trimmed, because a URL
     /// pasted on a phone routinely arrives with whitespace attached.
     pub fn relay_url(&self) -> Option<String> {
-        self.custom_relay_url
-            .as_deref()
-            .map(str::trim)
-            .filter(|u| !u.is_empty())
-            .map(str::to_string)
+        trimmed(self.custom_relay_url.as_deref())
     }
+
+    /// The configured Blossom, ignoring an empty value.
+    pub fn blossom_url(&self) -> Option<String> {
+        trimmed(self.custom_blossom_url.as_deref())
+    }
+}
+
+fn trimmed(v: Option<&str>) -> Option<String> {
+    v.map(str::trim)
+        .filter(|u| !u.is_empty())
+        .map(str::to_string)
 }
 
 fn path_in(data_dir: &Path) -> PathBuf {
@@ -111,6 +124,7 @@ mod tests {
             &dir,
             &Settings {
                 custom_relay_url: Some("  ws://10.0.0.5:4869  ".to_string()),
+                ..Default::default()
             },
         )
         .unwrap();
@@ -125,6 +139,7 @@ mod tests {
             &dir,
             &Settings {
                 custom_relay_url: Some(String::new()),
+                ..Default::default()
             },
         )
         .unwrap();

--- a/myco-core/src/settings_store.rs
+++ b/myco-core/src/settings_store.rs
@@ -1,0 +1,135 @@
+//! Settings that have to survive a restart, in `settings.json`.
+//!
+//! Only one lives here so far: the custom relay URL. It has to be persisted
+//! rather than held in memory like `offline_only`, because it decides how the
+//! content layer is *constructed* — the backend is chosen before anything else
+//! opens, so the answer must already be on disk at startup.
+//!
+//! Deliberately a plain file rather than a settings framework. There is one
+//! value, it is read once per launch, and a missing or corrupt file means "use
+//! the defaults" — which is the behaviour we want anyway, since a broken
+//! settings file must never stop the app opening its own store.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// The persisted settings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Settings {
+    /// A relay to store events on instead of the embedded one. `None` (or an
+    /// empty string, which is how the UI clears it) means the built-in store.
+    ///
+    /// Pointing this somewhere is an act of trust: reads are not re-verified,
+    /// because NIP-01 makes signature checking the relay's job
+    /// (`reference/thinning-custom-relay.md`, D7).
+    pub custom_relay_url: Option<String>,
+}
+
+impl Settings {
+    /// The configured relay, ignoring an empty value. Trimmed, because a URL
+    /// pasted on a phone routinely arrives with whitespace attached.
+    pub fn relay_url(&self) -> Option<String> {
+        self.custom_relay_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .map(str::to_string)
+    }
+}
+
+fn path_in(data_dir: &Path) -> PathBuf {
+    data_dir.join("settings.json")
+}
+
+/// Read the settings, falling back to defaults on anything unreadable.
+///
+/// A corrupt file is logged and ignored rather than propagated: the alternative
+/// is refusing to start because a preference could not be parsed.
+pub fn load(data_dir: &Path) -> Settings {
+    let path = path_in(data_dir);
+    match std::fs::read(&path) {
+        Ok(raw) => match serde_json::from_slice(&raw) {
+            Ok(settings) => settings,
+            Err(e) => {
+                tracing::warn!(error = %e, "settings: ignoring corrupt settings.json");
+                Settings::default()
+            }
+        },
+        // Absent on first run, which is not a problem.
+        Err(_) => Settings::default(),
+    }
+}
+
+/// Write the settings, atomically (temp + rename) so a crash mid-write cannot
+/// leave a half-file that the next launch would discard.
+pub fn save(data_dir: &Path, settings: &Settings) -> anyhow::Result<()> {
+    let path = path_in(data_dir);
+    let json = serde_json::to_vec_pretty(settings)?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &json)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_dir(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("myco-settings-{}-{}", std::process::id(), tag))
+    }
+
+    #[test]
+    fn a_missing_file_is_defaults_not_an_error() {
+        let dir = tmp_dir("missing");
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(load(&dir).relay_url().is_none());
+    }
+
+    /// A settings file we cannot parse must not stop the app from starting. The
+    /// built-in store is a safe fallback; refusing to launch is not.
+    #[test]
+    fn a_corrupt_file_falls_back_to_defaults() {
+        let dir = tmp_dir("corrupt");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(path_in(&dir), b"{not json").unwrap();
+
+        assert!(load(&dir).relay_url().is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_url_round_trips_and_empty_clears_it() {
+        let dir = tmp_dir("roundtrip");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        save(
+            &dir,
+            &Settings {
+                custom_relay_url: Some("  ws://10.0.0.5:4869  ".to_string()),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            load(&dir).relay_url().as_deref(),
+            Some("ws://10.0.0.5:4869"),
+            "a pasted URL is trimmed"
+        );
+
+        // The UI clears by writing an empty string rather than deleting a key.
+        save(
+            &dir,
+            &Settings {
+                custom_relay_url: Some(String::new()),
+            },
+        )
+        .unwrap();
+        assert!(load(&dir).relay_url().is_none(), "empty means built-in");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/myco-core/src/state.rs
+++ b/myco-core/src/state.rs
@@ -56,6 +56,10 @@ pub struct AppState {
     /// The custom relay URL as last saved, which may differ from the one in use
     /// until the app restarts.
     pub pending_relay_url: String,
+    /// The configured custom Blossom and whether it can be reached.
+    pub blob_backend: crate::remote_backend::BackendHealth,
+    /// The custom Blossom URL as last saved.
+    pub pending_blossom_url: String,
     /// Status of the latest nsite update check (feedback for "Check for updates").
     pub update_check: crate::content::UpdateCheckView,
     /// Result of the dev-menu peer speedtest (a Blossom upload+download round-trip).

--- a/myco-core/src/state.rs
+++ b/myco-core/src/state.rs
@@ -49,6 +49,13 @@ pub struct AppState {
     pub discovered: Vec<crate::content::DiscoveredNsite>,
     /// "Mesh-only": the IP online fallback is disabled (pull only over the mesh).
     pub offline_only: bool,
+    /// The configured custom relay and whether it can be reached. Empty `url`
+    /// means the built-in store; a non-empty `error` is what the Storage screen
+    /// warns about, the same way it warns about a radio being off.
+    pub relay_backend: crate::remote_backend::BackendHealth,
+    /// The custom relay URL as last saved, which may differ from the one in use
+    /// until the app restarts.
+    pub pending_relay_url: String,
     /// Status of the latest nsite update check (feedback for "Check for updates").
     pub update_check: crate::content::UpdateCheckView,
     /// Result of the dev-menu peer speedtest (a Blossom upload+download round-trip).

--- a/myco-relay/Cargo.toml
+++ b/myco-relay/Cargo.toml
@@ -12,14 +12,8 @@ async-trait = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-axum = { workspace = true }
 hex = { workspace = true }
-tokio = { workspace = true }
-socket2 = { workspace = true }
-futures-util = { workspace = true }
 
 [dev-dependencies]
 nsite-deck = { path = "../nsite-deck", features = ["testing"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
-tokio-tungstenite = { workspace = true }
-futures-util = { workspace = true }

--- a/myco-relay/src/lib.rs
+++ b/myco-relay/src/lib.rs
@@ -1,7 +1,11 @@
 //! `myco-relay` — a generic embedded **Nostr relay**: a NIP-01 event store
-//! implementing `nsite-deck`'s [`RelayBackend`] seam, plus a `ws://…:4870` socket
-//! ([`server`]). See `docs/design/nsite-layer.md` §2.1 and
-//! `docs/design/event-gossip.md`.
+//! implementing `nsite-deck`'s [`RelayBackend`] seam. See
+//! `docs/design/nsite-layer.md` §2.1 and `docs/design/event-gossip.md`.
+//!
+//! This crate holds no Myco concepts — no mesh, no ttl, no circles. The
+//! WebSocket front door that applies those is `myco-core::mesh_relay`, which
+//! keeps this store swappable for any other NIP-01 relay
+//! (`reference/thinning-custom-relay.md`).
 //!
 //! Two kinds of event live here:
 //!
@@ -27,8 +31,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use nostr::{Event, PublicKey};
 use nsite_deck::seams::{ManifestFilter, RelayBackend};
-
-pub mod server;
 
 /// An embedded NIP-01 event store, keyed by event id, with replaceable/addressable
 /// dedup, NIP-40 expiry, and JSON persistence of the non-expiring (manifest) set.

--- a/myco-relay/src/lib.rs
+++ b/myco-relay/src/lib.rs
@@ -153,8 +153,10 @@ fn slot_of(event: &Event) -> (u16, [u8; 32], Option<String>) {
     (kind, event.pubkey.to_bytes(), d)
 }
 
-/// The NIP-40 `expiration` tag value (a unix timestamp), if present.
-fn expiration(event: &Event) -> Option<u64> {
+/// The NIP-40 `expiration` tag value (a unix timestamp), if present. Public so
+/// the proxy in front can size its seen-set to how long an event can still be
+/// circulating.
+pub fn expiration(event: &Event) -> Option<u64> {
     event.tags.iter().find_map(|t| {
         let s = t.as_slice();
         (s.first().map(String::as_str) == Some("expiration"))
@@ -212,9 +214,17 @@ fn admit(map: &mut HashMap<[u8; 32], Event>, event: Event, now: u64) -> bool {
     }
 }
 
-#[async_trait]
-impl RelayBackend for RelayStore {
-    async fn store_event(&self, event: Event) -> anyhow::Result<bool> {
+impl RelayStore {
+    /// Store an event, reporting whether it was **new** to this store — `false`
+    /// for a duplicate id or an event already superseded in its replaceable slot.
+    ///
+    /// This answer describes *this store*, and nothing else should be built on
+    /// it. In particular it is not a mesh loop-guard: an id GC'd at NIP-40 expiry
+    /// looks new again on a later pull, so gossip novelty is the proxy's own
+    /// seen-set instead (`reference/thinning-custom-relay.md`, D2). The
+    /// [`RelayBackend`] seam therefore does not expose it — an arbitrary NIP-01
+    /// relay could not answer it anyway.
+    pub async fn admit_event(&self, event: Event) -> anyhow::Result<bool> {
         let now = now_secs();
         let persistable = expiration(&event).is_none();
         let snapshot = {
@@ -237,6 +247,13 @@ impl RelayBackend for RelayStore {
             self.persist(&snapshot);
         }
         Ok(true)
+    }
+}
+
+#[async_trait]
+impl RelayBackend for RelayStore {
+    async fn publish(&self, event: Event) -> anyhow::Result<()> {
+        self.admit_event(event).await.map(|_| ())
     }
 
     async fn get_manifest(
@@ -323,8 +340,8 @@ mod tests {
         let root = build_test_site_with_keys(&keys, &[("/index.html", b"r")], None, None);
         let named = build_test_site_with_keys(&keys, &[("/index.html", b"n")], Some("blog"), None);
 
-        assert!(store.store_event(root.manifest.clone()).await.unwrap());
-        assert!(store.store_event(named.manifest.clone()).await.unwrap());
+        assert!(store.admit_event(root.manifest.clone()).await.unwrap());
+        assert!(store.admit_event(named.manifest.clone()).await.unwrap());
 
         let got_root = store
             .get_manifest(KIND_ROOT, &keys.public_key(), None)
@@ -348,8 +365,8 @@ mod tests {
 
         let m1 = chat_event(&keys, "mesh", "hello", None);
         let m2 = chat_event(&keys, "mesh", "world", None);
-        assert!(store.store_event(m1.clone()).await.unwrap());
-        assert!(store.store_event(m2.clone()).await.unwrap());
+        assert!(store.admit_event(m1.clone()).await.unwrap());
+        assert!(store.admit_event(m2.clone()).await.unwrap());
 
         let filter = ManifestFilter {
             kinds: vec![9],
@@ -360,7 +377,7 @@ mod tests {
         assert_eq!(got.len(), 2, "both chat messages retained");
 
         // Re-storing the same id is a no-op (dedup), not a second copy.
-        assert!(!store.store_event(m1).await.unwrap());
+        assert!(!store.admit_event(m1).await.unwrap());
         assert_eq!(store.query(&filter).await.unwrap().len(), 2);
     }
 
@@ -373,9 +390,9 @@ mod tests {
         let live = chat_event(&keys, "mesh", "fresh", Some(now + 600));
         let dead = chat_event(&keys, "mesh", "stale", Some(now.saturating_sub(10)));
 
-        assert!(store.store_event(live.clone()).await.unwrap());
+        assert!(store.admit_event(live.clone()).await.unwrap());
         assert!(
-            !store.store_event(dead).await.unwrap(),
+            !store.admit_event(dead).await.unwrap(),
             "an already-expired event is not stored"
         );
 
@@ -398,9 +415,9 @@ mod tests {
 
         {
             let store = RelayStore::open(&dir).unwrap();
-            store.store_event(site.manifest.clone()).await.unwrap();
+            store.admit_event(site.manifest.clone()).await.unwrap();
             store
-                .store_event(chat_event(&keys, "mesh", "ephemeral", Some(now + 600)))
+                .admit_event(chat_event(&keys, "mesh", "ephemeral", Some(now + 600)))
                 .await
                 .unwrap();
             assert_eq!(store.count(), 2, "both live in memory");
@@ -427,7 +444,7 @@ mod tests {
 
         {
             let store = RelayStore::open(&dir).unwrap();
-            store.store_event(site.manifest.clone()).await.unwrap();
+            store.admit_event(site.manifest.clone()).await.unwrap();
         }
         let store = RelayStore::open(&dir).unwrap();
         assert_eq!(store.count(), 1);

--- a/myco-relay/src/lib.rs
+++ b/myco-relay/src/lib.rs
@@ -29,8 +29,9 @@ use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use nostr::{Event, PublicKey};
-use nsite_deck::seams::{ManifestFilter, RelayBackend};
+use nostr::filter::MatchEventOptions;
+use nostr::{Event, Filter};
+use nsite_deck::seams::{AdminBackend, RelayBackend};
 
 /// An embedded NIP-01 event store, keyed by event id, with replaceable/addressable
 /// dedup, NIP-40 expiry, and JSON persistence of the non-expiring (manifest) set.
@@ -171,13 +172,13 @@ pub fn is_expired(event: &Event, now: u64) -> bool {
     expiration(event).is_some_and(|exp| exp <= now)
 }
 
-/// Does an event satisfy a basic `{kinds, authors, #d}` filter? Used by both the
-/// stored `query` and the server's live-subscription forwarding.
-pub fn matches_filter(event: &Event, filter: &ManifestFilter) -> bool {
-    (filter.kinds.is_empty() || filter.kinds.contains(&event.kind.as_u16()))
-        && (filter.authors.is_empty() || filter.authors.contains(&event.pubkey))
-        && (filter.d_tags.is_empty()
-            || event_d_tag(event).is_some_and(|d| filter.d_tags.contains(&d)))
+/// Does an event satisfy a NIP-01 filter? Used by both the stored `query` and the
+/// proxy's live-subscription forwarding.
+///
+/// Delegates to the `nostr` crate rather than hand-rolling a subset, so `since`,
+/// `until`, ids, and general tag matching behave the way any other relay would.
+pub fn matches_filter(event: &Event, filter: &Filter) -> bool {
+    filter.match_event(event, MatchEventOptions::new())
 }
 
 /// Admit an event into `map`, applying replaceable/addressable dedup (newest wins)
@@ -256,41 +257,26 @@ impl RelayBackend for RelayStore {
         self.admit_event(event).await.map(|_| ())
     }
 
-    async fn get_manifest(
-        &self,
-        kind: u16,
-        author: &PublicKey,
-        d_tag: Option<&str>,
-    ) -> anyhow::Result<Option<Event>> {
-        let now = now_secs();
-        let map = self.events.lock().unwrap();
-        Ok(map
-            .values()
-            .filter(|e| {
-                e.kind.as_u16() == kind
-                    && e.pubkey == *author
-                    && event_d_tag(e).as_deref() == d_tag
-                    && !is_expired(e, now)
-            })
-            .max_by_key(|e| e.created_at)
-            .cloned())
-    }
-
-    async fn query(&self, filter: &ManifestFilter) -> anyhow::Result<Vec<Event>> {
+    async fn query(&self, filters: &[Filter]) -> anyhow::Result<Vec<Event>> {
         let now = now_secs();
         let map = self.events.lock().unwrap();
         let mut out: Vec<Event> = map
             .values()
-            .filter(|e| !is_expired(e, now) && matches_filter(e, filter))
+            .filter(|e| !is_expired(e, now) && filters.iter().any(|f| matches_filter(e, f)))
             .cloned()
             .collect();
         out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        if let Some(limit) = filter.limit {
+        // Honour the smallest limit any filter asked for, matching how a relay
+        // caps a multi-filter REQ.
+        if let Some(limit) = filters.iter().filter_map(|f| f.limit).min() {
             out.truncate(limit);
         }
         Ok(out)
     }
+}
 
+#[async_trait]
+impl AdminBackend for RelayStore {
     async fn wipe(&self) -> anyhow::Result<()> {
         self.events.lock().unwrap().clear();
         if let Some(path) = &self.path {
@@ -343,14 +329,14 @@ mod tests {
         assert!(store.admit_event(root.manifest.clone()).await.unwrap());
         assert!(store.admit_event(named.manifest.clone()).await.unwrap());
 
-        let got_root = store
-            .get_manifest(KIND_ROOT, &keys.public_key(), None)
-            .await
-            .unwrap();
-        let got_named = store
-            .get_manifest(KIND_NAMED, &keys.public_key(), Some("blog"))
-            .await
-            .unwrap();
+        let got_root =
+            nsite_deck::seams::newest_in_slot(&store, KIND_ROOT, &keys.public_key(), None)
+                .await
+                .unwrap();
+        let got_named =
+            nsite_deck::seams::newest_in_slot(&store, KIND_NAMED, &keys.public_key(), Some("blog"))
+                .await
+                .unwrap();
         assert_eq!(got_root.map(|e| e.id), Some(root.manifest.id));
         assert_eq!(got_named.map(|e| e.id), Some(named.manifest.id));
         assert_eq!(store.count(), 2);
@@ -368,17 +354,67 @@ mod tests {
         assert!(store.admit_event(m1.clone()).await.unwrap());
         assert!(store.admit_event(m2.clone()).await.unwrap());
 
-        let filter = ManifestFilter {
-            kinds: vec![9],
-            d_tags: vec!["mesh".to_string()],
-            ..Default::default()
-        };
-        let got = store.query(&filter).await.unwrap();
+        let filter = Filter::new().kind(Kind::from(9u16)).identifier("mesh");
+        let got = store.query(std::slice::from_ref(&filter)).await.unwrap();
         assert_eq!(got.len(), 2, "both chat messages retained");
 
         // Re-storing the same id is a no-op (dedup), not a second copy.
         assert!(!store.admit_event(m1).await.unwrap());
-        assert_eq!(store.query(&filter).await.unwrap().len(), 2);
+        assert_eq!(
+            store
+                .query(std::slice::from_ref(&filter))
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    /// The store answers the whole NIP-01 filter surface, not a hand-rolled
+    /// subset of it.
+    ///
+    /// The old query took `{kinds, authors, #d, limit}` and silently ignored
+    /// everything else, so a `since`/`until` window or an id lookup matched far
+    /// more than the caller asked for. A backend swapped in behind this seam
+    /// would have honoured them, so the two would have disagreed.
+    #[tokio::test]
+    async fn the_full_filter_surface_is_honoured() {
+        let store = RelayStore::in_memory();
+        let keys = Keys::generate();
+
+        let old = EventBuilder::new(Kind::from(9u16), "old")
+            .custom_created_at(nostr::Timestamp::from(1_000))
+            .sign_with_keys(&keys)
+            .unwrap();
+        let recent = EventBuilder::new(Kind::from(9u16), "recent")
+            .custom_created_at(nostr::Timestamp::from(9_000))
+            .sign_with_keys(&keys)
+            .unwrap();
+        store.admit_event(old.clone()).await.unwrap();
+        store.admit_event(recent.clone()).await.unwrap();
+
+        // A time window: previously ignored, so both would have come back.
+        let windowed = store
+            .query(&[Filter::new().since(nostr::Timestamp::from(5_000))])
+            .await
+            .unwrap();
+        assert_eq!(windowed.len(), 1, "since must exclude the older event");
+        assert_eq!(windowed[0].id, recent.id);
+
+        // An id lookup, likewise.
+        let by_id = store.query(&[Filter::new().id(old.id)]).await.unwrap();
+        assert_eq!(by_id.len(), 1);
+        assert_eq!(by_id[0].id, old.id);
+
+        // Several filters are an any-match, the way a multi-filter REQ behaves.
+        let either = store
+            .query(&[
+                Filter::new().id(old.id),
+                Filter::new().since(nostr::Timestamp::from(5_000)),
+            ])
+            .await
+            .unwrap();
+        assert_eq!(either.len(), 2);
     }
 
     #[tokio::test]
@@ -396,11 +432,8 @@ mod tests {
             "an already-expired event is not stored"
         );
 
-        let filter = ManifestFilter {
-            kinds: vec![9],
-            ..Default::default()
-        };
-        let got = store.query(&filter).await.unwrap();
+        let filter = Filter::new().kind(Kind::from(9u16));
+        let got = store.query(std::slice::from_ref(&filter)).await.unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].id, live.id);
     }
@@ -426,8 +459,7 @@ mod tests {
         // written to disk.
         let store = RelayStore::open(&dir).unwrap();
         assert_eq!(store.count(), 1, "only the manifest persists");
-        let got = store
-            .get_manifest(KIND_ROOT, &keys.public_key(), None)
+        let got = nsite_deck::seams::newest_in_slot(&store, KIND_ROOT, &keys.public_key(), None)
             .await
             .unwrap();
         assert_eq!(got.map(|e| e.id), Some(site.manifest.id));
@@ -448,8 +480,7 @@ mod tests {
         }
         let store = RelayStore::open(&dir).unwrap();
         assert_eq!(store.count(), 1);
-        let got = store
-            .get_manifest(KIND_ROOT, &keys.public_key(), None)
+        let got = nsite_deck::seams::newest_in_slot(&store, KIND_ROOT, &keys.public_key(), None)
             .await
             .unwrap();
         assert_eq!(got.map(|e| e.id), Some(site.manifest.id));

--- a/nsite-deck/src/gateway.rs
+++ b/nsite-deck/src/gateway.rs
@@ -60,9 +60,8 @@ pub async fn readiness(
     addr: &SiteAddr,
 ) -> anyhow::Result<Readiness> {
     let kind = kind_for(addr.d_tag.as_deref());
-    let event = relay
-        .get_manifest(kind, &addr.author, addr.d_tag.as_deref())
-        .await?;
+    let event =
+        crate::seams::newest_in_slot(relay, kind, &addr.author, addr.d_tag.as_deref()).await?;
     let Some(event) = event else {
         return Ok(Readiness::ManifestMissing);
     };

--- a/nsite-deck/src/lib.rs
+++ b/nsite-deck/src/lib.rs
@@ -125,9 +125,15 @@ mod tests {
             .unwrap();
         assert_eq!(relay.len(), 1);
 
-        let accepted = relay.store_event(site.manifest).await.unwrap();
-        assert!(!accepted, "an equal-timestamp duplicate is not re-accepted");
-        assert_eq!(relay.len(), 1);
+        // Publishing is idempotent: re-storing the same manifest is a no-op
+        // rather than a second entry in the slot. The seam reports nothing back,
+        // so the store's own size is what pins the behaviour.
+        relay.publish(site.manifest).await.unwrap();
+        assert_eq!(
+            relay.len(),
+            1,
+            "an equal-timestamp duplicate does not stack"
+        );
     }
 
     #[tokio::test]

--- a/nsite-deck/src/lib.rs
+++ b/nsite-deck/src/lib.rs
@@ -26,7 +26,9 @@ pub mod testing;
 pub use gateway::{serve, GatewayResponse, Readiness};
 pub use host::{parse_link, resolve_host, SiteAddr};
 pub use model::{kind_for, site_key, Manifest, KIND_NAMED, KIND_ROOT};
-pub use seams::{BlobStore, FanoutSink, ManifestFilter, NoopFanout, PeerSource, RelayBackend};
+pub use seams::{
+    newest_in_slot, AdminBackend, BlobStore, FanoutSink, NoopFanout, PeerSource, RelayBackend,
+};
 pub use sync::{import_site, sha256_hex, sync_site, verify_and_store_event, SyncOutcome};
 
 #[cfg(test)]

--- a/nsite-deck/src/seams.rs
+++ b/nsite-deck/src/seams.rs
@@ -61,19 +61,22 @@ pub async fn newest_in_slot(
     author: &PublicKey,
     d_tag: Option<&str>,
 ) -> anyhow::Result<Option<Event>> {
-    let mut filter = Filter::new()
-        .kind(Kind::from(kind))
-        .author(*author)
-        .limit(1);
+    let mut filter = Filter::new().kind(Kind::from(kind)).author(*author);
     if let Some(d) = d_tag {
         filter = filter.identifier(d);
     }
     let mut found = relay.query(&[filter]).await?;
-    // A backend is free to return more than `limit` suggests, and ordering is not
-    // guaranteed, so pick the newest here rather than trusting the first row.
+    // Ordering is not guaranteed, so pick the newest here rather than trusting
+    // the first row.
     found.sort_by_key(|e| std::cmp::Reverse(e.created_at));
     // `identifier()` matches a `#d` tag, which for a root manifest is absent
     // entirely — filter that out, or a named site could answer for the root slot.
+    //
+    // Deliberately **no `limit`** on the filter. A relay applies its limit before
+    // this filter runs, so one row that we then reject would be the only chance
+    // we got: the slot would read as empty while a matching event sat behind the
+    // cut. The slot holds one event by definition, so a limit bought nothing and
+    // cost correctness (`reference/thinning-custom-relay.md`, D3).
     Ok(found
         .into_iter()
         .find(|e| event_d_tag(e).as_deref() == d_tag))
@@ -147,3 +150,136 @@ pub struct NoopFanout;
 
 #[async_trait]
 impl FanoutSink for NoopFanout {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    /// A relay that honours `limit` strictly and returns the *oldest* match
+    /// first — both behaviours a real relay is free to have, and both of which
+    /// the embedded store happens not to have.
+    struct AwkwardRelay {
+        events: Mutex<Vec<Event>>,
+    }
+
+    #[async_trait]
+    impl RelayBackend for AwkwardRelay {
+        async fn publish(&self, event: Event) -> anyhow::Result<()> {
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+
+        async fn query(&self, filters: &[Filter]) -> anyhow::Result<Vec<Event>> {
+            let events = self.events.lock().unwrap();
+            let mut out: Vec<Event> = events
+                .iter()
+                .filter(|e| {
+                    filters
+                        .iter()
+                        .any(|f| f.match_event(e, nostr::filter::MatchEventOptions::new()))
+                })
+                .cloned()
+                .collect();
+            out.sort_by_key(|e| e.created_at); // oldest first
+            if let Some(limit) = filters.iter().filter_map(|f| f.limit).min() {
+                out.truncate(limit);
+            }
+            Ok(out)
+        }
+    }
+
+    fn manifest(keys: &nostr::Keys, kind: u16, d: Option<&str>, at: u64) -> Event {
+        let mut tags = Vec::new();
+        if let Some(d) = d {
+            tags.push(nostr::Tag::identifier(d.to_string()));
+        }
+        nostr::EventBuilder::new(nostr::Kind::from(kind), "")
+            .tags(tags)
+            .custom_created_at(nostr::Timestamp::from(at))
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    /// The root slot must be found even when the relay's own `limit` would have
+    /// handed back something else first.
+    ///
+    /// `newest_in_slot` filters by `d` tag *after* the query, so any limit the
+    /// relay applies is spent before that filter runs. With `limit(1)` a single
+    /// unwanted row was the only chance we got, and the slot read as empty while
+    /// the wanted event sat behind the cut. The embedded store never showed this
+    /// because it does not emit a root manifest carrying a `d` tag — a different
+    /// relay is under no such obligation.
+    #[tokio::test]
+    async fn a_relays_limit_cannot_hide_the_wanted_event() {
+        let keys = nostr::Keys::generate();
+        let relay = AwkwardRelay {
+            events: Mutex::new(Vec::new()),
+        };
+
+        // A stray root-kind event carrying a `d` tag, older so it sorts first on
+        // a relay that returns oldest-first, plus the root manifest we want.
+        relay
+            .publish(manifest(
+                &keys,
+                crate::model::KIND_ROOT,
+                Some("stray"),
+                1_000,
+            ))
+            .await
+            .unwrap();
+        let wanted = manifest(&keys, crate::model::KIND_ROOT, None, 2_000);
+        relay.publish(wanted.clone()).await.unwrap();
+
+        let got = newest_in_slot(&relay, crate::model::KIND_ROOT, &keys.public_key(), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            got.map(|e| e.id),
+            Some(wanted.id),
+            "the root manifest must be found even though another row sorted ahead of it"
+        );
+    }
+
+    /// The named slot still resolves by its `d` tag, and does not answer for a
+    /// different one.
+    #[tokio::test]
+    async fn a_named_slot_resolves_by_its_d_tag() {
+        let keys = nostr::Keys::generate();
+        let relay = AwkwardRelay {
+            events: Mutex::new(Vec::new()),
+        };
+        let blog = manifest(&keys, crate::model::KIND_NAMED, Some("blog"), 1_000);
+        relay.publish(blog.clone()).await.unwrap();
+        relay
+            .publish(manifest(
+                &keys,
+                crate::model::KIND_NAMED,
+                Some("notes"),
+                2_000,
+            ))
+            .await
+            .unwrap();
+
+        let got = newest_in_slot(
+            &relay,
+            crate::model::KIND_NAMED,
+            &keys.public_key(),
+            Some("blog"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(got.map(|e| e.id), Some(blog.id));
+
+        let absent = newest_in_slot(
+            &relay,
+            crate::model::KIND_NAMED,
+            &keys.public_key(),
+            Some("missing"),
+        )
+        .await
+        .unwrap();
+        assert!(absent.is_none());
+    }
+}

--- a/nsite-deck/src/seams.rs
+++ b/nsite-deck/src/seams.rs
@@ -29,10 +29,14 @@ pub struct ManifestFilter {
 /// the backend's responsibility.
 #[async_trait]
 pub trait RelayBackend: Send + Sync {
-    /// Store an already-signed, already-verified event. Returns `true` if it was
-    /// accepted as the newest in its (replaceable) slot, `false` if an
-    /// equal-or-newer event already won that slot.
-    async fn store_event(&self, event: Event) -> anyhow::Result<bool>;
+    /// Store an already-signed, already-verified event.
+    ///
+    /// Idempotent: a relay dedups by id and collapses replaceable slots on its
+    /// own, so re-publishing is a no-op and there is nothing useful to report
+    /// back. Deliberately no "was it new?" answer — NIP-01's `OK true` covers
+    /// accept and duplicate alike, so no arbitrary backend could supply one, and
+    /// nothing should depend on it (`reference/thinning-custom-relay.md`, D2).
+    async fn publish(&self, event: Event) -> anyhow::Result<()>;
 
     /// The newest manifest for a replaceable slot: `kind` + `author`, plus the
     /// `d-tag` for parameterized-replaceable (35128). `d_tag = None` selects the

--- a/nsite-deck/src/seams.rs
+++ b/nsite-deck/src/seams.rs
@@ -8,25 +8,16 @@
 //!   P3 no-op stub here.
 
 use async_trait::async_trait;
-use nostr::{Event, PublicKey};
+use nostr::{Event, Filter, Kind, PublicKey};
 
-/// A basic event filter — the entire query surface Myco's gateway and discovery
-/// use (`{kinds, authors, #d, limit}`, `docs/design/nsite-layer.md` §2.1). No
-/// general tag/`since`/`until` filtering: manifests are tiny and addressed by
-/// `(kind, author, d-tag)`.
-#[derive(Debug, Clone, Default)]
-pub struct ManifestFilter {
-    pub kinds: Vec<u16>,
-    pub authors: Vec<PublicKey>,
-    pub d_tags: Vec<String>,
-    pub limit: Option<usize>,
-}
-
-/// Stores and queries manifest events (a plain NIP-01 store). The default is the
-/// embedded `myco-relay`; an alternate impl could forward to a local relay app
-/// (e.g. Citrine). Replaceable semantics — keep only the newest event per
-/// `(kind, author)` for 15128 and per `(kind, author, d-tag)` for 35128 — are
-/// the backend's responsibility.
+/// Stores and queries events (a plain NIP-01 relay). The default is the embedded
+/// `myco-relay`; an alternate impl forwards to any other relay — Citrine on the
+/// same device, a strfry on the LAN — which is the whole point of keeping this
+/// surface to verbs every relay already speaks.
+///
+/// Replaceable semantics (newest per `(kind, author)` for 15128, per
+/// `(kind, author, d-tag)` for 35128) are the backend's responsibility, because
+/// they are NIP-01's, not ours.
 #[async_trait]
 pub trait RelayBackend: Send + Sync {
     /// Store an already-signed, already-verified event.
@@ -38,21 +29,64 @@ pub trait RelayBackend: Send + Sync {
     /// nothing should depend on it (`reference/thinning-custom-relay.md`, D2).
     async fn publish(&self, event: Event) -> anyhow::Result<()>;
 
-    /// The newest manifest for a replaceable slot: `kind` + `author`, plus the
-    /// `d-tag` for parameterized-replaceable (35128). `d_tag = None` selects the
-    /// root (15128) slot.
-    async fn get_manifest(
-        &self,
-        kind: u16,
-        author: &PublicKey,
-        d_tag: Option<&str>,
-    ) -> anyhow::Result<Option<Event>>;
+    /// Events matching any of `filters` — a `REQ` read to `EOSE`.
+    ///
+    /// Takes real [`nostr::Filter`]s rather than a hand-rolled subset, so the
+    /// query surface is exactly NIP-01's: `since`, `until`, ids, and general tag
+    /// matching all work, and a remote backend needs no translation layer.
+    async fn query(&self, filters: &[Filter]) -> anyhow::Result<Vec<Event>>;
+}
 
-    /// Events matching the basic filter — used by discovery ("nsites around me").
-    async fn query(&self, filter: &ManifestFilter) -> anyhow::Result<Vec<Event>>;
-
+/// Operations with no NIP-01 expression, which therefore cannot be required of
+/// an arbitrary backend.
+///
+/// The embedded store implements this; a remote relay generally will not. Where
+/// it is absent the UI reports the operation as unavailable rather than silently
+/// doing nothing (`reference/thinning-custom-relay.md`, D4).
+#[async_trait]
+pub trait AdminBackend: Send + Sync {
     /// Drop every stored event (the dev/test wipe; `WipeStores`).
     async fn wipe(&self) -> anyhow::Result<()>;
+}
+
+/// The newest event in a replaceable slot: `kind` + `author`, plus the `d-tag`
+/// for parameterized-replaceable (35128). `d_tag = None` selects the root (15128)
+/// slot.
+///
+/// A helper over [`RelayBackend::query`] rather than a backend method: it is an
+/// ordinary filter, and every relay can already answer it.
+pub async fn newest_in_slot(
+    relay: &dyn RelayBackend,
+    kind: u16,
+    author: &PublicKey,
+    d_tag: Option<&str>,
+) -> anyhow::Result<Option<Event>> {
+    let mut filter = Filter::new()
+        .kind(Kind::from(kind))
+        .author(*author)
+        .limit(1);
+    if let Some(d) = d_tag {
+        filter = filter.identifier(d);
+    }
+    let mut found = relay.query(&[filter]).await?;
+    // A backend is free to return more than `limit` suggests, and ordering is not
+    // guaranteed, so pick the newest here rather than trusting the first row.
+    found.sort_by_key(|e| std::cmp::Reverse(e.created_at));
+    // `identifier()` matches a `#d` tag, which for a root manifest is absent
+    // entirely — filter that out, or a named site could answer for the root slot.
+    Ok(found
+        .into_iter()
+        .find(|e| event_d_tag(e).as_deref() == d_tag))
+}
+
+/// The `d` tag value of an event, if it has one.
+fn event_d_tag(event: &Event) -> Option<String> {
+    event.tags.iter().find_map(|t| {
+        let s = t.as_slice();
+        (s.first().map(String::as_str) == Some("d"))
+            .then(|| s.get(1).cloned())
+            .flatten()
+    })
 }
 
 /// A content-addressed blob store keyed by lowercase-hex sha256. Blobs are

--- a/nsite-deck/src/sync.rs
+++ b/nsite-deck/src/sync.rs
@@ -34,17 +34,16 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(hasher.finalize())
 }
 
-/// Verify an event's id + signature, then store it. Returns whether it was
-/// accepted as the newest in its replaceable slot. Rejects on bad signature —
+/// Verify an event's id + signature, then store it. Rejects on bad signature —
 /// the self-authenticating guarantee is what makes any source trustworthy.
 pub async fn verify_and_store_event(
     relay: &dyn RelayBackend,
     event: nostr::Event,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<()> {
     event
         .verify()
         .map_err(|e| anyhow::anyhow!("event signature/id verification failed: {e}"))?;
-    relay.store_event(event).await
+    relay.publish(event).await
 }
 
 /// Import an already-verified, externally-authored site: store each blob (keyed
@@ -86,7 +85,7 @@ pub async fn import_site(
         present += 1;
     }
 
-    relay.store_event(manifest_event).await?;
+    relay.publish(manifest_event).await?;
     Ok(SyncOutcome::Ready)
 }
 
@@ -116,7 +115,7 @@ pub async fn sync_site(
     match fetch_blobs(blobs, source, &manifest, progress).await? {
         // All blobs verified+stored → activate by storing the signed manifest.
         SyncOutcome::Ready => {
-            relay.store_event(manifest_event).await?;
+            relay.publish(manifest_event).await?;
             Ok(SyncOutcome::Ready)
         }
         other => Ok(other),

--- a/nsite-deck/src/testing.rs
+++ b/nsite-deck/src/testing.rs
@@ -116,7 +116,7 @@ fn slot_of(event: &Event) -> Slot {
 
 #[async_trait]
 impl RelayBackend for MemRelay {
-    async fn store_event(&self, event: Event) -> anyhow::Result<bool> {
+    async fn publish(&self, event: Event) -> anyhow::Result<()> {
         let slot = slot_of(&event);
         let mut map = self.events.lock().unwrap();
         let accept = match map.get(&slot) {
@@ -126,7 +126,7 @@ impl RelayBackend for MemRelay {
         if accept {
             map.insert(slot, event);
         }
-        Ok(accept)
+        Ok(())
     }
 
     async fn get_manifest(

--- a/nsite-deck/src/testing.rs
+++ b/nsite-deck/src/testing.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use nostr::{Event, EventBuilder, Keys, Kind, PublicKey, Tag};
 
 use crate::model::{KIND_NAMED, KIND_ROOT};
-use crate::seams::{BlobStore, ManifestFilter, RelayBackend};
+use crate::seams::{BlobStore, RelayBackend};
 use crate::sync::sha256_hex;
 
 /// A generated, signed test nsite: its manifest event and the blob bytes it
@@ -129,35 +129,27 @@ impl RelayBackend for MemRelay {
         Ok(())
     }
 
-    async fn get_manifest(
-        &self,
-        kind: u16,
-        author: &PublicKey,
-        d_tag: Option<&str>,
-    ) -> anyhow::Result<Option<Event>> {
-        let slot = (kind, author.to_bytes(), d_tag.map(str::to_string));
-        Ok(self.events.lock().unwrap().get(&slot).cloned())
-    }
-
-    async fn query(&self, filter: &ManifestFilter) -> anyhow::Result<Vec<Event>> {
+    async fn query(&self, filters: &[nostr::Filter]) -> anyhow::Result<Vec<Event>> {
         let map = self.events.lock().unwrap();
         let mut out: Vec<Event> = map
             .values()
-            .filter(|e| filter.kinds.is_empty() || filter.kinds.contains(&e.kind.as_u16()))
-            .filter(|e| filter.authors.is_empty() || filter.authors.contains(&e.pubkey))
             .filter(|e| {
-                filter.d_tags.is_empty()
-                    || event_d_tag(e).is_some_and(|d| filter.d_tags.contains(&d))
+                filters
+                    .iter()
+                    .any(|f| f.match_event(e, nostr::filter::MatchEventOptions::new()))
             })
             .cloned()
             .collect();
         out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        if let Some(limit) = filter.limit {
+        if let Some(limit) = filters.iter().filter_map(|f| f.limit).min() {
             out.truncate(limit);
         }
         Ok(out)
     }
+}
 
+#[async_trait]
+impl crate::seams::AdminBackend for MemRelay {
     async fn wipe(&self) -> anyhow::Result<()> {
         self.events.lock().unwrap().clear();
         Ok(())

--- a/reference/FIX-TODOS.md
+++ b/reference/FIX-TODOS.md
@@ -33,6 +33,20 @@ GENERAL:
   transport restart supervisor since Aware rides the ordinary UDP transport and can't
   fail a fips transport start
 
+- a shared custom relay's other writers never reach an open nsite subscription
+    The proxy's live bus is fed where it accepts a frame, not by watching the
+    store, so it only carries events the proxy itself handled. That was the same
+    set back when the store was ours and the proxy was the only writer; pointing
+    at a shared relay pulls them apart. If another Nostr app writes to the same
+    Citrine, the event IS in the store and a fresh REQ finds it, but no open
+    subscription is ever told — a chat view stays silent until something makes it
+    re-query. Fix is an upstream REQ the proxy republishes onto the bus, which
+    costs a permanently open subscription to the backend and needs the seen-set to
+    suppress the echo of our own writes, or every local publish reaches the client
+    twice. Only bites when the relay is genuinely shared — a Citrine run solely
+    for Myco has no other writers — so it is waiting on whether that is a real use
+    case. See reference/thinning-custom-relay.md.
+
 UI:
 - [DONE 2026-08-06] TOP bar usage should be opt-in, not opt-out like it is now (for nsites)
     NsiteActivity drew edge-to-edge with the top explicitly full-bleed, so nsites

--- a/reference/FIX-TODOS.md
+++ b/reference/FIX-TODOS.md
@@ -18,7 +18,7 @@ CRUCIAL:
     pinned every app. gatewayGet gained an allowSync flag: WebView loads keep the
     self-healing sync, icon probes serve local-only and never sync.
 
-
+- source of entropy for fips key generation?
 
 GENERAL:
 

--- a/reference/aware-transport-churn.md
+++ b/reference/aware-transport-churn.md
@@ -1,0 +1,156 @@
+# Wi-Fi Aware teardowns: transport churn
+
+State of play as of 2026-08-18. Read this before touching the Aware or BLE
+radios — several plausible theories are already disproven and re-testing them
+costs hours.
+
+## The symptom
+
+Wi-Fi Aware data paths between the Pixel 7 Pro and the Galaxy A52s died on a
+regular 61–65s cycle. The path came up, established a FIPS session in ~3s,
+carried steady traffic, then the firmware ended it (`NAN_EVENT_DATA_END`) with
+no application activity beforehand. Recovery took ~3s, then the cycle repeated.
+
+Only the Pixel logs the vendor event — it is a Broadcom BCM4389 (`bcmdhd4389`
+for Wi-Fi, Bluetooth over `hci_uart`, one die). The A52s is Qualcomm and only
+ever follows ~100ms later. After correcting for a 0.5s clock offset between the
+phones, the Pixel is always first, so the teardown originates there.
+
+## The cause
+
+The core re-establishes the same peer alternately over BLE and Aware. In every
+window containing teardowns, `Connection initiated` for one peer alternates
+between transports seconds apart. The single teardown-free window in hours of
+logs was the one where it settled on a single transport and stopped re-dialling.
+
+Suppressing our outbound BLE dials to a peer that Aware is already carrying
+takes teardowns from one per 64s to zero in steady state, with both radios
+scanning harder than before. That is the direct experiment, run three times.
+
+## What is implemented
+
+`AwareRadio` publishes the `node_addr` prefixes of peers it is carrying;
+`BleRadio` refuses to dial them and withholds their adverts from the core.
+
+`node_addr` is the only identity both radios can compute. BLE reads a 6-byte
+prefix of it from the peer's scan response. Aware derives it from the peer's
+npub as `SHA-256(x-only pubkey)[..16]`, mirroring `NodeAddr::from_pubkey` in
+fips. Verified on device: each phone refuses dials to exactly the other's
+prefix.
+
+Inbound connections, advertising and scanning are untouched.
+
+## Remaining issues
+
+### 1. Startup churn (the live one)
+
+Teardowns still happen for the first ~3 minutes after launch, then stop
+completely. Consistent across three builds: 1, 2 and 3 teardowns respectively,
+each followed by 4+ minutes clean.
+
+The gate only prevents *new* dials. At launch Aware is not up yet, so BLE
+legitimately connects the peer first; when the NDP then arrives the core holds
+that peer on two live transports and flip-flops until it settles.
+
+The fix is the other half of "drop BLE and use only Aware": actively close the
+existing BLE channel when Aware takes over a peer, not just decline future
+dials. Needs a chId → MAC association in `BleRadio`; the MAC → prefix map is
+already there.
+
+### 2. Unidentified peers are dialled anyway
+
+The `node_addr` prefix rides the scan response, and the advertiser only builds
+one when both the display name and node addr are known. A peer with no name set
+never sends it. So unidentified addresses are held back for only 4 sightings
+(~1–2s) and then reported regardless, rather than being withheld indefinitely —
+otherwise unnamed peers would be permanently undiscoverable over BLE.
+
+That leaves a small window on every RPA rotation where a dial can slip through.
+Rotation is otherwise handled: the prefix is stable across it, and the new MAC
+re-learns the mapping from the next scan response. The map is TTL-bounded
+(30 min, pruned at 128 entries) so rotations do not accumulate.
+
+### 3. Silent scanner is never re-armed
+
+Independent bug, hit repeatedly during this investigation and it invalidates any
+BLE measurement while active.
+
+The scanner can stop delivering with no `onScanFailed` callback. `logScanSummary`
+counts empty windows and sets `BleHealth.scannerConfirmedSilent`, but the only
+consumer of that flag is a location-services warning gated on
+`!locationServicesEnabled`. With location on, a dead scanner produces no warning
+and no recovery — observed dead for 4+ minutes with no attempt to restart.
+
+`scheduleScanRetry()` already handles the throttle correctly; it is simply
+unreachable from this path. Call it when `emptyScanWindows >= 2`.
+
+### 4. Dialling the default PSM
+
+57 consecutive dials to one peer at `psm 133`, all failing `No PSM available`.
+133 is `DEFAULT_PSM` (`0x0085` in fips `transport/ble/mod.rs`), the fallback used
+when the real PSM is unknown. Peers on air were advertising 180 and 228. Caused
+by (3): with no adverts arriving, stale cache entries get retried indefinitely.
+
+### 5. fips: transport-blind cross-connection tie-break
+
+`cross_connection_winner` picks the surviving connection from node addresses and
+direction only:
+
+```rust
+if we_are_smaller { this_is_outbound } else { !this_is_outbound }
+```
+
+It is globally consistent — both sides agree, no split-brain — but only the
+*smaller* node's outbound connection can ever win. If the larger node is the one
+that initiates a transport upgrade, it is rejected by both sides every time and
+re-dials indefinitely. For this pair the Samsung is smaller (`a16d353c…` vs the
+Pixel's `c66233c1…`) while the Pixel initiates the Aware NDP.
+
+Not firing today — sessions die before they live long enough to be upgraded — so
+it is latent. It will surface once the churn is fixed.
+
+### 6. Aware is disabled by Doze on Android 13/14/15
+
+See [#30](https://github.com/Origami74/myco/issues/30). `WifiAwareStateManager`
+calls `disableUsage()` on device idle, tearing down every session and NDP, unless
+some Aware client app is exempt from battery optimizations. A foreground service
+does not help — the check is the battery-opt whitelist. Removed in Android 16.
+Unrelated to the churn above, but it will end Aware sessions in the field.
+
+## Disproven — do not re-test
+
+- **Radio coexistence / BLE scan duty cycle.** The obvious theory, given one die
+  shares a 2.4GHz front end. Backing the scan off from `LOW_LATENCY` to
+  `BALANCED` while a path was live changed nothing: teardowns continued at the
+  same 64s cadence. The counter-example is decisive — with dials suppressed,
+  teardowns stop while BLE scans *harder* than ever (77 and 137 adverts/30s).
+  A dose-response that appeared to support coexistence (31 → 16 → 0 adverts as
+  teardowns tapered) was the scanner of issue (3) dying, not causation.
+- **Firmware reaping an idle path.** `aware_data0` counters showed steady
+  mirrored traffic throughout, right up to each teardown.
+- **NDP slot exhaustion.** `availableDataPathsCount` is the *free* count and read
+  8 of a maximum 8 (`NAN_MAX_NDP_PEER`) every time.
+- **Discovery match expiry.** `NAN_EVENT_MATCH_EXPIRY` did not precede the
+  teardowns.
+- **Our own release causing it.** The firmware event precedes our
+  `releaseNetworkFor` by ~108ms.
+- **Duplicate network requests.** `Aware NDP up` is logged from
+  `onCapabilitiesChanged`, which fires repeatedly — a logging artifact, not two
+  requests. Requests and releases balance.
+- **The tie-break causing it.** See (5): the loser path never executes today.
+
+## Loose artifact
+
+A tested fips change making session lookup transport-agnostic — `pending_outbound`,
+`peers_by_index`, `decrypt_registered_sessions` and the decrypt worker keyed on
+the session index alone instead of `(TransportId, u32)` — is saved at
+`reference/fips-transport-agnostic-session-key.patch`. It is **not** committed to
+either repo and `reference/` is gitignored, so it will be lost if that file is
+deleted.
+
+It applies to fips `integration/platform` and passed 1830 tests, clippy and fmt.
+It fixes a real defect: a msg2 arriving on a different transport than the msg1
+that created the entry cannot match, so a cross-transport reply can never
+complete a handshake. It did not measurably change the churn, which is why it was
+reverted rather than kept. It becomes relevant if we ever want a transport change
+to be free instead of a full re-handshake.


### PR DESCRIPTION
Two threads on one branch: the Wi-Fi Aware teardown fix, and the work that makes
Myco's relay and blob store swappable for ones you run yourself.

They landed together because the second is long and the first was urgent. They
touch different files and can be read independently — commits `676a35d`/`430509d`
are the Aware work; everything else is the relay/store work.

## Wi-Fi Aware links stop dying every 64 seconds

Data paths between the Pixel 7 Pro and the A52s were being torn down by firmware
on a strikingly regular cycle: up, session in ~3s, steady traffic, dead, with no
application activity preceding it.

Radio coexistence was the obvious suspect and was wrong — backing the BLE scan
off from `LOW_LATENCY` to `BALANCED` changed nothing at all. The cause was
transport churn: the core re-establishing the same peer alternately over BLE and
Aware. Suppressing our outbound BLE dials to a peer Aware already carries takes
teardowns from one per 64s to one in seven minutes, *with both radios scanning
harder than before* — which is the direct counter-example to the coexistence
theory.

`node_addr` is the only identity both radios can compute, so that is the key:
BLE reads a 6-byte prefix from the scan response, Aware derives it from the npub.
The advert is withheld as well as the dial refused, closing the race on a freshly
rotated RPA. Unidentified addresses are held back for only a few sightings, since
a peer with no display name never sends the prefix and would otherwise be
undiscoverable.

Remaining: teardowns still occur for the first ~3 minutes after launch, because
the gate only prevents new dials and BLE legitimately connects first. Closing the
existing BLE channel on takeover is the other half. Written up with the disproven
theories in `reference/aware-transport-churn.md`.

## The relay and blob store become swappable

Myco's mesh behaviour was baked into the events and filters it stored: a hop
count added to the event object, a pull budget added inside a filter object. That
made the embedded relay a fork of NIP-01 rather than a component — no other relay
could hold Myco's data, because holding it meant understanding Myco.

That state now travels *beside* the message instead of inside it:

```jsonc
["MESH", {"ttl": 2}, ["EVENT", <event>]]
["MESH", {"ttl": 1, "qid": "…", "budgetMs": 5000}, ["REQ", <sub>, <filter>…]]
```

The inner element is canonical NIP-01, byte for byte. Two boundaries are asserted
by test rather than left as convention: the nsite link and the backend link must
never carry a `MESH` verb or a ttl key.

With that true, `RelayBackend` was re-cut as `publish` + `query` over real
`nostr::Filter` values, and `RemoteBackend` / `RemoteBlobStore` implement it over
WebSocket and BUD-01. **Citrine is confirmed working as the event store.** The
setting lives under Settings → Storage → Advanced, off by default.

### Breaking

Mesh state moved on the wire, so **two phones must be on the same build to
exchange events**. Deliberate — the plan took the clean break rather than a
compatibility shim, and the envelope makes a 1-hop shim cheap later if it is ever
wanted.

The auth service also moved from `:4871` to `:4873` late in the branch: 4871 is
`LAN_UDP_PORT` for the LAN/AP lane. Nothing collided (that lane is UDP, this is
TCP), but a port meaning two unrelated things is a trap for whoever next reads a
capture.

### Pairing got its own plane

Pairing created the circle that gates everything else, yet travelled on the plane
it authorised: a kind whitelist let unpaired peers publish to the relay, and the
handshake was written into the event store as a side effect nothing ever read
back. With a swappable relay that is a stranger's write path into a store we do
not own.

`POST /pair` on `:4873` is now the only thing an unpaired device can reach. The
content ports refuse non-members *before the WebSocket upgrade*, and the relay
refuses the pairing kinds from every source. No tokens: FIPS addresses are
identity-derived and Noise-IK authenticated, so the address already is the
authenticated npub.

Per-peer permissions ride the circle record — six flags, all on by default except
Blossom upload, which nothing in normal operation needs. Not exposed in the UI
yet; stored now so enabling it later is a UI change rather than a migration.

### Bugs found and fixed along the way

- **Update checks had silently gone single-hop.** Removing `req-ttl` from the
  filter in the wire change did not add the envelope at that call site. Caught
  while reconciling the design docs against the code.
- **Manifest forwarding ignored `relay_write_multihop`.** The chat plane consulted
  the grant; the manifest plane never did, so a peer denied multihop still had its
  manifests relayed onward.
- **A client `REQ` waited on every peer before `EOSE`.** One unreachable phone
  made an app look hung.
- **Old messages were re-flooded** whenever someone came into range, because
  novelty was decided by whether the store still held the event.
- **Unpairing did not close connections already open.**

## Review notes

**New dependency surface** is small: `axum` and `socket2` were already workspace
dependencies and are now used by `myco-core` too; `tower` is dev-only, for driving
axum routers in tests where a real socket can only ever be loopback.

**Security.** One deliberately open port, rate limited (1/s per source, burst 5,
8 in flight, 8 KiB bodies), signature-verified before anything is touched, with an
explicit NIP-40 freshness check now that nothing is stored. Reads from a custom
relay are *not* re-verified — NIP-01 makes that the relay's job — which is a trust
decision surfaced in the configuration dialog rather than buried.

**Tests.** 133 in `myco-core`. The load-bearing ones were each confirmed to fail
without their fix: the `EOSE` hang, the boundary assertions, and an action-tag
mismatch that made the settings Save silently do nothing.

**Docs.** `docs/design/` was rewritten to match — `event-gossip.md` §2 had been
arguing *for* the design this branch reverses. `CHANGELOG.md`, `ports.md`,
`identity-pairing.md` and `security.md` all updated.

## Known gaps

- `RemoteBlobStore` has not met a third-party Blossom server. Citrine covers the
  relay side; the blob side is tested only against our own implementation.
- A **shared** custom relay's other writers never reach an open nsite
  subscription — the proxy's live bus is fed where it accepts a frame, not by
  watching the store. Only bites if you point Myco at a relay another Nostr app
  also writes to. Noted in `reference/FIX-TODOS.md` with the fix and its costs.
- Per-peer permissions have no UI yet.

Related: [#30](https://github.com/Origami74/myco/issues/30) is Aware being killed
by deep Doze, which is a different mechanism from the churn fixed here and is not
addressed by this branch.
