### PR TITLE
fix(android): self-heal the LAN mDNS browse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Phones on the same Wi-Fi now find each other over the network instead of
+  Bluetooth. Myco announces itself on the local network the same way a fips
+  node does, so two phones — or a phone and a desktop — on one Wi-Fi connect
+  over UDP, which moves a file in seconds rather than minutes.
 - Send a file straight to a paired phone. Share anything from another app, pick
   one of your paired phones, and it arrives encrypted over the mesh — no
   hotspot, no internet. The receiving phone is asked first and can say no, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Same-Wi-Fi peers that dropped off mDNS now reconnect on their own: the
+  discovery browse restarts periodically so a peer the phone quietly stopped
+  reporting is found again, instead of the connection staying dead.
+
 ### Added
 
 - Phones on the same Wi-Fi now find each other over the network instead of

--- a/android/app/src/main/java/app/myco/ap/ApRadio.kt
+++ b/android/app/src/main/java/app/myco/ap/ApRadio.kt
@@ -25,15 +25,19 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * The `!FIPS` access-point lane. When the phone associates with a FIPS AP's
- * open `!FIPS` SSID (or any LAN carrying a fips node), this connects the app's
- * node to the AP's fips node over the ordinary UDP transport:
+ * The LAN lane (born as the `!FIPS` access-point lane). When the phone is on
+ * any Wi-Fi — a FIPS AP's open `!FIPS` SSID, or a home network shared with
+ * another Myco phone or a desktop — this connects the app's node to the other
+ * fips nodes there over the ordinary UDP transport:
  *
  *  1. watch infrastructure Wi-Fi via a [ConnectivityManager.NetworkCallback]
  *     (passive, permissionless);
  *  2. while any Wi-Fi is up, browse mDNS for `_fips._udp` — the advert fips
  *     LAN discovery publishes (`reference/fips` `src/discovery/lan`), whose
  *     TXT carries the node's `npub`;
+ *  2b. and publish the same advert for ourselves ([startAdvert]), so the
+ *     other side finds us too — two phones on one Wi-Fi meet here instead of
+ *     over BLE;
  *  3. on resolve, push `(npub, addr)` into the core's platform peer queue
  *     ([NativeCore.awarePeerFound], lane `"udp"`) — the same seam the Wi-Fi
  *     Aware radio uses, labelled with this lane's own name rather than
@@ -103,6 +107,7 @@ class ApRadio private constructor(private val context: Context) {
     private var resolving = false
     private var browsing = false
     private var browseListener: NsdManager.DiscoveryListener? = null
+    private var advert: NsdManager.RegistrationListener? = null
     private var ssid: String? = null
 
     /** Pins this lane's UDP transport socket to the current Wi-Fi [Network] —
@@ -111,8 +116,9 @@ class ApRadio private constructor(private val context: Context) {
      *  never Wi-Fi Aware's. */
     private val udpPin = UdpSocketPin(LANE, handler, TAG)
 
-    /** Own npub, to skip a self-advert (defensive — the app never publishes
-     *  mDNS, only browses). Resolved lazily; the core is up by first resolve. */
+    /** Own npub: skipped when it comes back from the browse as our own advert,
+     *  and carried in the advert we publish. Resolved lazily; the core is up by
+     *  first Wi-Fi, and [startAdvert] retries until it is. */
     private val ownNpub: String by lazy {
         runCatching { MycoCore.client(context).state().ownNpub }.getOrDefault("")
     }
@@ -124,7 +130,10 @@ class ApRadio private constructor(private val context: Context) {
         constructor(flags: Int) : super(flags)
 
         override fun onAvailable(network: Network) {
-            if (wifiNets.add(network) && wifiNets.size == 1) startBrowse()
+            if (wifiNets.add(network) && wifiNets.size == 1) {
+                startBrowse()
+                startAdvert()
+            }
             udpPin.bindTo(network)
             publishWifi()
         }
@@ -139,6 +148,7 @@ class ApRadio private constructor(private val context: Context) {
             if (wifiNets.remove(network) && wifiNets.isEmpty()) {
                 ssid = null
                 stopBrowse()
+                stopAdvert()
             }
             publishWifi()
         }
@@ -227,6 +237,68 @@ class ApRadio private constructor(private val context: Context) {
         npubByService.clear()
         publishNodes()
         publishWifi()
+    }
+
+    // --- mDNS advert ---
+
+    /** Publish our own `_fips._udp` advert on this Wi-Fi, so a peer browsing it
+     *  (another phone, a desktop, a fips node with LAN rendezvous on) learns
+     *  `(npub, this address, :4871)` and dials the LAN lane's socket directly.
+     *  Without this the lane was one-way: a phone could find an advertising
+     *  node but two phones on the same Wi-Fi never found each other, and fell
+     *  back to BLE at a fraction of the throughput.
+     *
+     *  The TXT mirrors the fips advert (`reference/fips` `src/mdns`): `npub`
+     *  and `v=1`, so the same browser code serves both. A fixed port is
+     *  advertised rather than the socket's: the core binds the LAN lane to
+     *  [LAN_UDP_PORT] unconditionally, and `NsdManager` needs a port at
+     *  registration time, before mesh is necessarily on. A dial that lands on
+     *  a closed port simply goes unanswered until the node is up. */
+    private fun startAdvert() {
+        if (advert != null || wifiNets.isEmpty()) return
+        val npub = ownNpub
+        if (npub.isEmpty()) {
+            handler.postDelayed({ startAdvert() }, ADVERT_RETRY_MS)
+            return
+        }
+        val info = NsdServiceInfo().apply {
+            serviceName = "myco-" + npub.takeLast(8)
+            serviceType = SERVICE_TYPE
+            port = LAN_UDP_PORT
+            setAttribute(TXT_NPUB, npub)
+            setAttribute("v", "1")
+        }
+        val listener = object : NsdManager.RegistrationListener {
+            override fun onServiceRegistered(registered: NsdServiceInfo) {
+                Log.i(TAG, "advert up: ${registered.serviceName} $SERVICE_TYPE:$LAN_UDP_PORT")
+            }
+
+            override fun onRegistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                Log.w(TAG, "advert failed ($errorCode); retrying")
+                handler.post {
+                    if (advert === this) advert = null
+                    handler.postDelayed({ startAdvert() }, ADVERT_RETRY_MS)
+                }
+            }
+
+            override fun onServiceUnregistered(serviceInfo: NsdServiceInfo) {}
+
+            override fun onUnregistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                Log.w(TAG, "advert unregister failed ($errorCode)")
+            }
+        }
+        advert = listener
+        runCatching { nsd.registerService(info, NsdManager.PROTOCOL_DNS_SD, listener) }
+            .onFailure {
+                Log.w(TAG, "advert registration threw", it)
+                advert = null
+                handler.postDelayed({ startAdvert() }, ADVERT_RETRY_MS)
+            }
+    }
+
+    private fun stopAdvert() {
+        advert?.let { runCatching { nsd.unregisterService(it) } }
+        advert = null
     }
 
     /** Periodic tick while the browse is live: advance an *unconnected* peer to
@@ -470,6 +542,12 @@ class ApRadio private constructor(private val context: Context) {
          *  nothing is connected, and an established session is worth far more
          *  than shaving seconds off finding one. */
         private const val REPUSH_MS = 35_000L
