### PR TITLE
feat(android): join a FIPS hotspot as a local-only second connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Phones on the same Wi-Fi now find each other over the network instead of
+  Bluetooth. Myco announces itself on the local network the same way a fips
+  node does, so two phones — or a phone and a desktop — on one Wi-Fi connect
+  over UDP, which moves a file in seconds rather than minutes.
 - Send a file straight to a paired phone. Share anything from another app, pick
   one of your paired phones, and it arrives encrypted over the mesh — no
   hotspot, no internet. The receiving phone is asked first and can say no, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Dev: join a FIPS Wi-Fi hotspot (`!FIPS`) as a second, local-only connection
+  while staying on your normal internet Wi-Fi, so the phone can carry mesh
+  traffic over the hotspot without giving up its internet. Under Dev → Wi-Fi
+  AP. The system shows its usual join prompt.
 - Phones on the same Wi-Fi now find each other over the network instead of
   Bluetooth. Myco announces itself on the local network the same way a fips
   node does, so two phones — or a phone and a desktop — on one Wi-Fi connect

--- a/android/app/src/main/java/app/myco/ap/ApRadio.kt
+++ b/android/app/src/main/java/app/myco/ap/ApRadio.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.net.wifi.WifiNetworkSpecifier
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.net.wifi.WifiInfo
@@ -110,6 +111,15 @@ class ApRadio private constructor(private val context: Context) {
     private var advert: NsdManager.RegistrationListener? = null
     private var ssid: String? = null
 
+    /** A running local-only-STA request for a FIPS SSID, if the user asked for
+     *  one, and the [Network] it produced. The single UDP socket is pinned to
+     *  this network in preference to the default Wi-Fi while it is up — the
+     *  FIPS AP is where the mesh peers are — so the phone can stay on its
+     *  internet Wi-Fi and still carry mesh traffic over the FIPS link. */
+    private var localOnlyCallback: ConnectivityManager.NetworkCallback? = null
+    private var localOnlyNet: Network? = null
+    private var localOnlySsid: String? = null
+
     /** Pins this lane's UDP transport socket to the current Wi-Fi [Network] —
      *  see [UdpSocketPin] for why each lane needs a socket of its own. Asks
      *  for [LANE] by name, so it can only ever receive the LAN lane's socket,
@@ -134,7 +144,7 @@ class ApRadio private constructor(private val context: Context) {
                 startBrowse()
                 startAdvert()
             }
-            udpPin.bindTo(network)
+            repin()
             publishWifi()
         }
 
@@ -150,6 +160,103 @@ class ApRadio private constructor(private val context: Context) {
                 stopBrowse()
                 stopAdvert()
             }
+            repin()
+            publishWifi()
+        }
+    }
+
+    /** Pin the lane's UDP socket to the network mesh traffic should ride: the
+     *  local-only FIPS network when one is up (that is where the peers are),
+     *  otherwise the default Wi-Fi. Called on every network change so the
+     *  socket follows the FIPS link even if the default Wi-Fi reconnects
+     *  after it. */
+    private fun repin() {
+        (localOnlyNet ?: wifiNets.firstOrNull())?.let { udpPin.bindTo(it) }
+    }
+
+    /** Join a specific (open) SSID as a local-only second connection, so the
+     *  phone stays on its current internet Wi-Fi and reaches a FIPS access
+     *  point at the same time. Shows the system network-join prompt. A single
+     *  Wi-Fi radio associates with one SSID at a time, so on a device without
+     *  concurrent-STA support the framework may briefly move the whole radio;
+     *  on API 31+ hardware that supports it the two run side by side. Idempotent
+     *  per SSID — a second call for the same name is ignored. */
+    fun requestLocalOnly(targetSsid: String) {
+        handler.post {
+            if (localOnlyCallback != null && localOnlySsid == targetSsid) return@post
+            localOnlyCallback?.let { runCatching { connectivity.unregisterNetworkCallback(it) } }
+            val specifier = WifiNetworkSpecifier.Builder().setSsid(targetSsid).build()
+            val request = NetworkRequest.Builder()
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                // Local-only: the FIPS AP carries no internet, and asking for
+                // the capability would make the framework reject or tear down
+                // the request the moment it fails validation.
+                .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .setNetworkSpecifier(specifier)
+                .build()
+            val callback = object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    localOnlyNet = network
+                    if (wifiNets.add(network) && wifiNets.size == 1) {
+                        startBrowse()
+                        startAdvert()
+                    }
+                    repin()
+                    Log.i(TAG, "local-only network up for '$targetSsid'")
+                    publishWifi()
+                }
+
+                override fun onLost(network: Network) {
+                    if (localOnlyNet == network) localOnlyNet = null
+                    udpPin.clearTarget(network)
+                    if (wifiNets.remove(network) && wifiNets.isEmpty()) {
+                        ssid = null
+                        stopBrowse()
+                        stopAdvert()
+                    }
+                    repin()
+                    Log.i(TAG, "local-only network lost for '$targetSsid'")
+                    publishWifi()
+                }
+
+                override fun onUnavailable() {
+                    Log.w(TAG, "local-only request for '$targetSsid' was declined or timed out")
+                    if (localOnlyCallback === this) {
+                        localOnlyCallback = null
+                        localOnlySsid = null
+                    }
+                    publishWifi()
+                }
+            }
+            localOnlyCallback = callback
+            localOnlySsid = targetSsid
+            runCatching { connectivity.requestNetwork(request, callback, handler) }
+                .onFailure {
+                    Log.w(TAG, "requestNetwork for '$targetSsid' threw", it)
+                    localOnlyCallback = null
+                    localOnlySsid = null
+                }
+        }
+    }
+
+    /** Drop the local-only-STA request and fall back to the default Wi-Fi. */
+    fun releaseLocalOnly() {
+        handler.post {
+            val cb = localOnlyCallback ?: return@post
+            runCatching { connectivity.unregisterNetworkCallback(cb) }
+            localOnlyNet?.let { net ->
+                udpPin.clearTarget(net)
+                if (wifiNets.remove(net) && wifiNets.isEmpty()) {
+                    ssid = null
+                    stopBrowse()
+                    stopAdvert()
+                }
+            }
+            localOnlyNet = null
+            localOnlyCallback = null
+            localOnlySsid = null
+            repin()
+            Log.i(TAG, "local-only request released")
             publishWifi()
         }
     }
