### PR TITLE
fix(ui): add clear icon to FirstRunNameDialog for easier name management

### DIFF
--- a/android/app/src/main/java/app/myco/ui/FirstRunNameDialog.kt
+++ b/android/app/src/main/java/app/myco/ui/FirstRunNameDialog.kt
@@ -4,7 +4,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -56,6 +60,16 @@ fun FirstRunNameDialog(ownNpub: String, onDone: (String) -> Unit) {
                     onValueChange = { name = it.take(DeviceName.MAX_LENGTH) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
+                    trailingIcon = {
+                        if (name.isNotEmpty()) {
+                            IconButton(onClick = { name = "" }) {
+                                Icon(
+                                    Icons.Filled.Clear,
+                                    contentDescription = "Clear name",
+                                )
+                            }
+                        }
+                    },
                 )
                 Spacer(Modifier.height(10.dp))
                 NameSuggestions(ownNpub, name) { name = it }


### PR DESCRIPTION
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/aff3c66a-f574-4a26-97bf-fcd428a649c4" />


Add a delete icon so i dont need to keep pressing delete button on keyboard :D