+
+        /** The LAN lane's fixed UDP port — `LAN_UDP_PORT` in `runtime.rs`. */
+        private const val LAN_UDP_PORT = 4871
+
+        /** Retry cadence for an advert that could not be registered yet. */
+        private const val ADVERT_RETRY_MS = 5_000L
 
         private val _wifi = MutableStateFlow(WifiApView())
         private val _nodes = MutableStateFlow<List<LanFipsNode>>(emptyList())

--- a/android/app/src/main/java/app/myco/ap/ApRadio.kt
+++ b/android/app/src/main/java/app/myco/ap/ApRadio.kt
@@ -191,9 +191,19 @@ class ApRadio private constructor(private val context: Context) {
     private fun startBrowse() {
         if (browseListener != null) return
         // A DiscoveryListener is single-use: a fresh one per browse session.
+        //
+        // Every callback checks it is still the current listener before doing
+        // anything. [rediscover] replaces the listener on a timer, and the old
+        // one's callbacks keep arriving after the new browse is up: a stale
+        // `onDiscoveryStopped` would report we are not looking while we are, a
+        // stale `onStartDiscoveryFailed` would null out the live listener (so
+        // nothing could stop it and a second browse could start), and a stale
+        // `onServiceLost` would strand exactly the peer this restart exists to
+        // recover.
         val listener = object : NsdManager.DiscoveryListener {
             override fun onDiscoveryStarted(serviceType: String) {
                 handler.post {
+                    if (browseListener !== this) return@post
                     browsing = true
                     publishWifi()
                     // Remove-before-post: onDiscoveryStarted fires again on
@@ -209,6 +219,7 @@ class ApRadio private constructor(private val context: Context) {
 
             override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
                 handler.post {
+                    if (browseListener !== this) return@post
                     Log.w(TAG, "mDNS browse failed to start: $errorCode")
                     browseListener = null
                     browsing = false
@@ -218,21 +229,33 @@ class ApRadio private constructor(private val context: Context) {
 
             override fun onServiceFound(info: NsdServiceInfo) {
                 handler.post {
+                    if (browseListener !== this) return@post
                     resolveQueue.add(info)
                     pumpResolve()
                 }
             }
 
             override fun onServiceLost(info: NsdServiceInfo) {
-                handler.post { serviceLost(info.serviceName) }
+                handler.post {
+                    if (browseListener !== this) return@post
+                    serviceLost(info.serviceName)
+                }
             }
 
             override fun onDiscoveryStopped(serviceType: String) {
-                handler.post { browsing = false; publishWifi() }
+                handler.post {
+                    if (browseListener !== this) return@post
+                    browsing = false
+                    publishWifi()
+                }
             }
 
             override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
-                handler.post { browsing = false; publishWifi() }
+                handler.post {
+                    if (browseListener !== this) return@post
+                    browsing = false
+                    publishWifi()
+                }
             }
         }
         browseListener = listener

--- a/android/app/src/main/java/app/myco/ap/ApRadio.kt
+++ b/android/app/src/main/java/app/myco/ap/ApRadio.kt
@@ -185,7 +185,13 @@ class ApRadio private constructor(private val context: Context) {
                 handler.post {
                     browsing = true
                     publishWifi()
+                    // Remove-before-post: onDiscoveryStarted fires again on
+                    // every rediscover restart, so a bare postDelayed would
+                    // stack a fresh copy of each timer every cycle.
+                    handler.removeCallbacks(repush)
                     handler.postDelayed(repush, REPUSH_MS)
+                    handler.removeCallbacks(rediscover)
+                    handler.postDelayed(rediscover, REDISCOVER_MS)
                     Log.i(TAG, "mDNS browse started")
                 }
             }
@@ -227,6 +233,7 @@ class ApRadio private constructor(private val context: Context) {
         browseListener = null
         browsing = false
         handler.removeCallbacks(repush)
+        handler.removeCallbacks(rediscover)
         resolveQueue.clear()
         // The LAN is gone with the link: tell the core so it closes the pooled
         // UDP sessions instead of re-using dead sockets.
@@ -326,6 +333,28 @@ class ApRadio private constructor(private val context: Context) {
                 rotate(npub)
             }
             handler.postDelayed(this, REPUSH_MS)
+        }
+    }
+
+    /** Periodic mDNS self-heal. NsdManager routinely drops a service with a
+     *  spurious onServiceLost and then never re-announces it, which strands a
+     *  peer that is still on the LAN: [serviceLost] has removed it from every
+     *  map, [repush] has nothing left to rotate, and BLE may be down too, so
+     *  nothing re-dials — connectivity does not recover on its own.
+     *
+     *  Restarting discovery with a fresh listener makes NsdManager re-report
+     *  every service actually present now, so a dropped-but-live peer is
+     *  re-found, re-resolved and re-pushed. The peer maps are left intact and
+     *  no [awarePeerLost] is sent, so a healthy UDP session is untouched and a
+     *  still-present peer just re-pushes its address (deduped in [push]). */
+    private val rediscover = object : Runnable {
+        override fun run() {
+            if (browseListener != null && wifiNets.isNotEmpty()) {
+                browseListener?.let { runCatching { nsd.stopServiceDiscovery(it) } }
+                browseListener = null
+                startBrowse()
+            }
+            handler.postDelayed(this, REDISCOVER_MS)
         }
     }
 
@@ -548,6 +577,10 @@ class ApRadio private constructor(private val context: Context) {
 
         /** Retry cadence for an advert that could not be registered yet. */
         private const val ADVERT_RETRY_MS = 5_000L
+
+        /** How often the mDNS browse is restarted to recover peers NsdManager
+         *  dropped and never re-announced (see [rediscover]). */
+        private const val REDISCOVER_MS = 60_000L
 
         private val _wifi = MutableStateFlow(WifiApView())
         private val _nodes = MutableStateFlow<List<LanFipsNode>>(emptyList())


### PR DESCRIPTION
## Symptom

Two devices on the same Wi-Fi would connect over the LAN lane, then a few minutes later drop and **never reconnect on their own** — even though both were still on the network and still advertising. Observed directly: a phone discovered the daemon over mDNS, dialled it, and later logged `gone from LAN`, after which nothing re-dialled (BLE was also down).

## Root cause

`NsdManager` routinely fires a **spurious `onServiceLost`** and then never re-announces the service. `serviceLost()` removes the peer from every `ApRadio` map, so the `repush` timer has nothing left to rotate, and recovery depends entirely on `NsdManager` re-firing `onServiceFound` — which it doesn't. The connection stays dead.

## Fix

`ApRadio` restarts discovery every 60 s with a fresh listener (`rediscover`). A fresh `discoverServices` re-reports every service actually present, so a dropped-but-live peer is re-found, re-resolved and re-pushed. Crucially it **leaves the peer maps intact and sends no `awarePeerLost`**, so a healthy UDP session rides through the restart untouched. The `repush`/`rediscover` timers are removed-before-posted (each `onDiscoveryStarted` re-fires on restart, so a bare `postDelayed` would stack copies).

## Testing

Device-verified (phone + laptop daemon on one Wi-Fi): the 60 s restart fires (`mDNS browse started` three times in ~2 min); an advert lapse in the same window logs `session still up — keeping it`; and the daemon keeps the phone as a `udp` peer throughout. `./gradlew assembleDebug` green. Kotlin-only, no new permissions, no core change.

Stacked on #40 (same lane, same file).
