### PR TITLE
build: add a Nix flake for the toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A Nix flake for the toolchain (`nix develop` for the Rust host shell,
+  `nix develop .#android` for the Android SDK/NDK/JDK 17/Gradle/adb shell), so a
+  NixOS or nix-enabled machine gets a working build environment without a manual
+  rustup/SDK-manager install. See `docs/how-to/build.md` §1.
 - Send a file from the Circle tab: tapping a paired contact now offers
   "Send a file" next to their npub and "Remove from circle". Pick the files
   and they go out the same encrypted mesh transfer the system Sharesheet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,10 @@ to produce the native library. `minSdk` is 29 (the L2CAP CoC floor).
 Install a debug build on a connected device with
 `./gradlew installDebug`.
 
+With Nix, `nix develop` gives you the Rust host toolchain and
+`nix develop .#android` adds the Android SDK/NDK, JDK 17, Gradle and
+adb — see [docs/how-to/build.md](docs/how-to/build.md) §1.
+
 ## Choosing a branch to target
 
 Myco is single-trunk: branch off the latest **`main`**, and open your

--- a/docs/how-to/build.md
+++ b/docs/how-to/build.md
@@ -27,15 +27,45 @@ For the system this build produces, see
 The toolchain matches the two reference projects. The fastest path is Nix; a
 manual install is also fine.
 
-### Option A — Nix (optional, recommended)
+### Option A — Nix (recommended)
+
+`flake.nix` at the repo root ships two dev shells:
 
 ```sh
-nix develop          # provides Rust, cargo-ndk, NDK, JDK 17, Gradle, just, adb
+nix develop            # host shell: Rust (+ aarch64-linux-android target), clippy,
+                       # rustfmt, rust-analyzer, just, clang/libclang, dbus —
+                       # enough for `just test` and `cargo fmt --check`
+nix develop .#android  # the above + Android SDK (platforms 29 + 36, build-tools
+                       # 35/36), NDK 26.1.10909125, cargo-ndk, JDK 17, Gradle, adb
 ```
 
