### PR TITLE
fix(core): bound a file download by silence, not total time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is still waiting is visible from anywhere in the app and can be cancelled.
   An offer nobody answers gives up after ten minutes instead of waiting forever.
 
+### Fixed
+
+- Receiving a large file over Bluetooth no longer fails part-way with
+  "error decoding response body". The download used to give up after two
+  minutes in total, which a few megabytes over a slow hop exceeds while still
+  arriving; it now only gives up when nothing has arrived for thirty seconds,
+  and a connection that drops mid-file is tried again a few times first.
+
 ## [0.6.0] - 2026-08-19
 
 ### Added

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -2158,26 +2158,27 @@ impl Content {
         };
         crate::dns_intercept::warm_route(sender_npub);
         let base = crate::ip_source::mesh_blossom_url(sender_npub);
-        let client = reqwest::Client::builder()
-            .connect_timeout(Duration::from_secs(15))
-            .timeout(Duration::from_secs(120))
-            .build()?;
-        let mut response = client.get(format!("{base}/{blob_hash}")).send().await?;
-        if !response.status().is_success() {
-            anyhow::bail!("peer Blossom returned {}", response.status());
-        }
-        if let Some(advertised) = response.content_length() {
-            if advertised > limit {
-                anyhow::bail!("peer offered {advertised} bytes but declared {limit}");
+        let url = format!("{base}/{blob_hash}");
+        // A mesh hop can be slow and can drop mid-body, so the fetch is bounded
+        // by silence rather than by total time, and a cut connection is tried
+        // again a few times before the transfer is failed.
+        let mut attempt = 0;
+        let package = loop {
+            attempt += 1;
+            match Self::fetch_package(&url, limit, file_transfer::DOWNLOAD_IDLE_TIMEOUT).await {
+                Ok(package) => break package,
+                Err(e) if attempt < file_transfer::DOWNLOAD_ATTEMPTS && is_transport_error(&e) => {
+                    tracing::warn!(
+                        transfer = %transfer_id,
+                        attempt,
+                        error = %e,
+                        "file share: download interrupted, retrying"
+                    );
+                    tokio::time::sleep(file_transfer::DOWNLOAD_RETRY_DELAY).await;
+                }
+                Err(e) => return Err(e),
             }
-        }
-        let mut package: Vec<u8> = Vec::with_capacity(limit.min(1024 * 1024) as usize);
-        while let Some(chunk) = response.chunk().await? {
-            if package.len() as u64 + chunk.len() as u64 > limit {
-                anyhow::bail!("peer sent more than the {limit} bytes it declared");
-            }
-            package.extend_from_slice(&chunk);
-        }
+        };
         if file_transfer::sha256_hex(&package) != blob_hash {
             anyhow::bail!("downloaded encrypted blob hash mismatch");
         }
@@ -2207,6 +2208,41 @@ impl Content {
             tracing::warn!(transfer = %transfer_id, error = %e, "file share: completion acknowledgement failed");
         }
         Ok(())
+    }
+
+    /// One download of the encrypted package: bounded against `limit` before
+    /// and while the body streams in, and failed if the peer goes quiet for
+    /// [`file_transfer::DOWNLOAD_IDLE_TIMEOUT`] — not by total duration, which
+    /// a large file over a slow Bluetooth hop legitimately exceeds.
+    async fn fetch_package(url: &str, limit: u64, idle: Duration) -> anyhow::Result<Vec<u8>> {
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(15))
+            .build()?;
+        let mut response = tokio::time::timeout(idle, client.get(url).send())
+            .await
+            .map_err(|_| anyhow::anyhow!("peer Blossom did not answer"))??;
+        if !response.status().is_success() {
+            anyhow::bail!("peer Blossom returned {}", response.status());
+        }
+        if let Some(advertised) = response.content_length() {
+            if advertised > limit {
+                anyhow::bail!("peer offered {advertised} bytes but declared {limit}");
+            }
+        }
+        let mut package: Vec<u8> = Vec::with_capacity(limit.min(1024 * 1024) as usize);
+        loop {
+            let chunk = tokio::time::timeout(idle, response.chunk())
+                .await
+                .map_err(|_| {
+                    anyhow::anyhow!("download stalled: no data for {}s", idle.as_secs())
+                })??;
+            let Some(chunk) = chunk else { break };
+            if package.len() as u64 + chunk.len() as u64 > limit {
+                anyhow::bail!("peer sent more than the {limit} bytes it declared");
+            }
+            package.extend_from_slice(&chunk);
+        }
+        Ok(package)
     }
 
     async fn send_file_message(
@@ -3473,6 +3509,18 @@ fn save_outbound_pairs(path: &Path, items: &[OutboundPairView]) {
     }
 }
 
