### PR TITLE
fix(ui): invite a nearby peer under their name, not your own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   needing a shared Wi-Fi.
 ### Fixed
 
+- Inviting someone from Nearby no longer labels them with your own device
+  name. The tap recorded your name against their npub, so the "invite sent"
+  pop-up — and their bubble everywhere else — read back as you. The invite now
+  carries the name they told us, and nothing at all when they have told us
+  none, so their real name still wins once it arrives.
 - Same-Wi-Fi peers that dropped off mDNS now reconnect on their own: the
   discovery browse restarts periodically so a peer the phone quietly stopped
   reporting is found again, instead of the connection staying dead.

--- a/android/app/src/main/java/app/myco/ui/MycoApp.kt
+++ b/android/app/src/main/java/app/myco/ui/MycoApp.kt
@@ -229,7 +229,10 @@ fun MycoApp(
         val added = current - knownInvites.value
         if (added.isNotEmpty()) {
             state.outboundPairs.firstOrNull { it.npub in added }?.let {
-                justInvited = it.name.ifEmpty { "them" }
+                // Resolve the name the same way every other surface does, so an
+                // invite recorded without one says the peer's npub-derived name
+                // rather than borrowing whatever string happened to be stored.
+                justInvited = peerLabel(state, it.npub)
             }
         }
         knownInvites.value = current

--- a/android/app/src/main/java/app/myco/ui/PeerLabel.kt
+++ b/android/app/src/main/java/app/myco/ui/PeerLabel.kt
@@ -4,30 +4,38 @@ import app.myco.core.AppState
 import app.myco.share.DeviceName
 
 /**
- * What to call a peer on screen — the name *they* chose, whenever we have
- * actually been told it.
+ * The name a peer has actually told us, or null when they have told us nothing.
  *
  * A device's chosen name reaches us only inside pair traffic: the Circle entry
  * written when pairing completed, the pending request they sent us, or the
  * invite we sent them (which echoes the name they were showing at the time).
- * Those are checked in that order — most recently confirmed first — and the
- * npub-derived name is the floor, not the default.
+ * Those are checked in that order — most recently confirmed first.
  *
  * Below those sits the name a peer broadcasts for itself in its BLE scan
- * response. It is deliberately last-but-one: it is an unauthenticated plaintext
+ * response. It is deliberately last: it is an unauthenticated plaintext
  * broadcast that anyone in range can forge, so it may fill a gap but must never
  * displace a name that arrived signed. It is also BLE-only — a peer found over
  * Wi-Fi Aware or the LAN carries none.
  *
- * The npub-derived name remains the floor, for a peer that has told us nothing
- * at all. It is at least the same two words on both screens.
+ * Null means "we do not know", which is not the same as the npub-derived
+ * placeholder [peerLabel] falls back to. Anything we *store* about a peer must
+ * use this, never the placeholder: a stored placeholder outranks the real name
+ * when it finally arrives.
  */
-fun peerLabel(state: AppState, npub: String): String {
-    if (npub.isEmpty()) return DeviceName.generated(npub)
+fun peerNameOrNull(state: AppState, npub: String): String? {
+    if (npub.isEmpty()) return null
     val told = state.circle.firstOrNull { it.npub == npub }?.name
         ?: state.pendingPairRequests.firstOrNull { it.npub == npub }?.name
         ?: state.outboundPairs.firstOrNull { it.npub == npub }?.name
     told?.trim()?.ifBlank { null }?.let { return it }
-    val advertised = state.peers.firstOrNull { it.npub == npub }?.advertisedName
-    return advertised?.trim()?.ifBlank { null } ?: DeviceName.generated(npub)
+    return state.peers.firstOrNull { it.npub == npub }?.advertisedName?.trim()?.ifBlank { null }
 }
+
+/**
+ * What to call a peer on screen — the name *they* chose whenever we have
+ * actually been told it (see [peerNameOrNull]), and otherwise the npub-derived
+ * name, which is the floor rather than the default. It is at least the same two
+ * words on both screens.
+ */
+fun peerLabel(state: AppState, npub: String): String =
+    peerNameOrNull(state, npub) ?: DeviceName.generated(npub)

--- a/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
+++ b/android/app/src/main/java/app/myco/ui/screens/CircleScreen.kt
@@ -91,6 +91,7 @@ import app.myco.ui.TransferCard
 import app.myco.ui.isLive
 import app.myco.ui.needsAttention
 import app.myco.ui.peerLabel
+import app.myco.ui.peerNameOrNull
 import app.myco.ui.theme.StatusConnected
 import app.myco.ui.theme.avatarColorFor
 
@@ -226,8 +227,17 @@ fun CircleScreen(
                                 dim = false,
                                 onClick = if (isSent) null else {
                                     {
+                                        // Their name, never ours: the invite record is
+                                        // what the pending dialog reads back, and what
+                                        // peerLabel() trusts as a name they told us.
+                                        // Empty when they have told us nothing, so a
+                                        // placeholder can't outrank the real name later.
                                         client.dispatch(
-                                            NativeActions.sendPairRequest(peer.npub, name, NsiteShare.newPairSecret())
+                                            NativeActions.sendPairRequest(
+                                                peer.npub,
+                                                peerNameOrNull(state, peer.npub).orEmpty(),
+                                                NsiteShare.newPairSecret(),
+                                            )
                                         )
                                     }
                                 },

--- a/android/app/src/test/java/app/myco/ui/PeerLabelTest.kt
+++ b/android/app/src/test/java/app/myco/ui/PeerLabelTest.kt
@@ -1,0 +1,116 @@
+package app.myco.ui
+
+import app.myco.core.AppState
+import app.myco.core.CacheStatus
+import app.myco.core.CircleContact
+import app.myco.core.OutboundPair
+import app.myco.core.PairRequest
+import app.myco.core.PeerDiagnostic
+import app.myco.share.DeviceName
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Peer names are the one thing on these screens a user can check against
+ * another phone in their hand, so the precedence has to hold: a name they told
+ * us over signed pair traffic first, an unauthenticated BLE advert only to fill
+ * a gap, and the npub-derived placeholder as a floor that is never stored.
+ */
+class PeerLabelTest {
+
+    private val them = "npub1" + "%059x".format(1)
+
+    private fun state(
+        circle: List<CircleContact> = emptyList(),
+        pending: List<PairRequest> = emptyList(),
+        outbound: List<OutboundPair> = emptyList(),
+        peers: List<PeerDiagnostic> = emptyList(),
+    ) = AppState(
+        rev = 1,
+        error = "",
+        appVersion = "test",
+        ownNpub = "npub1" + "%059x".format(99),
+        ownPubkeyHex = "",
+        nodeAddrHex = "",
+        fipsAddr = "",
+        fipsIpv6 = "",
+        fipsMtu = 0,
+        nodeRunning = false,
+        nodeStatus = "",
+        bleEnabled = false,
+        bleRole = "",
+        bleScanning = false,
+        bleAdapterName = "",
+        blePeers = emptyList(),
+        bleAdverts = emptyList(),
+        wifiAwareEnabled = false,
+        wifiAwarePort = 0,
+        sites = emptyList(),
+        library = emptyList(),
+        cache = CacheStatus(relayEvents = 0, blobCount = 0, usedBytes = 0),
+        circle = circle,
+        discovered = emptyList(),
+        pendingPairRequests = pending,
+        outboundPairs = outbound,
+        offlineOnly = true,
+        peers = peers,
+    )
+
+    private fun advert(npub: String, advertisedName: String) = PeerDiagnostic(
+        key = npub,
+        npub = npub,
+        nodeAddrHex = "",
+        bleAddr = "",
+        name = "",
+        state = "connected",
+        transport = "ble",
+        lastSeenMs = 0,
+        advertisedName = advertisedName,
+        rssi = null,
+        psm = 0,
+        pairState = "",
+        inCircle = false,
+    )
+
+    @Test
+    fun `a name they told us wins over what they broadcast`() {
+        val s = state(
+            circle = listOf(CircleContact(npub = them, name = "Redmi Note 8 Pro", addedAt = 0)),
+            peers = listOf(advert(them, "forged name")),
+        )
+        assertEquals("Redmi Note 8 Pro", peerLabel(s, them))
+    }
+
+    @Test
+    fun `an advertised name fills a gap when nothing signed has arrived`() {
+        assertEquals("their pixel", peerLabel(state(peers = listOf(advert(them, "their pixel"))), them))
+    }
+
+    @Test
+    fun `an invite recorded without a name does not become that peer's name`() {
+        // The nearby-tap invite used to store *our own* device name here, which
+        // peerLabel then read back as the name they had told us.
+        val s = state(
+            outbound = listOf(OutboundPair(npub = them, name = "", since = 0)),
+            peers = listOf(advert(them, "their pixel")),
+        )
+        assertNull(peerNameOrNull(state(outbound = listOf(OutboundPair(them, "", 0))), them))
+        assertEquals("their pixel", peerLabel(s, them))
+    }
+
+    @Test
+    fun `an unknown peer falls back to its npub-derived name, not to nothing`() {
+        assertNull(peerNameOrNull(state(), them))
+        assertEquals(DeviceName.generated(them), peerLabel(state(), them))
+    }
+
+    @Test
+    fun `a blank name is treated as no name at all`() {
+        val s = state(
+            circle = listOf(CircleContact(npub = them, name = "   ", addedAt = 0)),
+            peers = listOf(advert(them, "their pixel")),
+        )
+        assertEquals("their pixel", peerLabel(s, them))
+    }
+}


### PR DESCRIPTION
Nearby pairing sent this phone’s name as the invitee’s, making peers appear under your own name.

Use peerNameOrNull() to send the peer’s known name, or nothing. Keep npub-derived names display-only so placeholders never override real names. The pending-invite dialog now uses the same label resolution as other surfaces.