-A Nix dev shell would provide Rust, cargo-ndk, the Android NDK, JDK 17, Gradle,
-just and adb. A `flake.nix` for Myco is **TBD / open** — until it lands, use
-Option B.
+The Android shell exports `ANDROID_HOME`, `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`,
+`ANDROID_NDK_ROOT` and `JAVA_HOME`, so no `local.properties` is needed. It also
+sets `GRADLE_OPTS=-Dorg.gradle.project.android.aapt2FromMavenOverride=…`: without
+it AGP downloads an `aapt2` from Maven that cannot run on NixOS.
+
+Both shells export `LIBCLANG_PATH` (bindgen, via fips' `rustables` dependency)
+and carry dbus, which fips' Linux BLE backend (bluer) needs to link
+`libdbus-sys` — the same `libdbus-1-dev` the Rust CI job installs. Both also
+default `MYCO_FIPS_REPO_PATH` to `reference/fips` when that checkout is present,
+warning when it is not (§4).
+
+Two things the flake deliberately does **not** do:
+
+- **No `packages` output.** The workspace depends on `fips` as a path dependency
+  at `reference/fips` — a local, gitignored checkout — so a hermetic Nix build of
+  the crates is impossible. The flake provides the toolchain; cargo and Gradle
+  still drive the build.
+- **No udev rules.** `adb` is in the shell, but device access needs
+  `programs.adb.enable = true` (and your user in the `adbusers` group) in the
+  host NixOS configuration — a dev shell cannot grant that.
+
+Note that the flake sets `allowUnfree` and `android_sdk.accept_license` in its
+own nixpkgs import, so entering the Android shell accepts Google's SDK licence
+without touching your user or system config.
+
+Pins live at the top of `flake.nix` (`ndkVersion`, `platformVersions`,
+`buildToolsVersions`); keep them in sync with `android/app/build.gradle.kts`.
 
 ### Option B — manual install
 
@@ -369,7 +399,6 @@ two-device demo: [run-two-device-demo.md](./run-two-device-demo.md).
   candidates, the per-peer PSM change is a wire-breaking proposal to weigh with
   upstream, and the macOS `BleIo` reuse stays a local test-only patch — vs. carrying
   them all on the local checkout. **Tracked in §4c / roadmap P0–P1.**
-- **`flake.nix`:** Myco has no Nix dev shell yet. **TBD / open.**
 - **`compileSdk`/`targetSdk`:** proposed at 36 to match reference; not yet pinned
   for Myco. **TBD / open.**
 - **Canonical build driver (§3):** Gradle-driven `Exec` task vs. `just ndk-build`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788765185,
+        "narHash": "sha256-pp8lb5CrKjmscZbTK34HuCaq18zDU4Q6zlaD5dS+Hi4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ca7f624be3935a5bc46d2c240515491ab8675503",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,177 @@
+# Myco — Nix dev shells for the toolchain described in docs/how-to/build.md §1.
+#
+#   nix develop            host Rust shell: `just test`, `cargo fmt/clippy/test`
+#   nix develop .#android  the above + Android SDK/NDK/JDK 17/Gradle/adb
+#
+# There is deliberately no `packages` output: the workspace depends on `fips`
+# as a path dependency at reference/fips — a local, gitignored checkout — so a
+# hermetic Nix build of the crates is not possible. These shells provide the
+# toolchain; cargo and Gradle still drive the build.
+{
+  description = "Myco — offline-first P2P nsite mesh over BLE (Rust core + Android app) toolchain";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      rust-overlay,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+
+      # x86_64-darwin is omitted: nixpkgs 26.11 has dropped it, and the Android
+      # SDK archives androidenv resolves have no x86_64-darwin variant either.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = f: lib.genAttrs systems (system: f system);
+
+      # --- Version pins (keep in sync with android/app/build.gradle.kts) ---
+      ndkVersion = "26.1.10909125"; # docs/how-to/build.md §1
+      # compileSdk / targetSdk = 36; minSdk 29 kept for lint + docs of the floor.
+      platformVersions = [
+        "29"
+        "36"
+      ];
+      # 36.0.0 matches compileSdk 36; 35.0.0 is AGP 8.11's default request.
+      buildToolsVersions = [
+        "35.0.0"
+        "36.0.0"
+      ];
+      aapt2BuildTools = "36.0.0";
+
+      pkgsFor =
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+          config = {
+            allowUnfree = true; # the Android SDK is unfree
+            android_sdk.accept_license = true;
+          };
+        };
+
+      # Stable Rust plus the cross target the cargo-ndk build needs. `rust-src`
+      # and `rust-analyzer` are here so editors work inside the shell.
+      rustToolchainFor =
+        pkgs:
+        pkgs.rust-bin.stable.latest.default.override {
+          extensions = [
+            "rust-src"
+            "rust-analyzer"
+          ];
+          targets = [ "aarch64-linux-android" ];
+        };
+
+      androidCompositionFor =
+        pkgs:
+        pkgs.androidenv.composeAndroidPackages {
+          inherit platformVersions buildToolsVersions;
+          cmdLineToolsVersion = "13.0";
+          platformToolsVersion = "37.0.1";
+          includeNDK = true;
+          ndkVersions = [ ndkVersion ];
+          abiVersions = [ "arm64-v8a" ]; # arm64-v8a only (LOCKED)
+          includeEmulator = false; # no emulator target — BLE/L2CAP need real devices
+          includeSystemImages = false;
+          includeCmake = false; # the Rust build uses cargo-ndk, not the SDK's CMake
+        };
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          rustToolchain = rustToolchainFor pkgs;
+
+          # `rustables` (via fips) runs bindgen; `ring` / `secp256k1-sys` run cc.
+          libclang = pkgs.llvmPackages.libclang;
+
+          hostPackages = [
+            rustToolchain
+            pkgs.just
+            pkgs.pkg-config
+            pkgs.clang
+            libclang.lib
+          ];
+
+          # fips' Linux BLE backend (bluer) links libdbus-sys, so a host build
+          # needs dbus on the pkg-config path — CI's `libdbus-1-dev`. The Android
+          # cross-build does not: there fips uses AndroidBleIo, not bluer.
+          hostBuildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.dbus ];
+
+          hostEnv = ''
+            export LIBCLANG_PATH="${libclang.lib}/lib"
+
+            # The workspace's `fips` path dependency (gitignored local checkout).
+            if [ -z "''${MYCO_FIPS_REPO_PATH:-}" ] && [ -f "$PWD/reference/fips/Cargo.toml" ]; then
+              export MYCO_FIPS_REPO_PATH="$PWD/reference/fips"
+            fi
+            if [ ! -f "''${MYCO_FIPS_REPO_PATH:-$PWD/reference/fips}/Cargo.toml" ]; then
+              echo "warning: no fips checkout at reference/fips — nothing will build." >&2
+              echo "         See docs/how-to/build.md §4 (upstream: github.com/k0sti/fips)." >&2
+            fi
+          '';
+        in
+        {
+          default = pkgs.mkShell {
+            name = "myco";
+            packages = hostPackages;
+            buildInputs = hostBuildInputs;
+            shellHook = hostEnv + ''
+              echo "myco host shell — rustc $(rustc --version | cut -d' ' -f2), just $(just --version | cut -d' ' -f2)"
+              echo "  just test      host build + Rust unit tests"
+              echo "  nix develop .#android   for the APK toolchain"
+            '';
+          };
+
+          android =
+            let
+              androidComposition = androidCompositionFor pkgs;
+              androidSdk = "${androidComposition.androidsdk}/libexec/android-sdk";
+            in
+            pkgs.mkShell {
+              name = "myco-android";
+              packages = hostPackages ++ [
+                pkgs.cargo-ndk
+                pkgs.jdk17
+                pkgs.gradle
+                pkgs.android-tools # adb
+                androidComposition.androidsdk
+              ];
+              buildInputs = hostBuildInputs;
+
+              ANDROID_HOME = androidSdk;
+              ANDROID_SDK_ROOT = androidSdk;
+              ANDROID_NDK_HOME = "${androidSdk}/ndk/${ndkVersion}";
+              ANDROID_NDK_ROOT = "${androidSdk}/ndk/${ndkVersion}";
+              JAVA_HOME = pkgs.jdk17.home;
+
+              # AGP otherwise downloads an aapt2 from Maven that cannot run on
+              # NixOS; point it at the SDK's patched binary instead.
+              GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidSdk}/build-tools/${aapt2BuildTools}/aapt2";
+
+              shellHook = hostEnv + ''
+                echo "myco android shell — NDK ${ndkVersion}, JDK $(java -version 2>&1 | head -1 | cut -d'"' -f2)"
+                echo "  just build     assemble the debug APK (Gradle drives cargo-ndk)"
+                echo "  just install   build + adb install -r"
+                echo "note: adb device access needs programs.adb.enable = true in your NixOS config."
+              '';
+            };
+        }
+      );
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt-tree);
+    };
+}