+/// Whether a download error is the connection's fault (worth another try)
+/// rather than the peer's answer (a status, a size lie, a hash mismatch).
+fn is_transport_error(error: &anyhow::Error) -> bool {
+    match error.downcast_ref::<reqwest::Error>() {
+        Some(e) => e.is_timeout() || e.is_connect() || e.is_body() || e.is_request(),
+        None => {
+            let text = error.to_string();
+            text.starts_with("download stalled") || text.starts_with("peer Blossom did not answer")
+        }
+    }
+}
+
 fn load_file_transfers(path: &Path) -> Vec<FileTransferRecord> {
     std::fs::read(path)
         .ok()
@@ -3814,6 +3862,57 @@ mod tests {
             "comparison happens after sanitising, not before"
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A slow Bluetooth hop used to fail a large download by hitting a total
+    /// timeout while bytes were still arriving ("error decoding response
+    /// body"). The fetch is now bounded by silence: a body that keeps trickling
+    /// in completes no matter how long it takes, and one that goes quiet fails
+    /// with an error the retry loop recognises as the connection's fault.
+    #[tokio::test]
+    async fn a_download_is_failed_by_silence_not_by_total_time() {
+        use tokio::io::AsyncWriteExt;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            // First request: 8 bytes, drip-fed slower than the old total cap
+            // would scale to. Second: 8 bytes promised, 4 sent, then silence.
+            for stalls in [false, true] {
+                let (mut sock, _) = listener.accept().await.unwrap();
+                sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\n")
+                    .await
+                    .unwrap();
+                for i in 0..8u8 {
+                    if stalls && i == 4 {
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                        break;
+                    }
+                    sock.write_all(&[i]).await.unwrap();
+                    sock.flush().await.unwrap();
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                }
+            }
+        });
+        let url = format!("http://127.0.0.1:{port}/blob");
+        let idle = Duration::from_millis(600);
+
+        let slow = Content::fetch_package(&url, 1024, idle).await.unwrap();
+        assert_eq!(
+            slow,
+            (0..8u8).collect::<Vec<_>>(),
+            "a trickle still completes"
+        );
+
+        let stalled = Content::fetch_package(&url, 1024, idle).await.unwrap_err();
+        assert!(
+            stalled.to_string().starts_with("download stalled"),
+            "silence must fail the fetch: {stalled}"
+        );
+        assert!(is_transport_error(&stalled), "and be retried, not reported");
+        assert!(
+            !is_transport_error(&anyhow::anyhow!("downloaded encrypted blob hash mismatch")),
+            "a wrong answer from the peer is not retried"
+        );
     }
 
     /// The control plane is best-effort — `PeerRelayPool::send` drops frames

--- a/myco-core/src/content.rs
+++ b/myco-core/src/content.rs
@@ -2156,16 +2156,31 @@ impl Content {
         } else {
             declared_size.min(file_transfer::MAX_PACKAGE_BYTES)
         };
-        crate::dns_intercept::warm_route(sender_npub);
         let base = crate::ip_source::mesh_blossom_url(sender_npub);
         let url = format!("{base}/{blob_hash}");