@@ -483,6 +590,8 @@ class ApRadio private constructor(private val context: Context) {
             connected = wifiNets.isNotEmpty(),
             ssid = currentSsid() ?: ssid,
             browsing = browsing,
+            localOnlySsid = localOnlySsid,
+            localOnlyUp = localOnlyNet != null,
         )
     }
 
@@ -546,6 +655,21 @@ class ApRadio private constructor(private val context: Context) {
         /** The LAN lane's fixed UDP port — `LAN_UDP_PORT` in `runtime.rs`. */
         private const val LAN_UDP_PORT = 4871
 
+        /** The open SSID a FIPS access point broadcasts. */
+        const val FIPS_SSID = "!FIPS"
+
+        /** Ask to join [targetSsid] as a local-only second connection so the
+         *  phone keeps its internet Wi-Fi and reaches a FIPS AP at once. Shows
+         *  the system join prompt. No-op until [ensureStarted]. */
+        fun requestLocalOnly(targetSsid: String = FIPS_SSID) {
+            instance?.requestLocalOnly(targetSsid)
+        }
+
+        /** Drop any local-only request and fall back to the default Wi-Fi. */
+        fun releaseLocalOnly() {
+            instance?.releaseLocalOnly()
+        }
+
         /** Retry cadence for an advert that could not be registered yet. */
         private const val ADVERT_RETRY_MS = 5_000L
 
@@ -580,6 +704,10 @@ data class WifiApView(
     val connected: Boolean = false,
     val ssid: String? = null,
     val browsing: Boolean = false,
+    /** The SSID of a requested local-only FIPS connection, if any. */
+    val localOnlySsid: String? = null,
+    /** Whether that local-only connection is currently up. */
+    val localOnlyUp: Boolean = false,
 )
 
 /** One fips node seen on the current LAN. `pushed` = handed to the core's

--- a/android/app/src/main/java/app/myco/ap/ApRadio.kt
+++ b/android/app/src/main/java/app/myco/ap/ApRadio.kt
@@ -25,15 +25,19 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * The `!FIPS` access-point lane. When the phone associates with a FIPS AP's
- * open `!FIPS` SSID (or any LAN carrying a fips node), this connects the app's
- * node to the AP's fips node over the ordinary UDP transport:
+ * The LAN lane (born as the `!FIPS` access-point lane). When the phone is on
+ * any Wi-Fi — a FIPS AP's open `!FIPS` SSID, or a home network shared with
+ * another Myco phone or a desktop — this connects the app's node to the other
+ * fips nodes there over the ordinary UDP transport:
  *
  *  1. watch infrastructure Wi-Fi via a [ConnectivityManager.NetworkCallback]
  *     (passive, permissionless);
  *  2. while any Wi-Fi is up, browse mDNS for `_fips._udp` — the advert fips
  *     LAN discovery publishes (`reference/fips` `src/discovery/lan`), whose
  *     TXT carries the node's `npub`;
+ *  2b. and publish the same advert for ourselves ([startAdvert]), so the
+ *     other side finds us too — two phones on one Wi-Fi meet here instead of
+ *     over BLE;
  *  3. on resolve, push `(npub, addr)` into the core's platform peer queue
  *     ([NativeCore.awarePeerFound], lane `"udp"`) — the same seam the Wi-Fi
  *     Aware radio uses, labelled with this lane's own name rather than
@@ -103,6 +107,7 @@ class ApRadio private constructor(private val context: Context) {
     private var resolving = false
     private var browsing = false
     private var browseListener: NsdManager.DiscoveryListener? = null
+    private var advert: NsdManager.RegistrationListener? = null
     private var ssid: String? = null
 
     /** Pins this lane's UDP transport socket to the current Wi-Fi [Network] —
@@ -111,8 +116,9 @@ class ApRadio private constructor(private val context: Context) {
      *  never Wi-Fi Aware's. */
     private val udpPin = UdpSocketPin(LANE, handler, TAG)
 
-    /** Own npub, to skip a self-advert (defensive — the app never publishes
-     *  mDNS, only browses). Resolved lazily; the core is up by first resolve. */
+    /** Own npub: skipped when it comes back from the browse as our own advert,
+     *  and carried in the advert we publish. Resolved lazily; the core is up by
+     *  first Wi-Fi, and [startAdvert] retries until it is. */
     private val ownNpub: String by lazy {
         runCatching { MycoCore.client(context).state().ownNpub }.getOrDefault("")
     }
@@ -124,7 +130,10 @@ class ApRadio private constructor(private val context: Context) {
         constructor(flags: Int) : super(flags)
 
         override fun onAvailable(network: Network) {
-            if (wifiNets.add(network) && wifiNets.size == 1) startBrowse()
+            if (wifiNets.add(network) && wifiNets.size == 1) {
+                startBrowse()
+                startAdvert()
+            }
             udpPin.bindTo(network)
             publishWifi()
         }
@@ -139,6 +148,7 @@ class ApRadio private constructor(private val context: Context) {
             if (wifiNets.remove(network) && wifiNets.isEmpty()) {
                 ssid = null
                 stopBrowse()
+                stopAdvert()
             }
             publishWifi()
         }
@@ -227,6 +237,68 @@ class ApRadio private constructor(private val context: Context) {
         npubByService.clear()
         publishNodes()
         publishWifi()
+    }
+
+    // --- mDNS advert ---
+
+    /** Publish our own `_fips._udp` advert on this Wi-Fi, so a peer browsing it
+     *  (another phone, a desktop, a fips node with LAN rendezvous on) learns
+     *  `(npub, this address, :4871)` and dials the LAN lane's socket directly.
+     *  Without this the lane was one-way: a phone could find an advertising
+     *  node but two phones on the same Wi-Fi never found each other, and fell
+     *  back to BLE at a fraction of the throughput.
+     *
+     *  The TXT mirrors the fips advert (`reference/fips` `src/mdns`): `npub`
+     *  and `v=1`, so the same browser code serves both. A fixed port is
+     *  advertised rather than the socket's: the core binds the LAN lane to
+     *  [LAN_UDP_PORT] unconditionally, and `NsdManager` needs a port at
+     *  registration time, before mesh is necessarily on. A dial that lands on
+     *  a closed port simply goes unanswered until the node is up. */
+    private fun startAdvert() {
+        if (advert != null || wifiNets.isEmpty()) return
+        val npub = ownNpub
+        if (npub.isEmpty()) {
+            handler.postDelayed({ startAdvert() }, ADVERT_RETRY_MS)
+            return
+        }
+        val info = NsdServiceInfo().apply {
+            serviceName = "myco-" + npub.takeLast(8)
+            serviceType = SERVICE_TYPE
+            port = LAN_UDP_PORT
+            setAttribute(TXT_NPUB, npub)
+            setAttribute("v", "1")
+        }
+        val listener = object : NsdManager.RegistrationListener {
+            override fun onServiceRegistered(registered: NsdServiceInfo) {
+                Log.i(TAG, "advert up: ${registered.serviceName} $SERVICE_TYPE:$LAN_UDP_PORT")
+            }
+
+            override fun onRegistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                Log.w(TAG, "advert failed ($errorCode); retrying")
+                handler.post {
+                    if (advert === this) advert = null
+                    handler.postDelayed({ startAdvert() }, ADVERT_RETRY_MS)
+                }
+            }
+
+            override fun onServiceUnregistered(serviceInfo: NsdServiceInfo) {}
+
+            override fun onUnregistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                Log.w(TAG, "advert unregister failed ($errorCode)")
+            }
+        }
+        advert = listener
+        runCatching { nsd.registerService(info, NsdManager.PROTOCOL_DNS_SD, listener) }
+            .onFailure {
+                Log.w(TAG, "advert registration threw", it)
+                advert = null
+                handler.postDelayed({ startAdvert() }, ADVERT_RETRY_MS)
+            }
+    }
+
+    private fun stopAdvert() {
+        advert?.let { runCatching { nsd.unregisterService(it) } }
+        advert = null
     }
 
     /** Periodic tick while the browse is live: advance an *unconnected* peer to
@@ -470,6 +542,12 @@ class ApRadio private constructor(private val context: Context) {
          *  nothing is connected, and an established session is worth far more
          *  than shaving seconds off finding one. */
         private const val REPUSH_MS = 35_000L