### PR DESCRIPTION
## What this does

Adds `flake.nix` + `flake.lock` so a NixOS or nix-enabled machine gets the build environment reproducibly, and fills in the `nix develop` shell that `docs/how-to/build.md` §1 Option A has been promising while marked **TBD / open**.

Two dev shells:

| | `nix develop` | `nix develop .#android` |
| --- | --- | --- |
| Rust | stable + `aarch64-linux-android` target, clippy, rustfmt, rust-analyzer | same |
| Build deps | `just`, pkg-config, clang/libclang, dbus | same |
| Android | — | SDK (platforms 29 + 36, build-tools 35.0.0/36.0.0), NDK 26.1.10909125, cargo-ndk, JDK 17, Gradle, adb |

The host shell is enough for `just test` and `cargo fmt --check`; the android shell adds everything `just build` / `just install` need.

## Three details worth reviewing

1. **`aapt2FromMavenOverride`.** `GRADLE_OPTS` points AGP at the SDK's patched `aapt2`. Without it AGP downloads an `aapt2` from Maven that cannot run on NixOS — this is the first failure anyone hits, and it is not obvious from the error.
2. **dbus.** fips' Linux BLE backend (bluer) links `libdbus-sys`, so a host `cargo build` needs dbus on the pkg-config path — the same thing CI installs as `libdbus-1-dev`. The Android cross-build does not need it (fips uses `AndroidBleIo` there, not bluer), but it is in both shells since both can run host builds. I hit this the hard way: the first version of the shell passed `nix flake check` and still could not `cargo build`.
3. **No `packages` output, deliberately.** The workspace depends on `fips` as a path dependency at `reference/fips` — a local, gitignored checkout — so a hermetic Nix build of the crates is not possible. The shells provide the toolchain; cargo and Gradle still drive the build. Both shells default `MYCO_FIPS_REPO_PATH` to that checkout when present and warn when it is not, which is the useful failure mode for a fresh clone.

