### PR TITLE
feat(aware): carry several Wi-Fi Aware peers with a chipset-sized socket pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Wi-Fi Aware carries several phones at once instead of one. The lane ran a
+  single UDP socket, and Android lets a socket serve only one Wi-Fi Aware
+  connection, so a second phone's link came up and then went quiet — the
+  hardware was never the limit. Each phone now gets a socket of its own, up to
+  four at a time.
+
 ### Added
 
 - Send a file straight to a paired phone. Share anything from another app, pick

--- a/android/app/src/main/java/app/myco/MainActivity.kt
+++ b/android/app/src/main/java/app/myco/MainActivity.kt
@@ -46,6 +46,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import app.myco.ap.ApRadio
+import app.myco.aware.AwareCapability
 import app.myco.aware.AwareRadio
 import app.myco.aware.AwareService
 import app.myco.ble.BleRadio
@@ -144,6 +145,14 @@ class MainActivity : ComponentActivity() {
         captureExternalShare(intent)
         // Restore the mesh-only (no IP fallback) preference into the core.
         core.dispatch(NativeActions.setOfflineOnly(prefs.getBoolean(PREF_OFFLINE_ONLY, false)))
+        // Tell the core what this chipset can carry, before anything starts the
+        // node: the Aware socket pool is sized from it, and it is persisted
+        // because it is not readable at the moment the node actually needs it
+        // (Wi-Fi may be off then). Null — API below 33, Wi-Fi off — leaves the
+        // last known answer in place rather than overwriting it with a guess.
+        AwareCapability.supportedDataPaths(this)?.let {
+            core.dispatch(NativeActions.setAwareDataPaths(it))
+        }
         // (Device name is asserted in onResume, which also covers identity not yet
         // being ready at this point.)
 

--- a/android/app/src/main/java/app/myco/aware/AwareCapability.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareCapability.kt
@@ -1,0 +1,55 @@
+package app.myco.aware
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.wifi.aware.WifiAwareManager
+import android.os.Build
+import android.util.Log
+
+/**
+ * What the Wi-Fi Aware chipset says it can do — specifically, how many
+ * concurrent data paths it supports, which is what the core sizes its UDP
+ * socket pool to.
+ *
+ * # Why this is read separately from the radio
+ *
+ * The pool is bound when the **node** starts, which happens whether or not the
+ * Aware lane is on and long before [AwareRadio] attaches. So the number cannot
+ * come from the radio: it is read here, pushed to the core, and persisted, and
+ * the *next* node start uses it. A running node is never rebuilt for it — that
+ * would drop every live link, including BLE ones with nothing to do with Aware.
+ *
+ * # Why it is not always available
+ *
+ * `getNumberOfSupportedDataPaths()` is API 33, above this app's minSdk of 29,
+ * and `getCharacteristics()` returns null while Wi-Fi is off. Either way the
+ * answer is null and the core keeps its default until a launch that can read
+ * it.
+ *
+ * # Not to be confused with availability
+ *
+ * `AwareResources.getAvailableDataPathsCount()` is what is free *right now*,
+ * and it lies for this purpose: it reported 7 free throughout a run of instant
+ * refusals on a device that carried one peer. Capability comes from
+ * `Characteristics`, which matches `dumpsys wifiaware`'s `maxNdpSessions`.
+ */
+internal object AwareCapability {
+
+    /**
+     * Concurrent data paths this chipset supports, or null if it cannot be
+     * asked (no Aware hardware, API below 33, or Wi-Fi off).
+     */
+    fun supportedDataPaths(context: Context): Int? {
+        if (!context.packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI_AWARE)) return null
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
+        val mgr = context.getSystemService(Context.WIFI_AWARE_SERVICE) as? WifiAwareManager
+        // Null while the radio is unavailable — Wi-Fi off, typically.
+        val characteristics = runCatching { mgr?.characteristics }.getOrNull() ?: return null
+        val paths = runCatching { characteristics.numberOfSupportedDataPaths }.getOrNull()
+        if (paths == null || paths <= 0) return null
+        Log.i(TAG, "chipset supports $paths concurrent Aware data paths")
+        return paths
+    }
+
+    private const val TAG = "MycoAwareCap"
+}

--- a/android/app/src/main/java/app/myco/aware/AwareRadio.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareRadio.kt
@@ -41,41 +41,66 @@ import kotlinx.coroutines.flow.asStateFlow
  * touches a payload byte. See docs/design/wifi-aware-interop.md.
  *
  * That transport is **this lane's own** UDP socket, and this class pins it to
- * the NDP's [Network] ([udpPin]). Both halves matter. An NDP is a network of
+ * the NDP's [Network] ([pins]). Both halves matter. An NDP is a network of
  * its own with its own routing table, so a socket marked with any other
  * network — infrastructure Wi-Fi, as the AP lane marks it — cannot reach an
  * Aware peer at all: the address is well-formed, the send reports success, and
  * nothing arrives. That was the whole of the "Aware discovers everything and
  * peers with nothing" fault. See [UdpSocketPin].
  *
+ * # One socket per peer, not one per lane
+ *
+ * That exclusivity does not stop at the lane boundary: each NDP is a separate
+ * [Network] too, so one socket cannot serve two peers either — the most recent
+ * bind wins and the rest go dark with their data paths still up. The core
+ * therefore binds a pool of UDP transport instances (`aware0`…) and this class
+ * holds a pin per instance, giving each peer a [slotPool] slot and pinning that
+ * slot's socket to that peer's data path. The chipsets always had the headroom
+ * (a Pixel 7 Pro advertises 8 concurrent data paths, a Galaxy A52s 2); the
+ * single socket was the ceiling. See `reference/aware-multipeer-limit.md`.
+ *
  * Flow, per peer:
  *  1. publish + subscribe the Myco service (symmetric, no group owner).
  *  2. on a subscribe match, exchange identities over Aware `sendMessage`
  *     (the analog of BLE's in-band pubkey exchange — no identity is in the
- *     advert itself). The payload is `"<npub>|<port>"`.
+ *     advert itself). The payload is `"<npub>|<port>"`, where the port is the
+ *     one *this* peer's slot listens on.
  *  3. the smaller-npub side requests the NDP (the cross-probe tiebreaker,
  *     applied before spending a scarce data-path slot; the core backstops it).
  *  4. read the peer's scoped link-local IPv6 from [WifiAwareNetworkInfo] and
- *     push `awarePeerFound(npub, "[fe80::x%ifindex]:port")`.
+ *     push `awarePeerFound(npub, "[fe80::x%ifindex]:port", "aware<slot>")`.
  *