+
+        /** The LAN lane's fixed UDP port — `LAN_UDP_PORT` in `runtime.rs`. */
+        private const val LAN_UDP_PORT = 4871
+
+        /** Retry cadence for an advert that could not be registered yet. */
+        private const val ADVERT_RETRY_MS = 5_000L
 
         private val _wifi = MutableStateFlow(WifiApView())
         private val _nodes = MutableStateFlow<List<LanFipsNode>>(emptyList())

--- a/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/DevScreen.kt
@@ -166,10 +166,28 @@ fun DevScreen(state: AppState, client: AppCoreClient) {
                         apWifi.connected,
                     )
                     KeyValDot("mdns browse", if (apWifi.browsing) "active" else "idle", apWifi.browsing)
+                    KeyValDot(
+                        "local-only STA",
+                        apWifi.localOnlySsid?.let { if (apWifi.localOnlyUp) "up — $it" else "requested — $it" }
+                            ?: "off",
+                        apWifi.localOnlyUp,
+                    )
                     if (apNodes.isEmpty()) {
                         EmptyLine("no fips node on this lan")
                     } else {
                         apNodes.forEach { ApNodeRow(it) }
+                    }
+                    // Join a FIPS AP as a second, local-only connection while
+                    // staying on the current internet Wi-Fi. Shows the system
+                    // join prompt; local-only means no default route is taken.
+                    if (apWifi.localOnlySsid == null) {
+                        TextButton(onClick = { ApRadio.requestLocalOnly() }) {
+                            Text("Join a FIPS hotspot (${ApRadio.FIPS_SSID})")
+                        }
+                    } else {
+                        TextButton(onClick = { ApRadio.releaseLocalOnly() }) {
+                            Text("Leave the FIPS hotspot")
+                        }
                     }
                 }
                 // Stable alphabetical order — the state arrays arrive in snapshot


