### PR TITLE
feat(android): send a file from a Circle contact's sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Send a file from the Circle tab: tapping a paired contact now offers
+  "Send a file" next to their npub and "Remove from circle". Pick the files
+  and they go out the same encrypted mesh transfer the system Sharesheet
+  uses — to the contact's npub, over whatever path reaches them, without
+  needing a shared Wi-Fi.
 - Send a file straight to a paired phone. Share anything from another app, pick
   one of your paired phones, and it arrives encrypted over the mesh — no
   hotspot, no internet. The receiving phone is asked first and can say no, and

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -237,6 +237,14 @@ fun MycoApp(
     }
 
     val nav = rememberNavController()
+    // "Send a file" from a Circle contact: remember who, then let the user pick what.
+    var sendFileTarget by remember { mutableStateOf<CircleContact?>(null) }
+    var pickedShareUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
+    val pickFilesForPeer = androidx.activity.compose.rememberLauncherForActivityResult(
+        androidx.activity.result.contract.ActivityResultContracts.OpenMultipleDocuments()
+    ) { uris ->
+        if (uris.isNotEmpty()) pickedShareUris = uris else sendFileTarget = null
+    }
     // Keep the navigation host and all transient surfaces in one app-root layer.
     // File offers must not be owned by Circle or any other selected destination.
     Box(Modifier.fillMaxSize()) {
@@ -299,7 +307,15 @@ fun MycoApp(
                     AppsScreen(state, client, onLaunchNsite = onLaunchNsite, onPinToHome = onPinToHome, onScanned = onScanned)
                 }
                 composable("circle") {
-                    CircleScreen(state, client, onOpenQr = { nav.navigate("qr") })
+                    CircleScreen(
+                        state,
+                        client,
+                        onOpenQr = { nav.navigate("qr") },
+                        onSendFile = { peer ->
+                            sendFileTarget = peer
+                            pickFilesForPeer.launch(arrayOf("*/*"))
+                        },
+                    )
                 }
                 composable("discover") { DiscoverScreen(state, client, onLaunchNsite = onLaunchNsite) }
                 composable("settings") {
@@ -430,14 +446,19 @@ fun MycoApp(
         )
     }
 
+    // Files come either from Android's Sharesheet (peer chosen afterwards) or from
+    // a contact's sheet on the Circle tab (peer chosen first, files picked here).
+    // Both end in the same sheet; the Circle path just arrives with a preselection.
+    val shareUris = externalShareUris.ifEmpty { pickedShareUris }
     var peerShareVisible by remember { mutableStateOf(false) }
-    androidx.compose.runtime.LaunchedEffect(externalShareUris) {
-        if (externalShareUris.isNotEmpty()) peerShareVisible = true
+    androidx.compose.runtime.LaunchedEffect(shareUris) {
+        if (shareUris.isNotEmpty()) peerShareVisible = true
     }
-    if (peerShareVisible && externalShareUris.isNotEmpty()) {
+    if (peerShareVisible && shareUris.isNotEmpty()) {
         PeerShareSheet(
             state = state,
-            uris = externalShareUris,
+            uris = shareUris,
+            preselectedNpub = if (externalShareUris.isEmpty()) sendFileTarget?.npub else null,
             onDismiss = {
                 peerShareVisible = false
                 // Closing the sheet acknowledges the outcomes it was showing.
@@ -449,9 +470,11 @@ fun MycoApp(
                     .filter { it.status == "cancelled" || it.status == "denied" }
                     .forEach { client.dispatch(NativeActions.forgetFileTransfer(it.id)) }
                 state = client.state()
+                pickedShareUris = emptyList()
+                sendFileTarget = null
                 onExternalShareDismissed()
             },
-            onShare = { peer -> onShareToPeer(externalShareUris, peer) },
+            onShare = { peer -> onShareToPeer(shareUris, peer) },
             onCancelTransfer = {
                 state = client.dispatch(NativeActions.cancelFileTransfer(it.id))
             },

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -48,6 +48,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -109,6 +111,16 @@ private val TABS = listOf(
     Tab("discover", "Discover", Icons.Filled.TravelExplore),
     Tab("settings", "Settings", Icons.Filled.Settings),
     Tab("dev", "Dev", Icons.Filled.Terminal),
+)
+
+/**
+ * Picked share URIs across a configuration change. A `Uri` is Parcelable, but the
+ * list handed back by the picker is not guaranteed to be a shape the default saver
+ * can store, so save the strings and parse them back.
+ */
+private val UriListSaver = listSaver<List<Uri>, String>(
+    save = { it.map(Uri::toString) },
+    restore = { it.map(Uri::parse) },
 )
 
 @Composable
@@ -238,12 +250,18 @@ fun MycoApp(
 
     val nav = rememberNavController()
     // "Send a file" from a Circle contact: remember who, then let the user pick what.
-    var sendFileTarget by remember { mutableStateOf<CircleContact?>(null) }
-    var pickedShareUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
+    // Saveable, not merely remembered: the document picker is another activity, and
+    // a rotation behind it — or the sheet rotating afterwards — would otherwise drop
+    // the contact and the picks on the floor, leaving the user to start over with no
+    // sign of why.
+    var sendFileNpub by rememberSaveable { mutableStateOf<String?>(null) }
+    var pickedShareUris by rememberSaveable(stateSaver = UriListSaver) {
+        mutableStateOf<List<Uri>>(emptyList())
+    }
     val pickFilesForPeer = androidx.activity.compose.rememberLauncherForActivityResult(
         androidx.activity.result.contract.ActivityResultContracts.OpenMultipleDocuments()
     ) { uris ->
-        if (uris.isNotEmpty()) pickedShareUris = uris else sendFileTarget = null
+        if (uris.isNotEmpty()) pickedShareUris = uris else sendFileNpub = null
     }
     // Keep the navigation host and all transient surfaces in one app-root layer.
     // File offers must not be owned by Circle or any other selected destination.
@@ -312,7 +330,7 @@ fun MycoApp(
                         client,
                         onOpenQr = { nav.navigate("qr") },
                         onSendFile = { peer ->
-                            sendFileTarget = peer
+                            sendFileNpub = peer.npub
                             pickFilesForPeer.launch(arrayOf("*/*"))
                         },
                     )
@@ -458,7 +476,13 @@ fun MycoApp(
         PeerShareSheet(
             state = state,
             uris = shareUris,
-            preselectedNpub = if (externalShareUris.isEmpty()) sendFileTarget?.npub else null,
+            // Only if they are still there: a contact can drop off the mesh between
+            // the tap and the picker closing, and a preselection the picker then
+            // hides under "offline" is a selection the user cannot see.
+            preselectedNpub = sendFileNpub?.takeIf {
+                externalShareUris.isEmpty() &&
+                    (it in state.reachableNpubs || state.blePeers.any { p -> p.npub == it && p.connected })
+            },
             onDismiss = {
                 peerShareVisible = false
                 // Closing the sheet acknowledges the outcomes it was showing.
@@ -471,7 +495,7 @@ fun MycoApp(
                     .forEach { client.dispatch(NativeActions.forgetFileTransfer(it.id)) }
                 state = client.state()
                 pickedShareUris = emptyList()
-                sendFileTarget = null
+                sendFileNpub = null
                 onExternalShareDismissed()
             },
             onShare = { peer -> onShareToPeer(shareUris, peer) },

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Contactless
 import androidx.compose.material.icons.filled.ChevronRight
@@ -112,6 +113,8 @@ fun CircleScreen(
     state: AppState,
     client: AppCoreClient,
     onOpenQr: () -> Unit,
+    /** "Send a file" from a contact's sheet: pick documents, then offer them to this peer over the mesh. */
+    onSendFile: (CircleContact) -> Unit = {},
 ) {
     val context = LocalContext.current
     var name by remember(state.ownNpub) { mutableStateOf(DeviceName.current(context, state.ownNpub)) }
@@ -428,6 +431,7 @@ fun CircleScreen(
         ModalBottomSheet(onDismissRequest = { sheetFor = null }) {
             PersonSheet(
                 contact = c,
+                onSendFile = { sheetFor = null; onSendFile(c) },
                 onRemove = { sheetFor = null; confirmRemove = c },
             )
         }
@@ -480,6 +484,7 @@ fun CircleScreen(
 @Composable
 private fun PersonSheet(
     contact: CircleContact,
+    onSendFile: () -> Unit,
     onRemove: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, bottom = 28.dp)) {
@@ -498,6 +503,7 @@ private fun PersonSheet(
         }
         Spacer(Modifier.height(16.dp))
         SheetAction(Icons.Filled.Info, shortNpub(contact.npub)) { }
+        SheetAction(Icons.Filled.AttachFile, "Send a file") { onSendFile() }
         SheetAction(Icons.Filled.PersonRemove, "Remove from circle", tint = MaterialTheme.colorScheme.error) { onRemove() }
     }
 }

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -157,6 +157,9 @@ fun CircleScreen(
     }
 
     val connected = state.blePeers.filter { it.connected }.map { it.npub }.toSet()
+    // Who a file could actually reach right now — any mesh lane, not just BLE.
+    // The share sheet's picker partitions on the same test.
+    val reachable = state.reachableNpubs + connected
     // Who we have already invited, from the core rather than a list local to this
     // screen: an invite outlives leaving the tab, and the core is what refuses to
     // send a second one — the badge should agree with it.
@@ -431,6 +434,7 @@ fun CircleScreen(
         ModalBottomSheet(onDismissRequest = { sheetFor = null }) {
             PersonSheet(
                 contact = c,
+                canSendFile = c.npub in reachable,
                 onSendFile = { sheetFor = null; onSendFile(c) },
                 onRemove = { sheetFor = null; confirmRemove = c },
             )
@@ -484,6 +488,8 @@ fun CircleScreen(
 @Composable
 private fun PersonSheet(
     contact: CircleContact,
+    /** False when no lane reaches them: a file has nowhere to go, so we do not offer one. */
+    canSendFile: Boolean,
     onSendFile: () -> Unit,
     onRemove: () -> Unit,
 ) {
@@ -503,7 +509,7 @@ private fun PersonSheet(
         }
         Spacer(Modifier.height(16.dp))
         SheetAction(Icons.Filled.Info, shortNpub(contact.npub)) { }
-        SheetAction(Icons.Filled.AttachFile, "Send a file") { onSendFile() }
+        if (canSendFile) SheetAction(Icons.Filled.AttachFile, "Send a file") { onSendFile() }
         SheetAction(Icons.Filled.PersonRemove, "Remove from circle", tint = MaterialTheme.colorScheme.error) { onRemove() }
     }
 }

--- a/android/app/src/main/java/app/myco/ui/screens/PeerShareSheet.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/PeerShareSheet.kt
@@ -78,10 +78,12 @@ fun PeerShareSheet(
     onDismiss: () -> Unit,
     onShare: (CircleContact) -> Unit,
     onCancelTransfer: (FileTransfer) -> Unit = {},
+    /** Peer chosen before the files were — from a contact's sheet on the Circle tab. */
+    preselectedNpub: String? = null,
 ) {
     val context = LocalContext.current
     val items = remember(uris) { uris.map { ExternalShare.describe(context, it) } }
-    var selectedNpub by remember(uris) { mutableStateOf<String?>(null) }
+    var selectedNpub by remember(uris) { mutableStateOf(preselectedNpub) }
     // Once a send starts, this is the peer whose progress the sheet follows.
     var sendingTo by remember(uris) { mutableStateOf<CircleContact?>(null) }
     val selected = state.circle.firstOrNull { it.npub == selectedNpub }


### PR DESCRIPTION
## What

Tapping a paired contact on the Circle tab now offers **Send a file** (between the npub row and *Remove from circle*). It opens the document picker and hands the picks to the existing `PeerShareSheet` with that contact preselected, so the flow is the same one the system Sharesheet uses — and the transfer is the encrypted mesh transfer from #34, addressed to the contact's npub.

## Why

#34 could only be started from Android's Sharesheet. From inside Myco there was no way to send something to a specific person.

## Changes

- `CircleScreen.kt`: `onSendFile` callback + the sheet entry.
- `MycoApp.kt`: remembers the contact, launches `OpenMultipleDocuments`, shows `PeerShareSheet` for the picks (external Sharesheet URIs still take precedence).
- `PeerShareSheet.kt`: optional `preselectedNpub`.
- CHANGELOG entry.

No core change.

## Testing

Host checks unaffected (Kotlin only); `./gradlew assembleDebug` green. On-device: Pixel ↔ a desktop peer running the same core, both directions, accept/decline/cancel, and the row persisting on the Circle tab while the peer was unreachable.