One thing to be aware of: the flake sets `allowUnfree` and `android_sdk.accept_license` in its own nixpkgs import, so entering the Android shell accepts Google's SDK licence without the user touching their own nixpkgs config. That is the standard androidenv pattern and it keeps the shell usable out of the box, but it is a licence accepted on the user's behalf, so it is now called out in `docs/how-to/build.md` §1 rather than left implicit.

## Version pins

NDK, platform and build-tools versions sit in one block at the top of `flake.nix` with a comment to keep them in sync with `android/app/build.gradle.kts`. They match `.github/workflows/ci.yml`'s `NDK_VERSION` (26.1.10909125) and the app's `compileSdk = 36` / `minSdk = 29`. `abiVersions` is arm64-v8a only and the emulator and system images are off, matching the LOCKED arm64-only, physical-devices-only constraints.

`x86_64-darwin` is omitted from `systems`: nixpkgs 26.11 has dropped it, and androidenv resolves no x86_64-darwin SDK archives either.

## Dependency surface

Two flake inputs — `nixpkgs` (nixos-unstable) and `oxalica/rust-overlay`, the latter with `inputs.nixpkgs.follows = "nixpkgs"` so there is one nixpkgs in the closure. rust-overlay is what supplies a rustc carrying the `aarch64-linux-android` std; plain nixpkgs rustc does not. `flake.lock` is committed so the branch resolution is pinned. Nothing outside Nix changes — no Cargo, Gradle or source changes, so CI behaviour is unaffected.

## Testing

On NixOS x86_64-linux:

- `nix flake check --all-systems` — passes for x86_64-linux, aarch64-linux, aarch64-darwin.
- Default shell — `cargo fmt --check`, `cargo build`, `cargo test` all pass.
- Android shell — `just build` cross-compiles `myco-core` and assembles the debug APK (arm64-v8a only), which installs and runs on a physical Galaxy A52s (SM_A528B, API 34).

Not tested: aarch64-linux and aarch64-darwin evaluate but were not built; macOS in particular could surface an androidenv difference.

One pre-existing thing this does **not** fix: `cargo clippy --all-targets -- -D warnings`, which CONTRIBUTING lists, fails on warnings in `myco-core` and in the `fips` path dependency. That is unchanged by this PR — the diff contains no Rust — and CI's clippy step is explicitly non-gating for the same reason.

## Docs

- `docs/how-to/build.md` §1 Option A rewritten to describe the real shells; the `flake.nix` **TBD / open** bullet removed from Open questions.
- `CONTRIBUTING.md` quick start gained a two-line Nix pointer.
- `CHANGELOG.md` entry under `[Unreleased]`.