### PR DESCRIPTION
Stacked on #39 (the mDNS advert) — same lane, same file.

## What

Adds a **local-only second Wi-Fi connection** to the AP lane. `ApRadio.requestLocalOnly(ssid)` uses `WifiNetworkSpecifier` + `ConnectivityManager.requestNetwork()` (API 29+) to join an open FIPS SSID for local traffic **while the phone stays on its normal internet Wi-Fi**. Exposed under **Dev → Wi-Fi AP** as "Join a FIPS hotspot (`!FIPS`)" / "Leave the FIPS hotspot", with a local-only-STA status row.

## Why

The AP lane only browsed/advertised on whatever Wi-Fi was already up, so reaching a FIPS access point meant leaving your internet Wi-Fi to associate with the open `!FIPS` SSID. A single radio associates with one SSID at a time, but Android's local-only network request lets an app hold a second, internet-less connection to a named network — exactly the "stay online and also reach the FIPS AP" case.

## Notes for review

- The granted `Network` joins the same `wifiNets`/browse/advert bookkeeping as the default Wi-Fi. A new `repin()` pins the lane's single UDP socket to the **local-only network in preference** (that's where the mesh peers are) and re-applies on every network change, so a default-Wi-Fi reconnect can't steal the pin back.
- The request removes `NET_CAPABILITY_INTERNET` — the AP is local-only and the framework would otherwise tear the request down on failed internet validation.
- **Opt-in**: nothing joins automatically; the OS shows its standard join prompt when the button is tapped. Idempotent per SSID.
- No new permissions (`CHANGE_NETWORK_STATE`/`CHANGE_WIFI_STATE`/`ACCESS_WIFI_STATE` already declared). No core change.
- On hardware without concurrent-STA the framework may briefly move the whole radio; on API 31+ HW that supports it the two run side by side. Either way it's user-initiated.

## Testing

Validated end-to-end against a Walter board broadcasting `!FIPS`. On a concurrent-STA phone, Android put `!FIPS` on a second interface (`wlan1`, local-only, requestor app.myco) while `wlan0` kept the internet Wi-Fi — genuinely both at once. mDNS `_fips._udp` discovery fires over the local-only interface, the node dials UDP, and a mesh session forms with a fips node on the AP (a laptop on the same `!FIPS`) — confirmed as a `udp` peer, not BLE. `./gradlew assembleDebug` green.