+        // Nothing about this download is bounded by total time any more, so the
+        // row's own state is what ends it: the user cancelling, or the sweeper
+        // failing an expired offer, must stop the fetch rather than have it
+        // finish minutes later and publish a file that was called off.
+        let still_wanted =
+            || self.transfer_in_state(transfer_id, "incoming", sender_npub, &["downloading"]);
         // A mesh hop can be slow and can drop mid-body, so the fetch is bounded
         // by silence rather than by total time, and a cut connection is tried
         // again a few times before the transfer is failed.
         let mut attempt = 0;
         let package = loop {
             attempt += 1;
-            match Self::fetch_package(&url, limit, file_transfer::DOWNLOAD_IDLE_TIMEOUT).await {
+            // Re-warmed per attempt: a retry is usually a link that just
+            // flapped, and the route it flapped away from is the stale one.
+            crate::dns_intercept::warm_route(sender_npub);
+            match Self::fetch_package(
+                &url,
+                limit,
+                file_transfer::DOWNLOAD_IDLE_TIMEOUT,
+                &still_wanted,
+            )
+            .await
+            {
                 Ok(package) => break package,
                 Err(e) if attempt < file_transfer::DOWNLOAD_ATTEMPTS && is_transport_error(&e) => {
                     tracing::warn!(
@@ -2175,10 +2190,16 @@ impl Content {
                         "file share: download interrupted, retrying"
                     );
                     tokio::time::sleep(file_transfer::DOWNLOAD_RETRY_DELAY).await;
+                    if !still_wanted() {
+                        anyhow::bail!("transfer is no longer being downloaded");
+                    }
                 }
                 Err(e) => return Err(e),
             }
         };
+        if !still_wanted() {
+            anyhow::bail!("transfer is no longer being downloaded");
+        }
         if file_transfer::sha256_hex(&package) != blob_hash {
             anyhow::bail!("downloaded encrypted blob hash mismatch");
         }
@@ -2214,7 +2235,17 @@ impl Content {
     /// and while the body streams in, and failed if the peer goes quiet for
     /// [`file_transfer::DOWNLOAD_IDLE_TIMEOUT`] — not by total duration, which
     /// a large file over a slow Bluetooth hop legitimately exceeds.
-    async fn fetch_package(url: &str, limit: u64, idle: Duration) -> anyhow::Result<Vec<u8>> {
+    ///
+    /// `still_wanted` is asked between chunks, and answering `false` ends the
+    /// fetch. With no total bound, a peer trickling a byte before every idle
+    /// timeout would otherwise hold this task and its buffer for as long as it
+    /// liked, whatever the row said.
+    async fn fetch_package(
+        url: &str,
+        limit: u64,
+        idle: Duration,
+        still_wanted: &(dyn Fn() -> bool + Sync),
+    ) -> anyhow::Result<Vec<u8>> {
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(15))
             .build()?;
@@ -2241,6 +2272,9 @@ impl Content {
                 anyhow::bail!("peer sent more than the {limit} bytes it declared");
             }
             package.extend_from_slice(&chunk);
+            if !still_wanted() {
+                anyhow::bail!("transfer is no longer being downloaded");
+            }
         }
         Ok(package)
     }
@@ -3877,33 +3911,43 @@ mod tests {
         tokio::spawn(async move {
             // First request: 8 bytes, drip-fed slower than the old total cap
             // would scale to. Second: 8 bytes promised, 4 sent, then silence.
-            for stalls in [false, true] {
+            // Third: another trickle, for the abandoned case. Each is served on
+            // its own task, so the one that goes quiet does not hold up the
+            // next connection.
+            for stalls in [false, true, false] {
                 let (mut sock, _) = listener.accept().await.unwrap();
-                sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\n")
-                    .await
-                    .unwrap();
-                for i in 0..8u8 {
-                    if stalls && i == 4 {
-                        tokio::time::sleep(Duration::from_secs(5)).await;
-                        break;
+                tokio::spawn(async move {
+                    sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\n")
+                        .await
+                        .unwrap();
+                    for i in 0..8u8 {
+                        if stalls && i == 4 {
+                            tokio::time::sleep(Duration::from_secs(5)).await;
+                            break;
+                        }
+                        sock.write_all(&[i]).await.unwrap();
+                        sock.flush().await.unwrap();
+                        tokio::time::sleep(Duration::from_millis(150)).await;
                     }
-                    sock.write_all(&[i]).await.unwrap();
-                    sock.flush().await.unwrap();
-                    tokio::time::sleep(Duration::from_millis(150)).await;
-                }
+                });
             }
         });
         let url = format!("http://127.0.0.1:{port}/blob");
         let idle = Duration::from_millis(600);
 
-        let slow = Content::fetch_package(&url, 1024, idle).await.unwrap();
+        let wanted = || true;
+        let slow = Content::fetch_package(&url, 1024, idle, &wanted)
+            .await
+            .unwrap();
         assert_eq!(
             slow,
             (0..8u8).collect::<Vec<_>>(),
             "a trickle still completes"
         );
 
-        let stalled = Content::fetch_package(&url, 1024, idle).await.unwrap_err();
+        let stalled = Content::fetch_package(&url, 1024, idle, &wanted)
+            .await
+            .unwrap_err();
         assert!(
             stalled.to_string().starts_with("download stalled"),
             "silence must fail the fetch: {stalled}"
@@ -3912,6 +3956,20 @@ mod tests {
         assert!(
             !is_transport_error(&anyhow::anyhow!("downloaded encrypted blob hash mismatch")),
             "a wrong answer from the peer is not retried"
+        );
+
+        // Cancelled, or swept after the offer expired: the fetch stops instead
+        // of finishing minutes later and publishing a file nobody wants.
+        let abandoned = Content::fetch_package(&url, 1024, idle, &|| false)
+            .await
+            .unwrap_err();
+        assert!(
+            abandoned.to_string().starts_with("transfer is no longer"),
+            "a row that left `downloading` ends the fetch: {abandoned}"
+        );
+        assert!(
+            !is_transport_error(&abandoned),
+            "and is not treated as a connection fault worth retrying"
         );
     }
 

--- a/myco-core/src/file_transfer.rs
+++ b/myco-core/src/file_transfer.rs
@@ -21,6 +21,14 @@ pub const MAX_FILE_BYTES: usize = 64 * 1024 * 1024;
 /// paired peer cannot answer a small offer with an unbounded body.
 pub const MAX_PACKAGE_BYTES: u64 = MAX_FILE_BYTES as u64 + MAGIC.len() as u64 + 24 + 16;
 pub const OFFER_TTL_SECS: u64 = 10 * 60;
+/// The encrypted package download fails once the peer has sent nothing for
+/// this long. There is deliberately no cap on total duration: a multi-megabyte
+/// file over a Bluetooth hop takes minutes and is still making progress.
+pub const DOWNLOAD_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// How many times a download is started before the transfer is failed; a
+/// mesh link that flaps mid-body comes back within seconds.
+pub const DOWNLOAD_ATTEMPTS: u32 = 4;
+pub const DOWNLOAD_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 /// How many transfers this device will track at once. A Circle member that
 /// spams offers would otherwise grow `file_transfers.json` without bound; past
 /// this the oldest finished rows go first, and new offers are refused outright


### PR DESCRIPTION
## Symptom

Receiving a file of a megabyte or more over Bluetooth fails part-way with **"error decoding response body"** on the receiving phone; small files arrive fine.

## Root cause

`finish_incoming_transfer` builds its `reqwest` client with `.timeout(120 s)` — a cap on the *whole* request. A few MB over a BLE hop takes longer than that while still streaming steadily, so the body is cut mid-stream and reqwest surfaces it as a decoding error.

## Fix

- The fetch is bounded by **silence** instead: it fails once nothing has arrived for `DOWNLOAD_IDLE_TIMEOUT` (30 s), applied to the headers and to every chunk, with no total cap.
- A fetch that fails for a connection-side reason (timeout, connect, body cut, request error) is started again, up to `DOWNLOAD_ATTEMPTS` (4) with a 5 s gap — a mesh link that flaps mid-body is back within seconds. A wrong answer from the peer (non-2xx, size lie, hash mismatch) still fails the transfer immediately, so none of the #34 bounds are weakened: the declared-size cap is enforced exactly as before, per attempt.

## Tests

- `a_download_is_failed_by_silence_not_by_total_time` — a tiny TCP server drip-feeds an 8-byte body slower than the old cap would scale to (must complete), then promises 8 bytes, sends 4 and goes quiet (must fail as a stall the retry loop recognises); plus the classification check that a hash mismatch is *not* retried.
- On-device the symptom was seen with a 1.3 MB file laptop → Pixel over BLE; I'll confirm the fix on the same pair and note it here.

`cargo fmt --check`, `cargo test` green; clippy hits on this toolchain are the pre-existing ones on `main`. Independent of #37 (touches a different step of the same transfer).
