### PR TITLE
fix: stop calling a peer "Wi-Fi Aware" when Aware is neither carrying it nor running

### DIFF
--- a/android/app/src/main/java/app/myco/aware/AwareRadio.kt
+++ b/android/app/src/main/java/app/myco/aware/AwareRadio.kt
@@ -259,6 +259,16 @@ class AwareRadio(
     /** Drop NDPs + discovery + attach, but keep the availability watch (so the
      *  lane re-attaches if Aware flaps back). Called on availability loss. */
     private fun closeSessions() {
+        // Withdraw first, while the slots and the live set still say who was
+        // here. Unregistering a NetworkCallback delivers no `onLost`, and that
+        // callback is the only place this lane tells the core a peer is gone —
+        // so without this the core kept the pooled UDP session and the lane
+        // record went on labelling those peers "Wi-Fi Aware" long after the
+        // radio stopped. The LAN lane withdraws the same way when its browse
+        // stops (`ApRadio.stopBrowse`).
+        for (npub in liveNdps) {
+            NativeCore.awarePeerLost(npub, laneFor(slotPool.slotOf(npub) ?: 0))
+        }
         for ((_, cb) in ndpCallbacks) runCatching { connectivity.unregisterNetworkCallback(cb) }
         ndpCallbacks.clear()
         for ((_, st) in retries) st.pending?.let { handler.removeCallbacks(it) }

--- a/myco-core/src/peer_diagnostics.rs
+++ b/myco-core/src/peer_diagnostics.rs
@@ -76,10 +76,12 @@ fn short(s: &str) -> String {
 ///
 /// `lane_by_npub` is a lane-origin override (npub → observed lane, e.g.
 /// `"aware"`), consulted in preference to the raw fips-reported transport
-/// name. It exists because Wi-Fi Aware and the LAN/AP lane both ride fips's
-/// plain UDP transport and are indistinguishable from `PeerView.transport`
-/// alone — only the Kotlin radio push site knows which one carried a given
-/// peer. Empty in plan 01-01 (every transport passes through as fips
+/// name **where that name is `udp`**. It exists because Wi-Fi Aware and the
+/// LAN/AP lane both ride fips's plain UDP transport and are indistinguishable
+/// from `PeerView.transport` alone — only the Kotlin radio push site knows
+/// which one carried a given peer. It says nothing about any other transport:
+/// the radio that observed a peer is not necessarily the one carrying it, so
+/// a link fips reports as BLE stays BLE. Empty in plan 01-01 (every transport passes through as fips
 /// reported it, unmodified); plan 01-02 populates it from
 /// `aware_bridge_jni.rs`. Never inferred from address shape (e.g.
 /// link-local vs. routable) — that would be exactly the sort of
@@ -135,11 +137,22 @@ pub fn merge_peers(
         let name = pv
             .map(|p| truncate_chars(&p.display_name, 64))
             .unwrap_or_default();
-        let transport = lane_by_npub
-            .get(&bp.npub)
-            .cloned()
-            .or_else(|| pv.map(|p| p.transport.clone()))
-            .unwrap_or_default();
+        // The lane record disambiguates fips's *UDP* transport — the one thing
+        // Wi-Fi Aware and the LAN lane both ride — so it applies only where
+        // fips reports UDP. It records which radio observed a peer, which is
+        // not a claim about what carries the session: an Aware data path can
+        // come up beside a link fips is carrying over BLE, and fips keeps the
+        // link it has. Letting the record win there labelled a 750 B/s BLE
+        // session "Wi-Fi Aware" for as long as the row lived.
+        let fips_transport = pv.map(|p| p.transport.clone()).unwrap_or_default();
+        let transport = if fips_transport == "udp" {
+            lane_by_npub
+                .get(&bp.npub)
+                .cloned()
+                .unwrap_or(fips_transport)
+        } else {
+            fips_transport
+        };
         let last_seen_ms = pv.map(|p| p.last_seen_ms).unwrap_or(0);
         let authenticated_at_ms = pv.map(|p| p.authenticated_at_ms).unwrap_or(0);
         // `None` both when there is no PeerView and when MMP has not measured
@@ -1014,6 +1027,38 @@ mod tests {
         );
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].transport, "aware");
+    }
+
+    /// A lane record is an observation by a radio, not a statement about the
+    /// link. Aware can bring a data path up beside a session fips is already
+    /// carrying over BLE — fips keeps the link it has (`API connect resolved
+    /// against an already-connected peer`) — and the row then claimed "Wi-Fi
+    /// Aware" over a 750 B/s Bluetooth session, and went on claiming it after
+    /// the Aware radio was switched off.
+    #[test]
+    fn a_lane_record_does_not_relabel_a_link_fips_carries_elsewhere() {
+        let views = vec![pv("a1", "npub-ble", true, 1_000, "ble")];
+        let peers = vec![bp("a1", "npub-ble", true)];
+        let mut lane_by_npub = HashMap::new();
+        lane_by_npub.insert("npub-ble".to_string(), "aware".to_string());
+        let out = merge_peers(
+            &views,
+            &peers,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &lane_by_npub,
+            &HashMap::new(),
+            &[],
+            0,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].transport, "ble",
+            "the lane record disambiguates UDP; it does not overrule the link"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

On a Galaxy A52s, a peer row read **Wi-Fi Aware** while the session was a ~750 B/s Bluetooth link — and kept reading it after Wi-Fi Aware was switched off in settings.

## Root cause

Two independent faults, one either side of the JNI seam.

**The lane record overruled the link.** `lane_by_npub` answers "which radio observed this peer". `merge_peers` consulted it in preference to whatever transport fips reported. But an Aware data path can come up beside a link fips is already carrying, and fips keeps the link it has. From the device log, for the same peer:

```
MycoAwareRadio: Aware NDP up to npub1ljqc795… at [fe80::…]:4872 (slot 0)
fips::control::commands: API connect requested  … transport=udp/aware0
fips::node::lifecycle: API connect resolved against an already-connected peer … refreshed=true
```

…while every connection for that peer before and after read `remote_addr=ble0/60:13:7F:F8:1D:8C`, and MMP reported `rtt=156.4ms goodput=746B/s` — Bluetooth, not Wi-Fi.

**The record was never cleared.** `AwareRadio.closeSessions()` unregisters the NDP network callbacks, and unregistering delivers no `onLost` — which is the only site that calls `awarePeerLost` for this lane. So the core kept the pooled UDP session, and the stale record kept labelling the row.

## Fix

- The lane record is consulted only where fips reports `udp` — the one transport Aware and the LAN lane both ride, and the only reason they are confusable. A link fips calls `ble` stays `ble`.
- `closeSessions()` withdraws each live NDP peer before dropping the callbacks, the way the LAN lane already does in `ApRadio.stopBrowse`.

## Tests

- `a_lane_record_does_not_relabel_a_link_fips_carries_elsewhere` — a BLE-carried peer with an `aware` lane record renders as `ble`. The two existing lane tests still pass: an `udp` link with a record still resolves to the record, and one without still falls back.
- The Kotlin half is a lifecycle path with no host test; `./gradlew assembleDebug` green.

## Not fixed here

The reason the session was on Bluetooth at all. fips does promote an already-connected peer onto a better path, and over the LAN lane it does so in 12 ms — but the same handshake deadlocks on the Aware NDP, where msg1 crosses in both directions and msg2 in neither. Filed as #45; it is a fips-side transport bug, and the Aware path stays genuinely unusable until it is fixed.