- * The listener port is **per peer**, not a global constant. Each side binds
- * its own ([app.myco.core.AppState.wifiAwarePort], `runtime.rs`'s
- * `AWARE_UDP_PORT`) and advertises it in the identity exchange, and we dial
- * each peer at the port *it* named. Dialling our own port instead is what
- * broke interop the moment this lane moved off the LAN port: a peer on an
- * older build still listens on [LEGACY_UDP_PORT], so the dial lands on a dead
- * port, the handshake never completes, and Android tears the idle NDP down
- * ~35s later — forever. An identity payload with no port is exactly that peer,
- * and is dialled at [LEGACY_UDP_PORT]; there is no flag day.
+ * The listener port is **per peer**, not a global constant — and now doubly so.
+ * Each side advertises, in the identity exchange, the port of the socket it has
+ * pinned to *that* peer's data path (slot *i* listens on
+ * [app.myco.core.AppState.wifiAwarePort]` + i`, `runtime.rs`'s
+ * `AWARE_UDP_BASE_PORT`), and we dial each peer at the port *it* named.
+ * Dialling our own port instead is what broke interop the moment this lane
+ * moved off the LAN port: a peer on an older build still listens on
+ * [LEGACY_UDP_PORT], so the dial lands on a dead port, the handshake never
+ * completes, and Android tears the idle NDP down ~35s later — forever. An
+ * identity payload with no port is exactly that peer, and is dialled at
+ * [LEGACY_UDP_PORT]; there is no flag day.
+ *
+ * A peer discovered before its identity is known is told the base port, which
+ * is slot 0 — so two phones need no correction at all, and a third only learns
+ * its port a message later ([updatePeerPort] re-announces if its data path beat
+ * the correction).
+ *
  * The NDP is left **open** (no PSK) — fips authenticates with Noise IK.
  */
 class AwareRadio(
     private val context: Context,
     /** This device's npub, sent in the pubkey exchange and used for the tiebreaker. */
     private val ownNpub: String,
-    /** This device's Aware UDP port — bound locally and advertised to peers in
-     *  the identity exchange. Peers are dialled at *their* advertised port. */
+    /** The **base** port of this device's Aware socket pool: slot *i* is bound
+     *  at `port + i`. Each peer is told its own slot's port in the identity
+     *  exchange, and is itself dialled at *its* advertised port. */
     private val port: Int,
+    /** How many peers the lane can carry at once — the number of UDP transport
+     *  instances the core bound, read from the state rather than assumed, so
+     *  this class can never name an instance the node does not have. */
+    private val slots: Int,
 ) {
     private val manager: WifiAwareManager? =
         context.getSystemService(Context.WIFI_AWARE_SERVICE) as? WifiAwareManager
@@ -85,11 +110,15 @@ class AwareRadio(
     private val thread = HandlerThread("myco-aware").apply { start() }
     private val handler = Handler(thread.looper)
 
-    /** Pins this lane's UDP transport socket to the NDP [Network] — see the
-     *  class doc, and [UdpSocketPin] for why the lane needs a socket of its
-     *  own. Asks for [LANE] by name, so it can only ever receive the Aware
-     *  lane's socket, never the AP lane's. */
-    private val udpPin = UdpSocketPin(LANE, handler, TAG)
+    /** One pin per pooled UDP transport instance: pin *i* holds the socket the
+     *  core bound as `aware<i>` and marks it for the data path of whichever
+     *  peer holds slot *i*. Each asks for its own instance by name, so it can
+     *  only ever receive that socket — never the AP lane's, and never another
+     *  slot's. See the class doc and [UdpSocketPin]. */
+    private val pins: List<UdpSocketPin> = List(slots) { UdpSocketPin(laneFor(it), handler, TAG) }
+
+    /** Which pooled socket carries which peer. */
+    private val slotPool = AwareSlotPool(slots)
 
     private var session: WifiAwareSession? = null
     private var publishSession: PublishDiscoverySession? = null
@@ -109,12 +138,23 @@ class AwareRadio(
      *  the NDP drops so recovery does not have to wait for rediscovery. */
     private val ndpTargets = ConcurrentHashMap<String, NdpTarget>()
 
-    /** Peers whose NDP is established right now. The chipset has exactly one
-     *  `aware_data` interface, so a live NDP to one peer is the usual reason a
-     *  request for another is refused outright — and that is knowable here,
-     *  before spending a request, in a way [logResources] is not: it reports
-     *  seven of eight "data paths" free while the one interface is held. */
+    /** Peers whose NDP is established right now — the coexistence signal the
+     *  BLE radio reads, and the honest count of what the lane is carrying.
+     *  [logResources] is not a substitute: it reported seven of eight "data
+     *  paths" free throughout a run of instant refusals. */
     private val liveNdps: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /** Each peer's scoped link-local IPv6, kept from the moment its data path
+     *  came up so the address can be re-formatted if the peer later announces a
+     *  different port — see [updatePeerPort]. */
+    private val peerAddrs = ConcurrentHashMap<String, Inet6Address>()
+
+    /** The port we last told each peer to dial us on, and the port each peer
+     *  last named for itself. Together they decide whether an identity is worth
+     *  answering — see [announceSlot]. Cleared with the peer's slot, so a
+     *  re-established data path re-announces. */
+    private val announcedPorts = ConcurrentHashMap<String, Int>()
+    private val heardPorts = ConcurrentHashMap<String, Int>()
 
     /** Per-peer NDP retry state. Mutated only on [handler]; the map is
      *  concurrent because [ConnectivityManager.NetworkCallback]s (which arrive
@@ -144,7 +184,7 @@ class AwareRadio(
             return
         }
         running = true
-        udpPin.start()
+        pins.forEach { it.start() }
         registerAvailability(mgr)
         if (mgr.isAvailable) {
             attach(mgr)
@@ -227,6 +267,10 @@ class AwareRadio(
         publishCoexState()
         ndpTargets.clear()
         peerIdentities.clear()
+        peerAddrs.clear()
+        announcedPorts.clear()
+        heardPorts.clear()
+        slotPool.clear()
         _links.value = emptyList()
         runCatching { publishSession?.close() }
         runCatching { subscribeSession?.close() }
@@ -242,11 +286,11 @@ class AwareRadio(
         availabilityReceiver?.let { runCatching { context.unregisterReceiver(it) } }
         availabilityReceiver = null
         closeSessions()
-        // On the handler thread, where the pin's state lives. Releases our dup
-        // of the socket; the core's own descriptor, and its binding, are
+        // On the handler thread, where the pins' state lives. Releases our dups
+        // of the sockets; the core's own descriptors, and their bindings, are
         // untouched — a stale mark on a network that has gone away is harmless,
         // and the next NDP re-pins.
-        handler.post { udpPin.stop() }
+        handler.post { pins.forEach { it.stop() } }
     }
 
     fun shutdown() {
@@ -273,18 +317,16 @@ class AwareRadio(
                 NativeCore.awareSetDiscovering(discovering())
             }
 
-            // A subscriber reached us. Reply with our npub so it can label the
-            // NDP. Then, if WE are the responder for this pair (larger npub),
-            // request the data path on the publish session. Exactly one side is
-            // responder and one is initiator — an NDP needs both, complementary.
+            // A subscriber reached us. Reply with our npub and the port of the
+            // slot we just gave it, so it can label the NDP and dial the socket
+            // that will actually be marked for its data path. Then, if WE are
+            // the responder for this pair (larger npub), request the data path
+            // on the publish session. Exactly one side is responder and one is
+            // initiator — an NDP needs both, complementary.
             override fun onMessageReceived(peer: PeerHandle, message: ByteArray) {
                 val remote = parsePeer(message) ?: return
                 peerIdentities[peer] = remote
-                publishSession?.sendMessage(peer, MSG_ID_NPUB, identityPayload())
-                if (ownNpub > remote.npub) {
-                    Log.i(TAG, "publish: responder for ${short(remote.npub)}; requesting NDP")
-                    requestDataPath(publishSession, peer, remote)
-                }
+                onPeerIdentity(publishSession, peer, remote, initiate = ownNpub > remote.npub)
             }
         }, handler)
     }
@@ -308,31 +350,136 @@ class AwareRadio(
 
             // We discovered a publisher: we are the INITIATOR toward it.
             // Introduce ourselves; it replies with its npub (below).
+            //
+            // We cannot name a slot yet — a slot is per npub and the match
+            // carries no identity — so this advertises the base port, which is
+            // slot 0. That is exactly right for the first peer, and corrected
+            // one message later for any other (see [onPeerIdentity]).
             override fun onServiceDiscovered(
                 peer: PeerHandle,
                 serviceSpecificInfo: ByteArray?,
                 matchFilter: MutableList<ByteArray>?,
             ) {
                 Log.i(TAG, "discovered a peer; sending our identity")
-                subscribeSession?.sendMessage(peer, MSG_ID_NPUB, identityPayload())
+                subscribeSession?.sendMessage(peer, MSG_ID_NPUB, identityPayload(port))
             }
 
-            // The publisher replied with its npub. If WE are the initiator for
-            // this pair (smaller npub), request the NDP on the subscribe
-            // session; the peer's publish side requests as responder.
+            // The publisher replied with its npub — now we know who it is, so
+            // it gets a slot and, with it, the corrected port to dial us on. If
+            // WE are the initiator for this pair (smaller npub), request the
+            // NDP on the subscribe session; the peer's publish side requests as
+            // responder.
             override fun onMessageReceived(peer: PeerHandle, message: ByteArray) {
                 val remote = parsePeer(message) ?: return
                 peerIdentities[peer] = remote
-                if (ownNpub < remote.npub) {
-                    Log.i(TAG, "subscribe: initiator for ${short(remote.npub)}; requesting NDP")
-                    requestDataPath(subscribeSession, peer, remote)
-                }
+                onPeerIdentity(subscribeSession, peer, remote, initiate = ownNpub < remote.npub)
             }
         }, handler)
     }
 
-    /** This device's identity as it goes on the wire: `"<npub>|<port>"`. */
-    private fun identityPayload(): ByteArray = "$ownNpub$FIELD_SEP$port".toByteArray()
+    /**
+     * A peer has told us who it is, on `session`. Give it a slot, tell it which
+     * port that slot listens on, take note of the port *it* named, and request
+     * its data path if we are the side that does the requesting.
+     *
+     * The reply is conditional — see [announceSlot] for why, and why that is
+     * what stops two sides answering each other forever.
+     *
+     * A full pool is answered with silence rather than the base port: the port
+     * we would name belongs to a socket marked for somebody else's data path,
+     * so the peer's packets would arrive and our replies would leave down the
+     * wrong network. Silence leaves it to retry when a slot frees.
+     */
+    private fun onPeerIdentity(
+        session: DiscoverySession?,
+        peer: PeerHandle,
+        remote: AwarePeer,
+        initiate: Boolean,
+    ) {
+        val slot = slotPool.acquire(remote.npub)
+        if (slot == null) {
+            Log.i(
+                TAG,
+                "no free Aware slot for ${short(remote.npub)} " +
+                    "(${slotPool.inUse()}/$slots held); not answering",
+            )
+            return
+        }
+        announceSlot(remote.npub, slot, remote.port, session, peer)
+        updatePeerPort(remote)
+        if (initiate) {
+            Log.i(TAG, "initiator for ${short(remote.npub)}; requesting NDP")
+            requestDataPath(session, peer, remote)
+        }
+    }
+
+    /**
+     * Tell `npub` which port to dial us on — the one belonging to the socket we
+     * will pin to its data path.
+     *
+     * **Sent only when something has actually changed**, and that is what makes
+     * the exchange terminate. Both sides now answer an identity (the subscriber
+     * used to stay silent), so an unconditional reply would have each answering
+     * the other's answer forever. Two conditions, and each is load-bearing:
+     *
+     *  - *our* port changed — first contact, or a slot that moved because the
+     *    data path was re-established somewhere else;
+     *  - *their* port changed since we last heard it — which is how a peer that
+     *    restarted its radio, and is introducing itself at the base port again,
+     *    gets an answer instead of the silence its stale entry would otherwise
+     *    earn it.
+     *
+     * A message that changes neither is an echo, and gets nothing back. The
+     * gate lives here rather than in a marker in the payload because the
+     * payload's shape has to stay parseable by builds from before the pool.
+     *
+     * `peerPort` is what the peer just advertised, or null when re-announcing
+     * outside the identity exchange (a retry claiming a new slot).
+     */
+    private fun announceSlot(
+        npub: String,
+        slot: Int,
+        peerPort: Int?,
+        session: DiscoverySession?,
+        peer: PeerHandle,
+    ) {
+        val ours = portForSlot(slot)
+        val oursChanged = announcedPorts.put(npub, ours) != ours
+        val theirsChanged = peerPort != null && heardPorts.put(npub, peerPort) != peerPort
+        if (!oursChanged && !theirsChanged) return
+        Log.i(TAG, "telling ${short(npub)} to dial us on $ours (slot $slot)")
+        session?.sendMessage(peer, MSG_ID_NPUB, identityPayload(ours))
+    }
+
+    /**
+     * The peer named a different port than the one we are dialling it at — it
+     * has given us a slot of its own, and the message arrived after we had
+     * already started (or finished) bringing its data path up.
+     *
+     * Re-announce rather than negotiate: `platform_peers` suppresses a re-push
+     * by `(npub, address)`, so a changed port is not swallowed, and the core
+     * refreshes the peer's path instead of standing up a second one. Costs
+     * nothing when the ports already agree, which is every two-device pairing.
+     */
+    private fun updatePeerPort(remote: AwarePeer) {
+        val target = ndpTargets[remote.npub] ?: return // not requested yet; the request will use it
+        if (target.port == remote.port) return
+        ndpTargets[remote.npub] = NdpTarget(target.session, target.peer, remote.port)
+        val slot = slotPool.slotOf(remote.npub) ?: return
+        val addr = peerAddrs[remote.npub]?.let { formatPeerAddr(it, remote.port) } ?: return
+        Log.i(TAG, "${short(remote.npub)} moved to port ${remote.port}; re-announcing at $addr")
+        setLink(remote.npub, addr, up = true)
+        NativeCore.awarePeerFound(remote.npub, addr, laneFor(slot))
+    }
+
+    /** The port slot *i* listens on: the pool is contiguous from [port]. */
+    private fun portForSlot(slot: Int): Int = port + slot
+
+    /** This device's identity as it goes on the wire: `"<npub>|<port>"`, where
+     *  the port is the one the peer being addressed should dial. The shape is
+     *  unchanged by the pool, so a build from before it still parses this. */
+    private fun identityPayload(dialPort: Int): ByteArray =
+        "$ownNpub$FIELD_SEP$dialPort".toByteArray()
 
     /**
      * Parse an identity payload into the peer's npub and the UDP port to dial
@@ -389,10 +536,28 @@ class AwareRadio(
         // drop any queued retry: this request supersedes it.
         ndpTargets[peerNpub] = NdpTarget(sess, peer, remote.port)
         if (isRetry) cancelPendingRetry(peerNpub) else clearRetry(peerNpub)
-        // Don't spend a request that cannot be provisioned: the interface is
-        // already carrying someone else's NDP. Queue instead — see
-        // [deferNdpRetry], which does not touch the retry budget.
-        dataPathBlockedBy(peerNpub)?.let { why ->
+        // A socket to pin comes first. Without one, the data path could come up
+        // and still carry nothing: the peer would have no port of ours to dial.
+        // This is also where a retry gets its slot back — the previous one was
+        // handed in when the data path dropped, so another peer could use it
+        // while this one was down.
+        val slot = slotPool.acquire(peerNpub)
+        if (slot == null) {
+            Log.i(
+                TAG,
+                "not requesting NDP to ${short(peerNpub)}: " +
+                    "all $slots Aware slots in use (${logResources()})",
+            )
+            deferNdpRetry(peerNpub)
+            return false
+        }
+        // The slot may differ from the one this peer was last told about, so
+        // re-announce before the data path can come up under a stale port.
+        announceSlot(peerNpub, slot, peerPort = null, session = sess, peer = peer)
+        // Don't spend a request the framework has already said it cannot
+        // provision. Queue instead — see [deferNdpRetry], which does not touch
+        // the retry budget.
+        dataPathBlockedBy()?.let { why ->
             Log.i(TAG, "not requesting NDP to ${short(peerNpub)}: $why (${logResources()})")
             deferNdpRetry(peerNpub)
             return false
@@ -412,9 +577,19 @@ class AwareRadio(
         val callback = object : ConnectivityManager.NetworkCallback() {
             override fun onCapabilitiesChanged(network: Network, caps: NetworkCapabilities) {
                 val info = caps.transportInfo as? WifiAwareNetworkInfo ?: return
-                val addr = formatPeerAddr(info.peerIpv6Addr, remote.port) ?: return
-                Log.i(TAG, "Aware NDP up to ${short(peerNpub)} at $addr")
+                val ipv6 = info.peerIpv6Addr ?: return
+                // The port the peer last named, not the one it named when this
+                // request went out — a slot-qualified identity can overtake the
+                // data path it belongs to.
+                val dialPort = ndpTargets[peerNpub]?.port ?: remote.port
+                val addr = formatPeerAddr(ipv6, dialPort) ?: return
+                val slot = slotPool.slotOf(peerNpub) ?: run {
+                    Log.w(TAG, "NDP up to ${short(peerNpub)} with no slot held; not announcing")
+                    return
+                }
+                Log.i(TAG, "Aware NDP up to ${short(peerNpub)} at $addr (slot $slot)")
                 liveNdps.add(peerNpub)
+                peerAddrs[peerNpub] = ipv6
                 publishCoexState()
                 // The link is good: hand the peer a fresh retry budget.
                 if (retries.containsKey(peerNpub)) handler.post { clearRetry(peerNpub) }
@@ -423,15 +598,13 @@ class AwareRadio(
                 // socket is what used to time out. This callback repeats for
                 // the life of the NDP, so the re-pin is idempotent and cheap.
                 //
-                // One socket, one mark: with several concurrent NDPs the most
-                // recent one wins. Each NDP is a separate Network, so a single
-                // socket cannot serve them all — the pair this milestone has to
-                // get right is two phones, and a fan-out (a socket per NDP)
-                // would need a transport instance per peer, which fips has no
-                // way to configure at runtime.
-                udpPin.bindTo(network)
+                // One socket, one mark — so this pins *this peer's* socket, the
+                // one whose port it was told to dial. Binding a shared socket
+                // here is what used to make the most recent data path the only
+                // reachable one.
+                pins[slot].bindTo(network)
                 setLink(peerNpub, addr, up = true)
-                NativeCore.awarePeerFound(peerNpub, addr, LANE)
+                NativeCore.awarePeerFound(peerNpub, addr, laneFor(slot))
             }
 
             // An NDP is otherwise only requested on *rediscovery*, so a peer
@@ -440,8 +613,9 @@ class AwareRadio(
             // [scheduleNdpRetry] for the backoff and the give-up rule.
             override fun onLost(network: Network) {
                 Log.i(TAG, "Aware NDP lost to ${short(peerNpub)}")
-                udpPin.clearTarget(network)
-                NativeCore.awarePeerLost(peerNpub, LANE)
+                val slot = slotPool.slotOf(peerNpub)
+                slot?.let { pins[it].clearTarget(network) }
+                NativeCore.awarePeerLost(peerNpub, laneFor(slot ?: 0))
                 releaseNdp(peerNpub)
                 handler.post { scheduleNdpRetry(peerNpub, "NDP lost") }
             }
@@ -505,8 +679,8 @@ class AwareRadio(
      *  - **One outstanding request per peer**: guarded here (a queued retry and
      *    a live request both bar a new one) and again, atomically, in
      *    [requestDataPath]. A success resets the budget.
-     *  - **One data-path interface**: see [deferNdpRetry], which queues a try
-     *    that could not have worked without charging it to the budget.
+     *  - **A free slot**: see [deferNdpRetry], which queues a try that could not
+     *    have worked without charging it to the budget.
      *
      * Handler thread only.
      */
@@ -523,6 +697,7 @@ class AwareRadio(
                     "waiting for rediscovery",
             )
             clearRetry(peerNpub)
+            surrenderSlot(peerNpub)
             return
         }
         val delay = backoffMs(state.attempts)
@@ -576,10 +751,11 @@ class AwareRadio(
         if (state.deferrals > MAX_NDP_SLOT_DEFERRALS) {
             Log.w(
                 TAG,
-                "data-path interface still held after $MAX_NDP_SLOT_DEFERRALS deferrals; " +
+                "still no room after $MAX_NDP_SLOT_DEFERRALS deferrals; " +
                     "leaving ${short(peerNpub)} to rediscovery",
             )
             clearRetry(peerNpub)
+            surrenderSlot(peerNpub)
             return
         }
         val delay = backoffMs(state.deferrals - 1)
@@ -590,6 +766,21 @@ class AwareRadio(
                 "retries still ${state.attempts}/$MAX_NDP_RETRIES)",
         )
         queueRetry(peerNpub, state, delay)
+    }
+
+    /**
+     * Hand a slot back for a peer we have stopped trying to reach.
+     *
+     * A slot is claimed when a data path is *requested*, not when it comes up,
+     * so a peer that walks out of the room mid-negotiation would otherwise hold
+     * a socket until the lane restarts — and with four of them, two such peers
+     * are half the room's capacity. The peer keeps its [ndpTargets] entry:
+     * rediscovery still brings it back, and takes a slot again then.
+     */
+    private fun surrenderSlot(peerNpub: String) {
+        slotPool.release(peerNpub)
+        announcedPorts.remove(peerNpub)
+        heardPorts.remove(peerNpub)
     }
 
     private fun queueRetry(peerNpub: String, state: NdpRetry, delay: Long) {
@@ -618,17 +809,18 @@ class AwareRadio(
     }
 
     /**
-     * Why a request for `peerNpub` would be refused out of hand, or null if it
-     * has a chance. The Pixel's chipset has exactly one `aware_data`
-     * interface, so an NDP live to any *other* peer is a refusal we can see
-     * coming — and [android.net.wifi.aware.AwareResources] will not tell us:
-     * it reported `dataPaths=7` free throughout a run of instant refusals.
-     * Hence our own [liveNdps] first, with the framework's count as a backstop.
+     * Why a request would be refused out of hand by the *framework*, or null if
+     * it has a chance.
+     *
+     * This used to refuse whenever any other peer held a data path, which was
+     * right only because the lane had one socket to pin: a second NDP would
+     * have unbound the first. With a socket per slot that reason is gone, and
+     * what remains is our own pool (checked where the slot is acquired) and the
+     * framework's count — kept as a backstop but never trusted alone, since
+     * [android.net.wifi.aware.AwareResources] reported `dataPaths=7` free
+     * throughout a run of instant refusals.
      */
-    private fun dataPathBlockedBy(peerNpub: String): String? {
-        liveNdps.firstOrNull { it != peerNpub }?.let {
-            return "data-path interface held by ${short(it)}"
-        }
+    private fun dataPathBlockedBy(): String? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             val r = manager?.availableAwareResources
             if (r != null && r.availableDataPathsCount <= 0) return "no data paths free"
@@ -692,15 +884,23 @@ class AwareRadio(
         ndpCallbacks.remove(peerNpub)?.let {
             runCatching { connectivity.unregisterNetworkCallback(it) }
         }
+        // Hand the socket back so a peer waiting on a full pool can have it.
+        // The announced port goes with it: a re-established data path may land
+        // on a different slot, and the peer has to be told the new one —
+        // [requestDataPath] re-announces when the retry claims a slot again.
+        surrenderSlot(peerNpub)
+        peerAddrs.remove(peerNpub)
         removeLink(peerNpub)
     }
 
     /** Best-effort snapshot of free Aware data-path/session slots (API 31+),
-     *  for logging why an NDP request might be refused. */
+     *  next to our own pool occupancy — the two disagree, and which one is
+     *  refusing a request is the thing worth knowing. */
     private fun logResources(): String {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return "resources n/a"
-        val r = manager?.availableAwareResources ?: return "resources unknown"
-        return "dataPaths=${r.availableDataPathsCount} pub=${r.availablePublishSessionsCount} sub=${r.availableSubscribeSessionsCount}"
+        val ours = "slots=${slotPool.inUse()}/$slots"
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return "$ours resources n/a"
+        val r = manager?.availableAwareResources ?: return "$ours resources unknown"
+        return "$ours dataPaths=${r.availableDataPathsCount} pub=${r.availablePublishSessionsCount} sub=${r.availableSubscribeSessionsCount}"
     }
 
     /**
@@ -770,14 +970,20 @@ class AwareRadio(
         /** The Myco Wi-Fi Aware service name (the analog of the FIPS service UUID). */
         private const val SERVICE_NAME = "myco.fips.v1"
 
-        /** The lane label pushed to [NativeCore.awarePeerFound]/[NativeCore.awarePeerLost],
-         *  and asked of [NativeCore.nextUdpTransportFd] — distinguishes this radio from
-         *  [app.myco.ap.ApRadio], which pushes "udp" through the same seams. Both ride
-         *  UDP, but each lane is its own transport instance with its own socket, and
-         *  this label is what selects between them. The core turns it into the
-         *  qualified transport `"udp/aware"`, which is what makes fips dial this
-         *  lane's socket rather than the LAN lane's. */
+        /** Prefix of the lane label pushed to [NativeCore.awarePeerFound]/
+         *  [NativeCore.awarePeerLost] and asked of [NativeCore.nextUdpTransportFd]
+         *  — distinguishes this radio from [app.myco.ap.ApRadio], which pushes
+         *  "udp" through the same seams. Both ride UDP, but each transport
+         *  instance has its own socket and this label is what selects between
+         *  them. */
         private const val LANE = "aware"
+
+        /** The lane label for one pooled socket: `"aware2"`. The core maps it to
+         *  the transport instance of the same name and qualifies the peer's
+         *  address as `"udp/aware2"`, which is what makes fips dial the socket
+         *  pinned to *that* peer's data path rather than another peer's — or
+         *  the LAN lane's. */
+        private fun laneFor(slot: Int): String = "$LANE$slot"
 
         /** Message id for the identity-exchange `sendMessage`. */
         private const val MSG_ID_NPUB = 1

--- a/android/app/src/main/java/app/myco/aware/AwareService.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareService.kt
@@ -75,14 +75,19 @@ class AwareService : Service() {
             stopSelf()
             return
         }
-        val port = client.state().wifiAwarePort
+        // Base port and pool size both come from the core, which is what
+        // actually bound the sockets — the radio gives each peer a slot within
+        // that range and pins slot i's socket to peer i's data path.
+        val state = client.state()
+        val port = state.wifiAwarePort
+        val slots = state.wifiAwareSlots
         // The radio attaches now if Aware is available, or waits for it to
         // become available (e.g. once the user turns Wi-Fi on) — it does not
         // bail, so the lane stays armed. The UI pops the Wi-Fi panel when needed.
-        val r = AwareRadio(applicationContext, ownNpub, port)
+        val r = AwareRadio(applicationContext, ownNpub, port, slots)
         r.start()
         radio = r
-        Log.i(TAG, "Aware service started (port $port, available=${r.isAvailable()})")
+        Log.i(TAG, "Aware service started (ports $port..${port + slots - 1}, available=${r.isAvailable()})")
     }
 
     private fun stopAware() {

--- a/android/app/src/main/java/app/myco/aware/AwareSlotPool.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareSlotPool.kt
@@ -1,0 +1,73 @@
+package app.myco.aware
+
+/**
+ * Which of the Aware lane's UDP sockets carries which peer.
+ *
+ * # Why slots exist
+ *
+ * Every Wi-Fi Aware data path is its own `android.net.Network`, and
+ * `Network.bindSocket` marks a socket for exactly one of them. With a single
+ * socket the most recent NDP wins and every other peer, data path still up,
+ * becomes unreachable — which is why the radio used to refuse a second NDP
+ * outright. The core therefore binds a *pool* of UDP transport instances
+ * (`aware0`…), and this class decides which one a peer gets.
+ *
+ * # Allocation
+ *
+ * Lowest free slot, held for as long as the peer's data path is. Re-acquiring
+ * for a peer that already holds one returns the same slot, so the identity
+ * exchange can ask freely without spending the pool. `null` means full: the
+ * caller must not fall back to another peer's slot, because the port it would
+ * then advertise names a socket marked for somebody else's data path — the
+ * peer's packets would arrive and the replies would leave down the wrong
+ * network.
+ *
+ * Slot 0 is the base port, which is what a peer discovered before its identity
+ * is known — and a peer on a build from before the pool existed — is told, so
+ * a pair of phones lands on it without any correction.
+ *
+ * Thread-safe: NDP callbacks arrive on the framework's threads while discovery
+ * and retries run on the radio's handler.
+ */
+internal class AwareSlotPool(
+    /** Pool size, from the core (`wifiAwareSlots`) — the number of UDP
+     *  transport instances the node actually bound. */
+    private val size: Int,
+) {
+    private val byNpub = HashMap<String, Int>()
+
+    /** This peer's slot, allocating the lowest free one if it has none.
+     *  `null` when the pool is full — never another peer's slot. */
+    @Synchronized
+    fun acquire(npub: String): Int? {
+        byNpub[npub]?.let { return it }
+        val taken = byNpub.values.toSet()
+        val free = (0 until size).firstOrNull { it !in taken } ?: return null
+        byNpub[npub] = free
+        return free
+    }
+
+    /** This peer's slot, or null if it holds none. Never allocates. */
+    @Synchronized
+    fun slotOf(npub: String): Int? = byNpub[npub]
+
+    /** Give the slot back. Idempotent — teardown paths overlap. */
+    @Synchronized
+    fun release(npub: String) {
+        byNpub.remove(npub)
+    }
+
+    /** Drop every allocation (the lane went down). */
+    @Synchronized
+    fun clear() {
+        byNpub.clear()
+    }
+
+    /** Slots not currently held. */
+    @Synchronized
+    fun free(): Int = size - byNpub.size
+
+    /** Slots currently held — for logging alongside the framework's own count. */
+    @Synchronized
+    fun inUse(): Int = byNpub.size
+}

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -741,6 +741,18 @@ object NativeActions {
     fun setCustomBlossom(url: String): JSONObject =
         JSONObject().put("type", "set_custom_blossom").put("url", url)
 
+    /**
+     * Report how many concurrent Wi-Fi Aware data paths this chipset supports,
+     * which is what the core sizes its Aware UDP socket pool to.
+     *
+     * Persisted and applied at the next *node* start, not now: the pool is
+     * bound when the node is built, and rebuilding a running node would drop
+     * every live link. See [app.myco.aware.AwareCapability] for why the answer
+     * is not always available.
+     */
+    fun setAwareDataPaths(count: Int): JSONObject =
+        JSONObject().put("type", "set_aware_data_paths").put("count", count)
+
     /** Toggle mesh-only: when enabled, don't use the public IP relay/Blossom fallback. */
     fun setOfflineOnly(enabled: Boolean): JSONObject =
         JSONObject().put("type", "set_offline_only").put("enabled", enabled)

--- a/android/app/src/main/java/app/myco/core/AppCoreClient.kt
+++ b/android/app/src/main/java/app/myco/core/AppCoreClient.kt
@@ -207,7 +207,13 @@ data class AppState(
     val blePeers: List<BlePeer>,
     val bleAdverts: List<BleAdvert>,
     val wifiAwareEnabled: Boolean,
+    /** Base port of the Aware socket pool: slot *i* listens on `port + i`, and
+     *  a peer is told the port of the slot pinned to its own data path. */
     val wifiAwarePort: Int,
+    /** How many peers the Aware lane can carry at once — the number of UDP
+     *  transport instances the core bound. One socket can be marked for only
+     *  one data path, so this is the pool size, not a chipset limit. */
+    val wifiAwareSlots: Int = 1,
     /** Whether the Aware lane is actively discovering right now, sourced from
      *  the publish/subscribe session lifecycle. */
     val wifiAwareScanning: Boolean = false,
@@ -488,6 +494,7 @@ data class AppState(
                 bleAdverts = adverts,
                 wifiAwareEnabled = wifiAware.optBoolean("enabled"),
                 wifiAwarePort = wifiAware.optInt("port"),
+                wifiAwareSlots = wifiAware.optInt("slots", 1).coerceAtLeast(1),
                 wifiAwareScanning = wifiAware.optBoolean("scanning"),
                 wifiAwareScanningKnown = wifiAware.optBoolean("scanningKnown"),
                 sites = sites,

--- a/android/app/src/test/java/app/myco/aware/AwareSlotPoolTest.kt
+++ b/android/app/src/test/java/app/myco/aware/AwareSlotPoolTest.kt
@@ -1,0 +1,95 @@
+package app.myco.aware
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The pool decides which UDP socket carries which peer, and a socket can be
+ * marked for exactly one data path — so handing two peers the same slot is not
+ * a bookkeeping slip, it is one of them silently going dark.
+ */
+class AwareSlotPoolTest {
+
+    private fun npub(i: Int) = "npub1" + "%058x".format(i)
+
+    @Test
+    fun `each peer gets a slot of its own`() {
+        val pool = AwareSlotPool(4)
+        val slots = (0 until 4).map { pool.acquire(npub(it)) }
+        assertEquals(listOf(0, 1, 2, 3), slots)
+        assertEquals(0, pool.free())
+    }
+
+    @Test
+    fun `asking again returns the same slot without spending the pool`() {
+        val pool = AwareSlotPool(4)
+        val first = pool.acquire(npub(1))
+        assertEquals(first, pool.acquire(npub(1)))
+        assertEquals(first, pool.slotOf(npub(1)))
+        // The identity exchange asks on every message; only one slot is held.
+        assertEquals(3, pool.free())
+    }
+
+    /**
+     * A full pool must say so. Falling back to any slot would advertise a port
+     * whose socket is marked for another peer's data path — the packets arrive
+     * and the replies leave down the wrong network.
+     */
+    @Test
+    fun `a full pool refuses rather than reusing a slot`() {
+        val pool = AwareSlotPool(2)
+        pool.acquire(npub(1))
+        pool.acquire(npub(2))
+        assertNull(pool.acquire(npub(3)))
+        assertNull(pool.slotOf(npub(3)))
+    }
+
+    @Test
+    fun `a released slot is handed to the next peer`() {
+        val pool = AwareSlotPool(2)
+        pool.acquire(npub(1))
+        val second = pool.acquire(npub(2))
+        pool.release(npub(1))
+        assertEquals(0, pool.acquire(npub(3)))
+        // The peer that kept its data path keeps its socket.
+        assertEquals(second, pool.slotOf(npub(2)))
+    }
+
+    @Test
+    fun `releasing a peer that holds nothing is harmless`() {
+        val pool = AwareSlotPool(2)
+        pool.acquire(npub(1))
+        pool.release(npub(9))
+        pool.release(npub(9))
+        assertEquals(0, pool.slotOf(npub(1)))
+        assertEquals(1, pool.free())
+    }
+
+    @Test
+    fun `the lane going down frees everything`() {
+        val pool = AwareSlotPool(3)
+        pool.acquire(npub(1))
+        pool.acquire(npub(2))
+        pool.clear()
+        assertEquals(3, pool.free())
+        assertEquals(0, pool.inUse())
+        assertEquals(0, pool.acquire(npub(2)))
+    }
+
+    /**
+     * Slot 0 is the base port — what a peer discovered before its identity is
+     * known is told — so the first peer in the room needs no correction at all.
+     */
+    @Test
+    fun `the first peer lands on slot zero`() {
+        assertEquals(0, AwareSlotPool(4).acquire(npub(7)))
+    }
+
+    @Test
+    fun `two peers never share a socket`() {
+        val pool = AwareSlotPool(4)
+        assertNotEquals(pool.acquire(npub(1)), pool.acquire(npub(2)))
+    }
+}

--- a/docs/design/wifi-aware-interop.md
+++ b/docs/design/wifi-aware-interop.md
@@ -185,6 +185,11 @@ The exchanged pubkey then serves two purposes:
 The PSM problem — the defining fight of the BLE strategy — has no Wi-Fi Aware
 analog, and it is worth being precise about why.
 
+(It has a smaller cousin, though: the lane runs several sockets, one per peer,
+and which one a peer should dial does have to be told to it. See
+[One socket per peer](#one-socket-per-peer) below. Nothing is *discovered* —
+every port is still one we chose.)
+
 BLE's listener PSM is **assigned by the OS**; the app cannot choose it, so
 every node must advertise its PSM and every dialer must learn it before
 dialing — universal per-peer PSM discovery, a real fips-core patch. A bound UDP
@@ -210,6 +215,48 @@ is called, and open is what we want: FIPS authenticates with Noise IK, not
 with WPA3, precisely as the BLE strategy chose *insecure* L2CAP over
 Bluetooth bonding. Same trust model, new radio:
 [security.md](./security.md).
+
+### One socket per peer
+
+There is a port problem after all, one layer down from the PSM question — and
+the answer is a pool.
+
+Android routes by the network a socket is *marked* with. Every NDP is its own
+`Network`, and `Network.bindSocket` marks a socket for exactly one of them, so a
+single socket can serve exactly one peer: the most recent bind wins and every
+other peer goes dark with its data path still up. That, not the chipset, is what
+limited the lane to one peer — a Pixel 7 Pro advertises 8 concurrent data paths
+and a Galaxy A52s 2. Full investigation:
+`reference/aware-multipeer-limit.md`.
+
+So the node binds **four** UDP transport instances for this lane, `aware0…aware3`
+on ports 4872–4875, all at node start. Fixed rather than one per peer because
+fips builds its transports from config when the node starts and cannot add one
+later; growing the pool would mean rebuilding the node mid-session and dropping
+every live link, which is exactly what the Wi-Fi Aware toggle must never do.
+
+`AwareRadio` holds a pin per instance and gives each peer a slot, pinning that
+slot's socket to that peer's data path. The peer is pushed to the core under the
+lane label `"aware<slot>"`, which qualifies its address as `"udp/aware2"` — so
+fips dials the socket marked for *that* peer's network and refuses rather than
+substituting another.
+
+### The port is per peer
+
+Each pooled socket has its own port, so a peer has to be told which one to dial.
+It goes out in the identity exchange, in the same `"<npub>|<port>"` payload
+already used for the lane's own port, and the value is now the port of the slot
+pinned to *that* peer.
+
+A peer discovered before its identity is known — the match carries no npub — is
+told the base port, which is slot 0. Two phones therefore need no correction at
+all; a third learns its port one message later, and if its data path beat the
+correction the radio re-announces it to the core.
+
+Both sides answer an identity now, so the answer is conditional: sent only when
+our port changed or theirs did. An echo gets nothing back, which is what makes
+the exchange terminate without a marker in the payload that older builds could
+not parse.
 
 ### Socket exposure
 

--- a/myco-core/src/action.rs
+++ b/myco-core/src/action.rs
@@ -115,6 +115,19 @@ pub enum NativeAppAction {
     /// launch, like [`NativeAppAction::SetCustomRelay`].
     SetCustomBlossom { url: String },
 
+    /// Report how many concurrent Wi-Fi Aware data paths this chipset supports
+    /// (`Characteristics.getNumberOfSupportedDataPaths()`), which is what the
+    /// Aware UDP socket pool is sized to.
+    ///
+    /// Persisted, and applied at the next **node** start rather than now: the
+    /// pool is bound when the node is built, and rebuilding it live would drop
+    /// every established link — including BLE ones that have nothing to do with
+    /// Aware. Kotlin pushes this whenever it can read it, which is not on every
+    /// launch: the call needs API 33 (above our minSdk) and returns nothing
+    /// while Wi-Fi is off. Reading last launch's answer off disk is what makes
+    /// the number available at the one moment it is needed.
+    SetAwareDataPaths { count: u8 },
+
     /// Set this device's human label (memorable name). Stamped on outgoing pair
     /// request/accept events so peers show the name the user chose. The Android
     /// app owns the value (persisted there) and re-applies it on launch.

--- a/myco-core/src/aware_bridge_jni.rs
+++ b/myco-core/src/aware_bridge_jni.rs
@@ -3,9 +3,10 @@
 //! Unlike the BLE bridge, this is *control-plane only*: there is no byte
 //! bridge and no `AndroidRadio` trait to implement. A Wi-Fi Aware data path
 //! terminates in a kernel network interface, so the bytes ride an ordinary
-//! UDP transport — the node's `"aware"` instance, bound at
-//! `runtime::AWARE_UDP_PORT` and pinned by `AwareRadio` to the NDP's
-//! `android.net.Network`.
+//! UDP transport — one of the node's `"aware0"`…`"aware3"` instances, bound at
+//! `runtime::AWARE_UDP_BASE_PORT + slot` and pinned by `AwareRadio` to that
+//! peer's NDP `android.net.Network`. One socket can be marked for only one
+//! network, so the pool is what lets the lane carry more than one peer.
 //! The Kotlin `AwareRadio` runs discovery autonomously and only pushes
 //! "peer reachable" events into Myco's own bounded queue
 //! ([`crate::platform_peers`]), which a tokio task drains onto the node's
@@ -35,18 +36,20 @@ fn jstring(env: &mut JNIEnv, s: &JString) -> Option<String> {
 /// transport; the Noise IK handshake authenticates — the pushed npub is only
 /// a routing hint.
 ///
-/// `lane` is `"aware"` or `"udp"` — which Kotlin radio (Wi-Fi Aware vs. the
-/// LAN/AP lane) observed this peer. Each lane is its own UDP transport
-/// instance with its own socket, pinned to its own `android.net.Network`, so
-/// the address is qualified with that instance's name (`"udp/aware"`,
-/// `"udp/lan"`). fips's `TransportSpec` routes the dial to the matching socket
-/// and, crucially, refuses rather than substituting the other one — dialing an
-/// Aware peer from the Wi-Fi-pinned socket is unroutable and was the reason
-/// Aware never carried a handshake.
+/// `lane` is `"udp"` for the LAN/AP radio, or the Aware radio's slot —
+/// `"aware0"`…`"aware3"`. Every lane, and every Aware slot within it, is its own
+/// UDP transport instance with its own socket, pinned to its own
+/// `android.net.Network`, so the address is qualified with that instance's name
+/// (`"udp/aware2"`, `"udp/lan"`). fips's `TransportSpec` routes the dial to the
+/// matching socket and, crucially, refuses rather than substituting another one
+/// — dialing an Aware peer from the Wi-Fi-pinned socket is unroutable and was
+/// the reason Aware never carried a handshake, and dialing peer B's NDP from
+/// the socket pinned to peer A's is the same fault one layer down.
 ///
-/// `lane` is *also* recorded, separately, in [`crate::lane_observation`], for
-/// `merge_peers()`'s `lane_by_npub` override; that record is Myco-owned and
-/// never reaches fips.
+/// The lane is *also* recorded, separately, in [`crate::lane_observation`], for
+/// `merge_peers()`'s `lane_by_npub` override — as the family name (`"aware"`),
+/// because which radio saw a peer is one fact regardless of which socket
+/// carries it. That record is Myco-owned and never reaches fips.
 #[no_mangle]
 pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerFound(
     mut env: JNIEnv,
@@ -62,7 +65,7 @@ pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerFound(
     ) else {
         return;
     };
-    crate::lane_observation::set_lane(&npub, &lane);
+    crate::lane_observation::set_lane(&npub, crate::runtime::lane_family(&lane));
     let transport = format!("udp/{}", crate::runtime::udp_instance_for_lane(&lane));
     crate::platform_peers::push(&npub, &addr, &transport);
 }
@@ -100,7 +103,7 @@ pub extern "system" fn Java_app_myco_core_NativeCore_awarePeerLost(
     let (Some(npub), Some(lane)) = (jstring(&mut env, &npub), jstring(&mut env, &lane)) else {
         return;
     };
-    crate::lane_observation::clear_lane(&npub, &lane);
+    crate::lane_observation::clear_lane(&npub, crate::runtime::lane_family(&lane));
 }
 
 // ============================================================================
@@ -177,12 +180,16 @@ pub extern "system" fn Java_app_myco_core_NativeCore_setUpstreamDns(
 /// it has opened and if it is newer than `since_version`. Blocks up to
 /// `timeout_ms`.
 ///
-/// `lane` is the caller's own label (`"aware"` or `"udp"`), mapped to a fips
-/// instance name by [`crate::runtime::udp_instance_for_lane`]. The node binds
-/// one socket per lane and fips labels each fd with the instance it belongs to,
-/// so a radio can only ever be handed *its* descriptor — never the other
-/// lane's, which it would then pin to the wrong `android.net.Network` and
-/// black-hole. A lane whose socket did not bind is told nothing instead.
+/// `lane` is the caller's own label (`"udp"`, or an Aware slot `"aware0"`…),
+/// mapped to a fips instance name by [`crate::runtime::udp_instance_for_lane`].
+/// The node binds one socket per instance and fips labels each fd with the
+/// instance it belongs to, so a caller can only ever be handed *its*
+/// descriptor — never another's, which it would then pin to the wrong
+/// `android.net.Network` and black-hole. An instance whose socket did not bind
+/// is told nothing instead.
+///
+/// `AwareRadio` calls this once per slot, holding a pin per instance, because
+/// each of its peers needs a socket marked for that peer's own NDP.
 ///
 /// The result packs `(version << 32) | fd`, because JNI has no tuple and two
 /// calls could not be made atomic. `fd` is `-1` when nothing newer arrived; the

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -14,8 +14,8 @@ use crate::state::{
     AppState, BleAdvert, BlePeer, BleStatus, IdentityView, NodeStatus, WifiAwareStatus,
 };
 
-/// The node runs **two** UDP transport instances, not one, and everything
-/// below names them.
+/// The node runs **several** UDP transport instances, not one, and everything
+/// below names them: one for the LAN/AP lane, and a fixed pool for Wi-Fi Aware.
 ///
 /// One socket cannot serve both lanes. Android routes by the network a socket
 /// is *marked* with, not by destination alone: `Network.bindSocket` pins a
@@ -27,43 +27,97 @@ use crate::state::{
 ///
 /// So: one instance per lane, each pinned by its own Kotlin radio (see
 /// [`crate::udp_fd_bridge`]), and peer addresses qualified with the instance
-/// name (`"udp/lan"`, `"udp/aware"`) so fips dials down the lane the peer was
+/// name (`"udp/lan"`, `"udp/aware0"`) so fips dials down the lane the peer was
 /// actually observed on rather than whichever transport id sorted lowest.
 const LAN_UDP_INSTANCE: &str = "lan";
-const AWARE_UDP_INSTANCE: &str = "aware";
+
+/// The Wi-Fi Aware lane's instance **pool** — one socket per concurrent peer.
+///
+/// The same exclusivity that separates the lanes also separates peers *within*
+/// the Aware lane: every NDP is its own `android.net.Network`, so a single
+/// socket can be marked for only one of them and the most recent bind silently
+/// blackholes the rest. That, and not the chipset, is what limited Aware to one
+/// peer — a Pixel 7 Pro advertises 8 concurrent data paths and a Galaxy A52s 2,
+/// against the one Myco carried. See `reference/aware-multipeer-limit.md`.
+///
+/// A **fixed** pool rather than an instance per peer because fips builds its
+/// transports from config at node start (`create_transports`) and has no way to
+/// add one at runtime. Four is sized for a room: Aware carries a handful of
+/// nearby phones, and each idle instance costs a bound socket.
+///
+/// The slot is chosen by `AwareRadio`, which pins slot *i*'s socket to peer
+/// *i*'s NDP and pushes the peer under the lane label `"aware<i>"`.
+const AWARE_UDP_INSTANCES: [&str; 4] = ["aware0", "aware1", "aware2", "aware3"];
 
 /// UDP port for the LAN / `!FIPS` AP lane. Unchanged at 4871: this lane talks
 /// to desktop fips nodes today and works, and desktop peers are discovered by
 /// mDNS advert, so moving it would break a working lane for nothing.
 const LAN_UDP_PORT: u16 = 4871;
 
-/// UDP port for the Wi-Fi Aware bulk lane. Both peers bind it on the NDP
-/// interface and exchange over it — symmetric, no listener/dialer roles. A
-/// fixed app constant (we bind our own port), so there is no PSM-style
-/// discovery problem. UDP is fips's native transport and the LAN-discovery
-/// path (which this reuses) is already UDP + scoped link-local IPv6.
-/// See docs/design/wifi-aware-interop.md.
+/// First UDP port of the Wi-Fi Aware pool: slot *i* binds `base + i`, so
+/// `aware0…aware3` listen on 4872–4875. Both peers bind their own and exchange
+/// over the NDP — symmetric, no listener/dialer roles. UDP is fips's native
+/// transport and the LAN-discovery path (which this reuses) is already UDP +
+/// scoped link-local IPv6. See docs/design/wifi-aware-interop.md.
 ///
-/// **Not a flag day.** Each phone advertises this port to its peers in the
-/// Aware identity exchange and is dialled at the port it advertised, so a
-/// phone on a build from before this port existed — which advertises no port
-/// and listens on [`LAN_UDP_PORT`] — is still reachable. `AwareRadio` formats
-/// `"[fe80::x%ifindex]:<peer's port>"`; see its `parsePeer`.
-const AWARE_UDP_PORT: u16 = 4872;
+/// **The port is per peer, and that is what makes the pool work.** A phone
+/// advertises, in the Aware identity exchange, the port of the socket it has
+/// pinned to *that* peer's NDP, and is dialled there. A peer discovered before
+/// its slot is known is told the base port, which is slot 0 — so a pair of
+/// phones needs no correction at all, and a phone on a build from before this
+/// port existed (which advertises no port and listens on [`LAN_UDP_PORT`]) is
+/// still reachable. `AwareRadio` formats `"[fe80::x%ifindex]:<peer's port>"`;
+/// see its `parsePeer`.
+const AWARE_UDP_BASE_PORT: u16 = 4872;
 
 /// Which UDP transport instance a Kotlin radio's lane rides.
 ///
-/// `lane` is the label the radio itself pushes (`AwareRadio` sends `"aware"`,
-/// `ApRadio` sends `"udp"`); this is the single place it is turned into a fips
-/// instance name, so the name a socket is pinned by and the name a dial is
-/// routed by cannot drift apart. Anything unrecognised is the AP lane, which
-/// is the one that behaves as UDP always has.
+/// `lane` is the label the radio itself pushes (`AwareRadio` sends the slot it
+/// allocated the peer — `"aware0"`… — and `ApRadio` sends `"udp"`); this is the
+/// single place it is turned into a fips instance name, so the name a socket is
+/// pinned by and the name a dial is routed by cannot drift apart.
+///
+/// A bare `"aware"` is a radio from before the pool existed and takes slot 0,
+/// which is the port such a build advertises anyway. Anything else — including
+/// a slot number beyond the pool, which would mean Kotlin and this file
+/// disagree about its size — is the AP lane, the one that behaves as UDP always
+/// has. Kotlin reads the size from [`WifiAwareStatus::slots`] rather than
+/// keeping its own copy, so that case is a bug, not a version skew.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 pub(crate) fn udp_instance_for_lane(lane: &str) -> &'static str {
-    match lane {
-        "aware" => AWARE_UDP_INSTANCE,
-        _ => LAN_UDP_INSTANCE,
+    if lane == "aware" {
+        return AWARE_UDP_INSTANCES[0];
     }
+    AWARE_UDP_INSTANCES
+        .iter()
+        .find(|instance| **instance == lane)
+        .copied()
+        .unwrap_or(LAN_UDP_INSTANCE)
+}
+
+/// The lane *family* a slot-qualified label belongs to: `"aware2"` → `"aware"`,
+/// anything else unchanged.
+///
+/// Which socket carries a peer is a routing fact; which radio saw it is what
+/// the Dev tab reports and what `merge_peers` overrides on. Only the first is
+/// per slot, so [`crate::lane_observation`] records the family and never grows
+/// a row per slot for what is one lane.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub(crate) fn lane_family(lane: &str) -> &str {
+    let trimmed = lane.trim_end_matches(|c: char| c.is_ascii_digit());
+    if trimmed.is_empty() {
+        lane
+    } else {
+        trimmed
+    }
+}
+
+/// How many peers the Aware lane can carry at once — the pool size, reported to
+/// Kotlin in [`WifiAwareStatus::slots`] so the radio allocates within the range
+/// this file actually configured.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub(crate) fn aware_udp_slots() -> u8 {
+    AWARE_UDP_INSTANCES.len() as u8
 }
 
 /// Consecutive failed `show_peers` queries before the peer feed is reported as
@@ -573,32 +627,39 @@ impl AppRuntime {
                     ..Default::default()
                 });
         }
-        // Two UDP transports, one per lane — see the instance constants at the
-        // top of this file for why one socket cannot serve both. UDP is
+        // One UDP transport for the LAN/AP lane and a pool of them for Wi-Fi
+        // Aware — see the instance constants at the top of this file for why
+        // one socket cannot serve two lanes, nor two concurrent NDPs. UDP is
         // symmetric (no listener/dialer), fips-native, and reuses the proven
         // scoped-link-local path. Peers are supplied only by the platform peer
         // queue — UDP is not advertised on Nostr and no peer config points
         // here — so `offline_only` semantics survive.
         //
-        // Both are configured UNCONDITIONALLY on Android (like the BLE
+        // All of them are configured UNCONDITIONALLY on Android (like the BLE
         // transport above), not gated on the Aware toggle: the toggle then
         // controls only the Kotlin radio (whether peers get pushed), never the
         // node's transport set — so flipping Wi-Fi Aware never restarts the
-        // node and never disrupts an active BLE link. `wifi_aware` still adds
-        // them on the host for the LAN-based dev/test stand-in.
+        // node and never disrupts an active BLE link. That is also why the pool
+        // is bound in full up front rather than grown as peers arrive: growing
+        // it would mean rebuilding the node mid-session, which costs every live
+        // link. `wifi_aware` still adds them on the host for the LAN-based
+        // dev/test stand-in.
         if wifi_aware || cfg!(target_os = "android") {
             let udp = |port: u16| fips::config::UdpConfig {
                 bind_addr: Some(format!("[::]:{port}")),
                 ..Default::default()
             };
-            config.transports.udp = fips::config::TransportInstances::Named(
-                [
-                    (LAN_UDP_INSTANCE.to_string(), udp(LAN_UDP_PORT)),
-                    (AWARE_UDP_INSTANCE.to_string(), udp(AWARE_UDP_PORT)),
-                ]
-                .into_iter()
-                .collect(),
-            );
+            let mut instances: std::collections::HashMap<String, fips::config::UdpConfig> =
+                [(LAN_UDP_INSTANCE.to_string(), udp(LAN_UDP_PORT))]
+                    .into_iter()
+                    .collect();
+            for (slot, instance) in AWARE_UDP_INSTANCES.iter().enumerate() {
+                instances.insert(
+                    (*instance).to_string(),
+                    udp(AWARE_UDP_BASE_PORT + slot as u16),
+                );
+            }
+            config.transports.udp = fips::config::TransportInstances::Named(instances);
         }
         fips::Node::new(config).map_err(|e| anyhow::anyhow!("fips Node::new failed: {e}"))
     }
@@ -1433,10 +1494,11 @@ impl AppRuntime {
                 WifiAwareStatus {
                     enabled: self.wifi_aware_enabled,
                     port: if self.wifi_aware_enabled {
-                        AWARE_UDP_PORT
+                        AWARE_UDP_BASE_PORT
                     } else {
                         0
                     },
+                    slots: aware_udp_slots(),
                     scanning,
                     scanning_known,
                 }
@@ -1666,6 +1728,52 @@ mod tests {
 
     fn temp_dir(tag: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!("myco-test-{}-{}", std::process::id(), tag))
+    }
+
+    /// The lane label Kotlin pushes and the instance the dial is routed to meet
+    /// only at this function, and a mismatch is invisible until a handshake
+    /// times out on a device: the peer would be dialled from a socket pinned to
+    /// somebody else's data path.
+    #[test]
+    fn every_aware_slot_maps_to_its_own_instance() {
+        for (slot, instance) in AWARE_UDP_INSTANCES.iter().enumerate() {
+            assert_eq!(udp_instance_for_lane(&format!("aware{slot}")), *instance);
+        }
+        // Distinct instances, so distinct sockets — the whole point of the pool.
+        let unique: std::collections::HashSet<_> = AWARE_UDP_INSTANCES.iter().collect();
+        assert_eq!(unique.len(), AWARE_UDP_INSTANCES.len());
+        assert_eq!(aware_udp_slots() as usize, AWARE_UDP_INSTANCES.len());
+    }
+
+    /// A radio from before the pool existed pushes a bare `"aware"` and listens
+    /// on the base port, which is slot 0's — so that is where it belongs.
+    #[test]
+    fn a_bare_aware_lane_takes_slot_zero() {
+        assert_eq!(udp_instance_for_lane("aware"), AWARE_UDP_INSTANCES[0]);
+    }
+
+    /// Everything else is the AP lane. A slot past the end of the pool means
+    /// Kotlin and this file disagree about its size; it must not be routed to
+    /// an Aware socket that does not exist.
+    #[test]
+    fn unknown_lanes_fall_back_to_the_lan_instance() {
+        for lane in ["udp", "", "aware9", "awares", "lan"] {
+            assert_eq!(udp_instance_for_lane(lane), LAN_UDP_INSTANCE);
+        }
+    }
+
+    /// The Dev tab reports which *radio* saw a peer, which is one fact however
+    /// many sockets the lane owns — so the slot digits come off before the lane
+    /// is recorded.
+    #[test]
+    fn lane_family_strips_the_slot() {
+        assert_eq!(lane_family("aware0"), "aware");
+        assert_eq!(lane_family("aware3"), "aware");
+        assert_eq!(lane_family("aware"), "aware");
+        assert_eq!(lane_family("udp"), "udp");
+        // All digits: nothing to strip down to, so it is left alone rather than
+        // recorded as an empty lane.
+        assert_eq!(lane_family("42"), "42");
     }
 
     /// The action tag the app sends has to be the one the reducer accepts.

--- a/myco-core/src/runtime.rs
+++ b/myco-core/src/runtime.rs
@@ -40,14 +40,27 @@ const LAN_UDP_INSTANCE: &str = "lan";
 /// peer — a Pixel 7 Pro advertises 8 concurrent data paths and a Galaxy A52s 2,
 /// against the one Myco carried. See `reference/aware-multipeer-limit.md`.
 ///
-/// A **fixed** pool rather than an instance per peer because fips builds its
-/// transports from config at node start (`create_transports`) and has no way to
-/// add one at runtime. Four is sized for a room: Aware carries a handful of
-/// nearby phones, and each idle instance costs a bound socket.
+/// These are the names a pool can draw on; how many are actually bound is the
+/// chipset's answer, not a constant — see [`aware_udp_slots`]. A **fixed set**
+/// rather than an instance per peer because fips builds its transports from
+/// config at node start (`create_transports`) and has no way to add one at
+/// runtime; the cap bounds what an implausible capability report can cost us in
+/// bound sockets.
 ///
 /// The slot is chosen by `AwareRadio`, which pins slot *i*'s socket to peer
 /// *i*'s NDP and pushes the peer under the lane label `"aware<i>"`.
-const AWARE_UDP_INSTANCES: [&str; 4] = ["aware0", "aware1", "aware2", "aware3"];
+const AWARE_UDP_INSTANCES: [&str; 8] = [
+    "aware0", "aware1", "aware2", "aware3", "aware4", "aware5", "aware6", "aware7",
+];
+
+/// How many instances to bind when the chipset has not said otherwise — an API
+/// below 33 (`Characteristics.getNumberOfSupportedDataPaths()` is 33+, above
+/// our minSdk of 29), or a first launch with Wi-Fi off, when the capability is
+/// simply not readable yet.
+///
+/// Four is a room-sized guess, and it is only ever the guess: the real number
+/// is persisted the first time Kotlin can read it and used from then on.
+const AWARE_UDP_DEFAULT_SLOTS: u8 = 4;
 
 /// UDP port for the LAN / `!FIPS` AP lane. Unchanged at 4871: this lane talks
 /// to desktop fips nodes today and works, and desktop peers are discovered by
@@ -112,12 +125,24 @@ pub(crate) fn lane_family(lane: &str) -> &str {
     }
 }
 
-/// How many peers the Aware lane can carry at once — the pool size, reported to
-/// Kotlin in [`WifiAwareStatus::slots`] so the radio allocates within the range
-/// this file actually configured.
-#[cfg_attr(not(target_os = "android"), allow(dead_code))]
-pub(crate) fn aware_udp_slots() -> u8 {
-    AWARE_UDP_INSTANCES.len() as u8
+/// How many peers the Aware lane can carry at once: **what the chipset says it
+/// supports**, clamped to what this file can name.
+///
+/// Sizing the pool to the hardware rather than to a constant is what stops the
+/// two mistakes a constant makes at once — a Galaxy A52s holding idle sockets
+/// it can never use (it supports 2 concurrent data paths), and a Pixel 7 Pro
+/// refusing a fifth peer it could have carried (it supports 8).
+///
+/// `reported` is Kotlin's last answer from
+/// `Characteristics.getNumberOfSupportedDataPaths()`, persisted in
+/// [`crate::settings_store`]. `None` — never readable, or a host build — falls
+/// back to [`AWARE_UDP_DEFAULT_SLOTS`]. A reported 0 is not taken at face
+/// value: it would leave the lane with no socket at all, which is worse than a
+/// guess, so it clamps up to one.
+pub(crate) fn aware_udp_slots(reported: Option<u8>) -> u8 {
+    reported
+        .unwrap_or(AWARE_UDP_DEFAULT_SLOTS)
+        .clamp(1, AWARE_UDP_INSTANCES.len() as u8)
 }
 
 /// Consecutive failed `show_peers` queries before the peer feed is reported as
@@ -179,6 +204,19 @@ pub struct AppRuntime {
     pending_relay_url: String,
     /// The custom Blossom URL as last saved, for the same reason.
     pending_blossom_url: String,
+    /// The chipset's concurrent-data-path count as last reported by Kotlin.
+    /// Held here as well as on disk so a state snapshot — which happens on
+    /// every dispatch — does not re-read the settings file.
+    aware_data_paths: Option<u8>,
+    /// How many Aware UDP instances the **running** node actually bound.
+    ///
+    /// Not the same as what [`Self::aware_data_paths`] would produce, and the
+    /// difference matters: this is the number Kotlin is told, and the radio
+    /// allocates slots from it. Reporting a pending, larger value would have
+    /// the radio pin `aware5` — an instance the node never bound, whose fd
+    /// never arrives and whose dial fips would refuse. A capability that lands
+    /// after the node is up therefore changes nothing until the next start.
+    aware_slots: u8,
     identity: IdentityView,
     ble_enabled: bool,
     wifi_aware_enabled: bool,
@@ -245,6 +283,13 @@ impl AppRuntime {
         }
     }
 
+    /// The pool size the *next* node build will use, from the last capability
+    /// Kotlin reported. Read at each build rather than cached, so a report that
+    /// arrived while the previous node was running is picked up.
+    fn configured_aware_slots(data_dir: &str) -> u8 {
+        aware_udp_slots(crate::settings_store::load(Path::new(data_dir)).aware_data_paths)
+    }
+
     fn try_new(data_dir: &str, app_version: &str) -> anyhow::Result<Self> {
         std::fs::create_dir_all(Path::new(data_dir))?;
 
@@ -252,7 +297,8 @@ impl AppRuntime {
         // FFI polls (see the struct doc).
         let rt = Runtime::new().map_err(|e| anyhow::anyhow!("tokio runtime: {e}"))?;
 
-        let node = Self::build_node(data_dir, false)?;
+        let aware_slots = Self::configured_aware_slots(data_dir);
+        let node = Self::build_node(data_dir, false, aware_slots)?;
         let mut identity = IdentityView::from_identity(node.identity());
         // FIPS's effective IPv6 MTU (transport_mtu - 77). The VpnService sets this
         // on the TUN and the MSS clamp derives from it, so packets fit the mesh.
@@ -543,6 +589,8 @@ impl AppRuntime {
             data_dir: data_dir.to_string(),
             pending_relay_url: settings.relay_url().unwrap_or_default(),
             pending_blossom_url: settings.blossom_url().unwrap_or_default(),
+            aware_data_paths: settings.aware_data_paths,
+            aware_slots,
             rev: 0,
             error: mesh_warning,
             identity,
@@ -577,7 +625,7 @@ impl AppRuntime {
     /// the Wi-Fi Aware bulk lane's data plane (docs/design/wifi-aware-interop.md).
     /// Deliberately not Android-gated: the identical UDP path is the lane's
     /// dev/test stand-in on a plain LAN.
-    fn build_node(data_dir: &str, wifi_aware: bool) -> anyhow::Result<fips::Node> {
+    fn build_node(data_dir: &str, wifi_aware: bool, aware_slots: u8) -> anyhow::Result<fips::Node> {
         let nsec = identity_store::load_or_generate(Path::new(data_dir))?;
         let mut config = fips::Config::new();
         config.node.identity.nsec = Some(nsec);
@@ -642,7 +690,10 @@ impl AppRuntime {
         // node and never disrupts an active BLE link. That is also why the pool
         // is bound in full up front rather than grown as peers arrive: growing
         // it would mean rebuilding the node mid-session, which costs every live
-        // link. `wifi_aware` still adds them on the host for the LAN-based
+        // link. For the same reason the pool size is read from disk here rather
+        // than pushed live — a chipset report that arrives after the node is up
+        // takes effect at the next start, not by restarting it under a working
+        // mesh. `wifi_aware` still adds them on the host for the LAN-based
         // dev/test stand-in.
         if wifi_aware || cfg!(target_os = "android") {
             let udp = |port: u16| fips::config::UdpConfig {
@@ -653,12 +704,19 @@ impl AppRuntime {
                 [(LAN_UDP_INSTANCE.to_string(), udp(LAN_UDP_PORT))]
                     .into_iter()
                     .collect();
-            for (slot, instance) in AWARE_UDP_INSTANCES.iter().enumerate() {
+            // As many as the chipset says it can carry — see `aware_udp_slots`.
+            let slots =
+                aware_udp_slots(crate::settings_store::load(Path::new(data_dir)).aware_data_paths);
+            for (slot, instance) in AWARE_UDP_INSTANCES.iter().take(slots as usize).enumerate() {
                 instances.insert(
                     (*instance).to_string(),
                     udp(AWARE_UDP_BASE_PORT + slot as u16),
                 );
             }
+            tracing::info!(
+                slots,
+                "Wi-Fi Aware UDP pool sized from the chipset's report"
+            );
             config.transports.udp = fips::config::TransportInstances::Named(instances);
         }
         fips::Node::new(config).map_err(|e| anyhow::anyhow!("fips Node::new failed: {e}"))
@@ -700,6 +758,8 @@ impl AppRuntime {
             error: msg.to_string(),
             pending_relay_url: String::new(),
             pending_blossom_url: String::new(),
+            aware_data_paths: None,
+            aware_slots: AWARE_UDP_DEFAULT_SLOTS,
             identity: IdentityView::default(),
             ble_enabled: false,
             wifi_aware_enabled: false,
@@ -885,6 +945,35 @@ impl AppRuntime {
                     Err(e) => {
                         tracing::warn!(error = %e, "settings: could not save the custom blossom");
                         self.error = format!("Could not save the blob store setting: {e}");
+                    }
+                }
+                self.rev += 1;
+            }
+            NativeAppAction::SetAwareDataPaths { count } => {
+                // Nothing to write if the answer has not moved. Kotlin pushes
+                // this on every launch it can read it, and a settings write per
+                // launch buys nothing.
+                if self.aware_data_paths == Some(count) {
+                    return;
+                }
+                // Read-modify-write: the settings share a file, so writing one
+                // from a stale struct would silently clear the others.
+                let mut settings = crate::settings_store::load(Path::new(&self.data_dir));
+                settings.aware_data_paths = Some(count);
+                match crate::settings_store::save(Path::new(&self.data_dir), &settings) {
+                    Ok(()) => {
+                        self.aware_data_paths = Some(count);
+                        tracing::info!(
+                            count,
+                            slots = aware_udp_slots(Some(count)),
+                            "settings: Aware data-path capability saved; \
+                             the pool is resized at the next node start"
+                        );
+                    }
+                    Err(e) => {
+                        // Not surfaced in `error`: the user can do nothing about
+                        // it and the lane still works at the previous size.
+                        tracing::warn!(error = %e, "settings: could not save the Aware capability");
                     }
                 }
                 self.rev += 1;
@@ -1125,9 +1214,15 @@ impl AppRuntime {
         }
         self.start_pending = false;
         // Rebuild the node if a prior stop consumed it (BLE toggled off then on).
+        // A capability report that arrived since the last build is picked up
+        // here — this is the "next node start" the Aware pool is resized at.
         if self.node.is_none() {
-            match Self::build_node(&self.data_dir, self.wifi_aware_enabled) {
-                Ok(n) => self.node = Some(n),
+            let aware_slots = Self::configured_aware_slots(&self.data_dir);
+            match Self::build_node(&self.data_dir, self.wifi_aware_enabled, aware_slots) {
+                Ok(n) => {
+                    self.node = Some(n);
+                    self.aware_slots = aware_slots;
+                }
                 Err(e) => {
                     self.error = format!("rebuild node: {e}");
                     return;
@@ -1498,7 +1593,7 @@ impl AppRuntime {
                     } else {
                         0
                     },
-                    slots: aware_udp_slots(),
+                    slots: self.aware_slots,
                     scanning,
                     scanning_known,
                 }
@@ -1742,7 +1837,70 @@ mod tests {
         // Distinct instances, so distinct sockets — the whole point of the pool.
         let unique: std::collections::HashSet<_> = AWARE_UDP_INSTANCES.iter().collect();
         assert_eq!(unique.len(), AWARE_UDP_INSTANCES.len());
-        assert_eq!(aware_udp_slots() as usize, AWARE_UDP_INSTANCES.len());
+    }
+
+    /// The pool follows the chipset, and the clamps exist because the number
+    /// comes from outside: a report of 0 would leave the lane with no socket at
+    /// all, and one larger than the name set would ask for an instance that was
+    /// never bound.
+    #[test]
+    fn the_pool_is_sized_by_the_chipset_within_bounds() {
+        assert_eq!(aware_udp_slots(Some(2)), 2); // Galaxy A52s
+        assert_eq!(aware_udp_slots(Some(8)), 8); // Pixel 7 Pro
+        assert_eq!(aware_udp_slots(None), AWARE_UDP_DEFAULT_SLOTS);
+        assert_eq!(aware_udp_slots(Some(0)), 1);
+        assert_eq!(
+            aware_udp_slots(Some(255)),
+            AWARE_UDP_INSTANCES.len() as u8,
+            "a report beyond the names we have must not configure one we cannot pin"
+        );
+        // Whatever the size, every slot in it has an instance to name.
+        for reported in 0..=12u8 {
+            let slots = aware_udp_slots(Some(reported)) as usize;
+            assert!(slots >= 1 && slots <= AWARE_UDP_INSTANCES.len());
+            assert_eq!(
+                udp_instance_for_lane(&format!("aware{}", slots - 1)),
+                AWARE_UDP_INSTANCES[slots - 1]
+            );
+        }
+    }
+
+    /// The capability arrives from Kotlin as an action and has to survive a
+    /// restart, because the pool is bound before it can be read again. The two
+    /// halves meet at this JSON tag and nothing else checks it.
+    #[test]
+    fn a_reported_capability_persists_for_the_next_node_start() {
+        let dir = temp_dir("aware-data-paths");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut rt = AppRuntime::new(dir.to_str().unwrap(), "test");
+
+        let state = rt.dispatch_json(r#"{"type":"set_aware_data_paths","count":8}"#);
+        assert!(
+            !state.contains("invalid action JSON"),
+            "the app's tag must deserialize: {state}"
+        );
+        assert_eq!(
+            crate::settings_store::load(&dir).aware_data_paths,
+            Some(8),
+            "the count has to be on disk before the next node build reads it"
+        );
+        // Deliberately NOT resized under the running node: the reported pool is
+        // what the node bound, because Kotlin allocates slots from it and a
+        // slot with no instance behind it can never carry a peer.
+        assert!(
+            state.contains(&format!("\"slots\":{AWARE_UDP_DEFAULT_SLOTS}")),
+            "a report must not resize the running pool: {state}"
+        );
+
+        // The next launch is where it lands.
+        let mut relaunched = AppRuntime::new(dir.to_str().unwrap(), "test");
+        assert!(
+            relaunched.state_json().contains("\"slots\":8"),
+            "the persisted count must size the pool at the next node start"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A radio from before the pool existed pushes a bare `"aware"` and listens
@@ -2064,7 +2222,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("temp data dir");
 
-        let node = AppRuntime::build_node(dir.to_str().unwrap(), false)
+        let node = AppRuntime::build_node(dir.to_str().unwrap(), false, AWARE_UDP_DEFAULT_SLOTS)
             .expect("node builds with a fresh identity");
         let config = node.config();
 

--- a/myco-core/src/settings_store.rs
+++ b/myco-core/src/settings_store.rs
@@ -1,9 +1,9 @@
 //! Settings that have to survive a restart, in `settings.json`.
 //!
-//! Both values here — the custom relay and the custom Blossom — have to be
-//! persisted rather than held in memory like `offline_only`, because they decide
-//! how the content layer is *constructed*. The backends are chosen before
-//! anything else opens, so the answers must already be on disk at startup.
+//! Everything here is persisted rather than held in memory like `offline_only`
+//! because it decides how something is *constructed*. The content backends are
+//! chosen before anything else opens, and the Wi-Fi Aware socket pool is bound
+//! when the node starts — so the answers must already be on disk at startup.
 //!
 //! Deliberately a plain file rather than a settings framework. A missing or
 //! corrupt file means "use the defaults", which is the behaviour we want anyway:
@@ -31,6 +31,19 @@ pub struct Settings {
     /// pointing this at an internet server means a peer pulling an app from us
     /// needs *our* connection (`reference/thinning-custom-relay.md`, D9).
     pub custom_blossom_url: Option<String>,
+
+    /// How many concurrent Wi-Fi Aware data paths this chipset says it
+    /// supports, as last reported by Kotlin.
+    ///
+    /// Persisted because it is not knowable when it is needed. The node binds
+    /// the Aware socket pool at start, and `WifiAwareManager.getCharacteristics()`
+    /// returns null while Wi-Fi is off — so on a cold launch the number is
+    /// simply not available yet. Reading last launch's answer off disk gets it
+    /// right every time after the first.
+    ///
+    /// `None` means never reported: an API below 33 (the call is 33+, above our
+    /// minSdk of 29), Wi-Fi off on every launch so far, or a host build.
+    pub aware_data_paths: Option<u8>,
 }
 
 impl Settings {

--- a/myco-core/src/state.rs
+++ b/myco-core/src/state.rs
@@ -273,9 +273,16 @@ pub struct BleStatus {
 pub struct WifiAwareStatus {
     /// Master switch (the `SetWifiAwareEnabled` action).
     pub enabled: bool,
-    /// The UDP port the Aware radio advertises in its
-    /// service-specific info (0 while the lane is off).
+    /// The **base** UDP port of the Aware pool (0 while the lane is off). Slot
+    /// *i* listens on `port + i`, and the radio advertises the port of the slot
+    /// it pinned to each peer's data path — the base is what a peer discovered
+    /// before its slot is known is told, and is slot 0.
     pub port: u16,
+    /// How many peers the Aware lane can carry at once: the size of the UDP
+    /// instance pool the node bound at start. The radio allocates slots within
+    /// this range rather than keeping its own copy of the number, so the two
+    /// sides cannot disagree about which instances exist.
+    pub slots: u8,
     /// Whether the Aware lane is actively discovering right now — the Aware
     /// analogue of a BLE scan, sourced from the publish/subscribe session
     /// lifecycle (`publishSession != null || subscribeSession != null`), never


### PR DESCRIPTION
## The problem

Wi-Fi Aware carried exactly one peer. Not a chipset limit — a Pixel 7 Pro advertises 8 concurrent data paths and a Galaxy A52s 2, against the one Myco held.

The lane had **one UDP socket**, and `Network.bindSocket` marks a socket for exactly one `android.net.Network`. Every NDP is its own network, so the most recent bind blackholed every other peer with its data path still established. Given that, `dataPathBlockedBy` refused a second NDP outright — correct behaviour for a design that could not have carried it.

Investigation: `reference/aware-multipeer-limit.md` (gitignored, local).

## What this does

**A pool of UDP transport instances**, `aware0…aware<n>` on ports 4872+, bound at node start and unconditionally on Android — so the Wi-Fi Aware toggle still never rebuilds the node. Fixed rather than grown on demand because fips builds its transports from config at start and cannot add one at runtime.

**Sized to the chipset.** Kotlin reads `Characteristics.getNumberOfSupportedDataPaths()` and reports it; the core persists it and binds that many, clamped 1–8. The A52s stops holding sockets it can never use; the Pixel gets all 8.

Persisted rather than applied live, because the pool is bound when the node starts and the capability is not readable then — `getCharacteristics()` returns null with Wi-Fi off, and the call needs API 33 against our minSdk of 29. Last launch's answer off disk is what makes the number available at the one moment it is needed. A first launch that cannot read it uses 4.

**A socket per peer.** `AwareRadio` holds a `UdpSocketPin` per instance; `AwareSlotPool` gives each peer a slot; that slot's socket is pinned to that peer's data path. The peer is pushed under the lane label `"aware<slot>"`, which the core turns into the qualified transport `"udp/aware2"` — so fips dials the socket marked for *that* peer's network and refuses rather than substituting another.

**The local gate came out.** `dataPathBlockedBy` now refuses only when the pool is full, with the framework's availability count still a backstop (it reported `dataPaths=7` free throughout a run of instant refusals, so it is not trusted alone). A slot is claimed when a data path is *requested* and surrendered when it drops or is given up on, so a peer that walks out mid-negotiation does not keep a socket.

## The part that needed a protocol decision

Each pooled socket has its own port, so a slot cannot be a purely local choice — **the peer has to be told which port to dial**.

It rides the existing `"<npub>|<port>"` identity payload. The shape is unchanged, so builds from before the pool still parse it, and a peer that advertises no port at all is still dialled at the legacy port.

A peer discovered before its identity is known (the Aware match carries no npub) is told the **base port, which is slot 0**. So a pair of phones is exact with no correction at all; a third is corrected one message later; and a correction that lands after the data path is already up re-pushes the peer at its new address — `platform_peers` suppresses re-pushes by `(npub, address)`, so a changed port is not swallowed.

Both sides now answer an identity, which needed a termination rule: the answer is sent **only when our port changed or theirs did**. An echo gets nothing back, so the exchange ends on its own — without a marker in the payload that older builds could not parse — and a peer that restarted its radio and is reintroducing itself at the base port still gets an answer rather than the silence a stale entry would earn it.

## One subtlety worth reviewing

`wifiAware.slots` in the state reports the pool the **running node bound**, not what the settings would produce. The radio allocates slots from that number, so reporting a pending larger value would have it pin `aware5` — an instance never bound, whose fd never arrives and whose dial fips would refuse. A capability arriving under a running node therefore changes nothing until the next start, which also keeps a live mesh from being torn down for it.

## Verification

- `cargo test -p myco-core` — 152 pass. New: lane→instance mapping for every slot, the legacy bare `"aware"` label, unknown-lane fallback, lane-family strip, the capability clamp table, and a persistence test that asserts a report does *not* resize the running pool but does size the next one.
- `./gradlew testDebugUnitTest` — 8 new `AwareSlotPoolTest` cases (no two peers share a slot, a full pool refuses rather than reusing, release/re-acquire, first peer lands on slot 0).
- `cargo fmt --check`, `./gradlew assembleDebug` — clean. `Cargo.lock` unperturbed.
- `cargo clippy --all-targets -- -D warnings` fails on `main` already (`content.rs`, `remote_backend.rs`, `lane_observation.rs`, `runtime.rs:985`, vendored fips). No new findings in the changed code; left alone as out-of-footprint.

## On-device

Verified on a Pixel 7 Pro with one peer — all instances bound, the slot-qualified transport routed the dial, and the Noise session established:

```
UDP transport started name=aware0 local_addr=[::]:4872
telling npub1ne8uwap… to dial us on 4872 (slot 0)
Aware NDP up to npub1ne8uwap… at [fe80::7d:65ff:feed:6b16%379]:4872 (slot 0)
pinned aware0 UDP socket to 1222
API connect … transport=udp/aware0
Session established (responder, XK) src=npub1ne8u…8v94
```

**Not yet exercised: more than one concurrent Aware peer.** Two phones both land on slot 0, so the correction path and pool exhaustion are untested on hardware — that needs a third device. Host tests cannot cover any of it; the NDP lifecycle and identity exchange only regress on physical devices.

**Also still unexplained:** the framework's ~3ms `onUnavailable` for a second peer, seen before this change. It was attributed to a `dumpsys` metrics field that turned out to be a high-water mark, not a limit. This removes *our* ceiling; whether an Android policy limit sits behind it is now measurable, since every NDP log line carries `slots=<held>/<pool>` next to the framework's `dataPaths=<free>`.
